### PR TITLE
try use updated windows compilers in PackageCompiler

### DIFF
--- a/.ci/Manifest.toml
+++ b/.ci/Manifest.toml
@@ -124,11 +124,11 @@ version = "0.3.28+3"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "02aabd917887f198fd0a01b1d935774c5c459f8c"
-repo-rev = "master"
+git-tree-sha1 = "946623a388d8cb5874a0e2cb062dbbcfbb90cea5"
+repo-rev = "kc/artifacts"
 repo-url = "https://github.com/JuliaLang/PackageCompiler.jl.git"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.1.22"
+version = "2.1.24"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -211,7 +211,7 @@ version = "1.3.1+1"
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
-version = "5.11.1+0"
+version = "5.11.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]


### PR DESCRIPTION
See if this gets rid of the warnings. Ref https://github.com/JuliaLang/PackageCompiler.jl/pull/1012