### PR TITLE
Non-contiguous matrices in triangular mul! and div!

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1208,14 +1208,14 @@ generic_trimatmul!(c::StridedVector{T}, uploc, isunitc, tfun::Function, A::Strid
 function generic_trimatmul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
         BLAS.trmm!('L', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), A, C === B ? C : copyto!(C, B))
-    else # incompatible with LAPACK
+    else # incompatible with BLAS
         @invoke generic_trimatmul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
 end
 function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
         BLAS.trmm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
-    else # incompatible with LAPACK
+    else # incompatible with BLAS
         @invoke generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
 end
@@ -1230,7 +1230,7 @@ end
 function generic_mattridiv!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
         BLAS.trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
-    else # incompatible with LAPACK
+    else # incompatible with BLAS
         @invoke generic_mattridiv!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1213,7 +1213,7 @@ function generic_trimatmul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function,
     end
 end
 function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
-    if stride(C,1) == stride(A,1) == 1
+    if stride(C,1) == stride(B,1) == 1
         BLAS.trmm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
     else # incompatible with LAPACK
         @invoke generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
@@ -1228,7 +1228,7 @@ function generic_trimatdiv!(C::StridedVecOrMat{T}, uploc, isunitc, tfun::Functio
     end
 end
 function generic_mattridiv!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
-    if stride(C,1) == stride(A,1) == 1
+    if stride(C,1) == stride(B,1) == 1
         BLAS.trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
     else # incompatible with LAPACK
         @invoke generic_mattridiv!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1427,4 +1427,17 @@ end
     end
 end
 
+@testset "(l/r)mul! and (l/r)div! for non-contiguous matrices" begin
+    U = UpperTriangular(reshape(collect(3:27.0),5,5))
+    B = float.(collect(reshape(1:100, 10,10)))
+    B2 = copy(B); B2v = view(B2, 1:2:9, 1:5); B2vc = copy(B2v)
+    @test lmul!(U, B2v) == lmul!(U, B2vc)
+    B2 = copy(B); B2v = view(B2, 1:2:9, 1:5); B2vc = copy(B2v)
+    @test rmul!(B2v, U) == rmul!(B2vc, U)
+    B2 = copy(B); B2v = view(B2, 1:2:9, 1:5); B2vc = copy(B2v)
+    @test ldiv!(U, B2v) ≈ ldiv!(U, B2vc)
+    B2 = copy(B); B2v = view(B2, 1:2:9, 1:5); B2vc = copy(B2v)
+    @test rdiv!(B2v, U) ≈ rdiv!(B2vc, U)
+end
+
 end # module TestTriangular


### PR DESCRIPTION
The LAPACK functions require contiguous matrices. Currently, the multiplication (BLAS) methods throw errors for non-contiguous arguments, while the `LAPACK.trtrs!` appears to silently accept a non-contiguous argument and returns an incorrect result (https://github.com/JuliaLang/julia/issues/40613). This PR makes such cases fall back to the julia implementation, and only the stride-1 cases are forwarded to the corresponding LAPACK/BLAS functions.

Fixes https://github.com/JuliaLang/julia/issues/40613
Fixes #878

After this, in-place multiplication by a triangular matrix works for non-contiguous matrices.
```julia
julia> U = UpperTriangular(float.(reshape(1:9,3,3)))
3×3 UpperTriangular{Float64, Matrix{Float64}}:
 1.0  4.0  7.0
  ⋅   5.0  8.0
  ⋅    ⋅   9.0

julia> B = float.(collect(reshape(1:25, 5, 5)));

julia> Bv_nc = view(B, 1:2:5, 1:2:5)
3×3 view(::Matrix{Float64}, 1:2:5, 1:2:5) with eltype Float64:
 1.0  11.0  21.0
 3.0  13.0  23.0
 5.0  15.0  25.0

julia> ldiv!(U, lmul!(U, Bv_nc))
3×3 view(::Matrix{Float64}, 1:2:5, 1:2:5) with eltype Float64:
 1.0  11.0  21.0
 3.0  13.0  23.0
 5.0  15.0  25.0

julia> rdiv!(rmul!(Bv_nc, U), U)
3×3 view(::Matrix{Float64}, 1:2:5, 1:2:5) with eltype Float64:
 1.0  11.0  21.0
 3.0  13.0  23.0
 5.0  15.0  25.0
```