### PR TITLE
don't refer to internal variable names in gemv exceptions

### DIFF
--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -572,9 +572,9 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar
                α::Number=true, β::Number=false) where {T<:BlasFloat}
     mA, nA = lapack_size(tA, A)
     nA != length(x) &&
-        throw(DimensionMismatch(lazy"second dimension of A, $nA, does not match length of x, $(length(x))"))
+        throw(DimensionMismatch(lazy"second dimension of matrix, $nA, does not match length of input vector, $(length(x))"))
     mA != length(y) &&
-        throw(DimensionMismatch(lazy"first dimension of A, $mA, does not match length of y, $(length(y))"))
+        throw(DimensionMismatch(lazy"first dimension of matrix, $mA, does not match length of output vector, $(length(y))"))
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
@@ -603,9 +603,9 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     α::Number = true, β::Number = false) where {T<:BlasReal}
     mA, nA = lapack_size(tA, A)
     nA != length(x) &&
-        throw(DimensionMismatch(lazy"second dimension of A, $nA, does not match length of x, $(length(x))"))
+        throw(DimensionMismatch(lazy"second dimension of matrix, $nA, does not match length of input vector, $(length(x))"))
     mA != length(y) &&
-        throw(DimensionMismatch(lazy"first dimension of A, $mA, does not match length of y, $(length(y))"))
+        throw(DimensionMismatch(lazy"first dimension of matrix, $mA, does not match length of output vector, $(length(y))"))
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
@@ -627,9 +627,9 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
         α::Number = true, β::Number = false) where {T<:BlasReal}
     mA, nA = lapack_size(tA, A)
     nA != length(x) &&
-        throw(DimensionMismatch(lazy"second dimension of A, $nA, does not match length of x, $(length(x))"))
+        throw(DimensionMismatch(lazy"second dimension of matrix, $nA, does not match length of input vector, $(length(x))"))
     mA != length(y) &&
-        throw(DimensionMismatch(lazy"first dimension of A, $mA, does not match length of y, $(length(y))"))
+        throw(DimensionMismatch(lazy"first dimension of matrix, $mA, does not match length of output vector, $(length(y))"))
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))


### PR DESCRIPTION
Currently, the `DimensionMismatch` exceptions refer to internal parameter names of `gemv!`, which is confusing because those don't necessarily match the caller's variables.  For example:
```jl
julia> B = rand(1000,100); c = rand(1000);

julia> B * c
ERROR: DimensionMismatch: second dimension of A, 100, does not match length of x, 1000
Stacktrace:
 [1] gemv!
   @ ~/.julia/juliaup/julia-1.11.2+0.x64.apple.darwin14/share/julia/stdlib/v1.11/LinearAlgebra/src/matmul.jl:438 [inlined]
```
This PR changes the error messages to refer to "matrix" instead of "A" and "input vector" instead of "x", etc.