### PR TITLE
Higher-order functions in `factorize` to obtain structure

### DIFF
--- a/test/dense.jl
+++ b/test/dense.jl
@@ -4,6 +4,7 @@ module TestDense
 
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasComplex, BlasFloat, BlasReal
+using Test: GenericArray
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
@@ -191,6 +192,8 @@ bimg  = randn(n,2)/2
         f = rand(eltya,n-2)
         A = diagm(0 => d)
         @test factorize(A) == Diagonal(d)
+        # test that the generic structure-evaluation method works
+        @test factorize(A) == factorize(GenericArray(A))
         A += diagm(-1 => e)
         @test factorize(A) == Bidiagonal(d,e,:L)
         A += diagm(-2 => f)


### PR DESCRIPTION
Instead of looping over the entire array to check the matrix structure, we may use higher-order querying functions like `istriu` and `issymmetric`. The advantage of this is that matrices might have optimized methods for these functions.

We still loop over the entire matrix for `StridedMatrix`es as before, and obtain the structure in one-pass. The performance therefore isn't impacted in this case.

An example with a sparse array wrapper:
```julia
julia> using LinearAlgebra

julia> struct MyMatrix{T,M<:AbstractMatrix{T}} <: AbstractMatrix{T}
           A::M
       end

julia> Base.size(M::MyMatrix) = size(M.A)

julia> Base.getindex(M::MyMatrix, i::Int, j::Int) = M.A[i, j]

julia> LinearAlgebra.istriu(M::MyMatrix, k::Integer=0) = istriu(M.A, k)

julia> LinearAlgebra.istril(M::MyMatrix, k::Integer=0) = istril(M.A, k)

julia> LinearAlgebra.issymmetric(M::MyMatrix) = issymmetric(M.A)

julia> LinearAlgebra.ishermitian(M::MyMatrix) = ishermitian(M.A)

julia> using SparseArrays

julia> S = sparse(1:4000, 1:4000, 1:4000);

julia> M = MyMatrix(S);

julia> @btime factorize($M);
  178.231 ms (4 allocations: 31.34 KiB) # master
  22.165 ms (10 allocations: 94.04 KiB) # this PR
```