### PR TITLE
use an explicit file extension when creating sysimage

### DIFF
--- a/.ci/create_sysimage_and_run_tests.jl
+++ b/.ci/create_sysimage_and_run_tests.jl
@@ -1,6 +1,6 @@
-using PackageCompiler
+using PackageCompiler, Libdl
 
-sysimage = tempname()
+sysimage = tempname() * "." * Libdl.dlext
 
 if haskey(ENV, "BUILDKITE")
     ncores = Sys.CPU_THREADS


### PR DESCRIPTION
Otherwise the windows compiler adds a `.exe` to it.