### PR TITLE
Fallback `newindex` method with a `BandIndex`

### DIFF
--- a/src/structuredbroadcast.jl
+++ b/src/structuredbroadcast.jl
@@ -194,6 +194,7 @@ isvalidstructbc(dest::Bidiagonal, bc::Broadcasted{StructuredMatrixStyle{Bidiagon
     @inbounds Broadcast._broadcast_getindex(bc, b)
 end
 
+Broadcast.newindex(A, b::BandIndex) = Broadcast.newindex(A, _cartinds(b))
 function Broadcast.newindex(A::StructuredMatrix, b::BandIndex)
     # we use the fact that a StructuredMatrix is square,
     # and we apply newindex to both the axes at once to obtain the result

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -376,4 +376,9 @@ end
     end
 end
 
+@testset "newindex with BandIndex" begin
+    ind = Broadcast.newindex(rand(2,2),LinearAlgebra.BandIndex(0,1))
+    @test ind == CartesianIndex(1,1)
+end
+
 end


### PR DESCRIPTION
Currently, `Broadcast.newindex` with a `BandIndex` is specialized for structured broadcasting, but this incorrectly assumed that all the matrices involved in a structured broadcast operation will be structured matrices. This PR adds a fallback that simply converts the `BandIndex` to a `CartesianIndex` before computing the `newindex`.

This PR gets the tests for `FillArrays` working on julia nightly.