### PR TITLE
Cache and reuse `R` in adjoint `QR` `ldiv!`

### DIFF
--- a/src/qr.jl
+++ b/src/qr.jl
@@ -725,7 +725,8 @@ function ldiv!(Fadj::AdjointFactorization{<:Any,<:Union{QR,QRCompactWY,QRPivoted
 
     # For underdetermined system, the triangular solve should only be applied to the top
     # part of B that contains the rhs. For square problems, the view corresponds to B itself
-    ldiv!(LowerTriangular(adjoint(F.R)), view(B, 1:size(F.R, 2), :))
+    R = F.R
+    ldiv!(LowerTriangular(adjoint(R)), view(B, axes(R, 2), :))
     lmul!(F.Q, B)
 
     return B


### PR DESCRIPTION
Since computing `R` may be expensive, we compute it once, and reuse it subsequently.
```julia
julia> using LinearAlgebra

julia> F = qr(rand(40,30), ColumnNorm());

julia> v = rand(30);

julia> @btime $F' \ $v;
  4.397 μs (16 allocations: 47.95 KiB) # nightly v"1.12.0-DEV.1710"
  3.483 μs (13 allocations: 40.80 KiB) # this PR
```