### PR TITLE
docs: fix unexported function names in svd doc

### DIFF
--- a/src/svd.jl
+++ b/src/svd.jl
@@ -151,7 +151,7 @@ number of singular values.
 
 `alg` specifies which algorithm and LAPACK method to use for SVD:
 - `alg = DivideAndConquer()` (default): Calls `LAPACK.gesdd!`.
-- `alg = QRIteration()`: Calls `LAPACK.gesvd!` (typically slower but more accurate) .
+- `alg = LinearAlgebra.QRIteration()`: Calls `LAPACK.gesvd!` (typically slower but more accurate) .
 
 !!! compat "Julia 1.3"
     The `alg` keyword argument requires Julia 1.3 or later.

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -150,7 +150,7 @@ and `V` is ``N \\times N``, while in the thin factorization `U` is ``M
 number of singular values.
 
 `alg` specifies which algorithm and LAPACK method to use for SVD:
-- `alg = DivideAndConquer()` (default): Calls `LAPACK.gesdd!`.
+- `alg = LinearAlgebra.DivideAndConquer()` (default): Calls `LAPACK.gesdd!`.
 - `alg = LinearAlgebra.QRIteration()`: Calls `LAPACK.gesvd!` (typically slower but more accurate) .
 
 !!! compat "Julia 1.3"


### PR DESCRIPTION
> QRIteration() is not exported, so I updated the svd.jl documentation section that suggests such a method exists for the `svd` function. Now it says to use `alg = LinearAlgebra.QRIteration()` instead of `alg = QRIteration()` which would produce an error before.

```jl
julia> VERSION
v"1.11.2"

julia> using LinearAlgebra

julia> DivideAndConquer
ERROR: UndefVarError: `DivideAndConquer` not defined in `Main`
Suggestion: check for spelling errors or missing imports.

julia> QRIteration
ERROR: UndefVarError: `QRIteration` not defined in `Main`
Suggestion: check for spelling errors or missing imports.

julia> LinearAlgebra.DivideAndConquer
LinearAlgebra.DivideAndConquer

julia> LinearAlgebra.QRIteration
LinearAlgebra.QRIteration
```

Moved from https://github.com/JuliaLang/julia/pull/56611
