### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,22 @@
-The code in this repository is part of the Julia project. See the LICENSE file in the Julia project:
+MIT License
 
-https://github.com/JuliaLang/julia/blob/master/LICENSE.md
+Copyright (c) 2018-2024 LinearAlgebra.jl contributors:
+https://github.com/JuliaLang/LinearAlgebra.jl/contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Close #1110

- `2018-2024`: see [move Base.LinAlg to LinearAlgebra stdlib](https://github.com/JuliaLang/LinearAlgebra.jl/commits/d7028479dd021f063d59f7812ff8aec75a7daf63/)