### PR TITLE
Consistently check matrix sizes in matmul

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -497,7 +497,7 @@ end
 
 # B .= A * B
 function lmul!(A::Bidiagonal, B::AbstractVecOrMat)
-    _muldiag_size_check(size(A), size(B))
+    matmul_size_check(size(A), size(B))
     (; dv, ev) = A
     if A.uplo == 'U'
         for k in axes(B,2)
@@ -518,7 +518,7 @@ function lmul!(A::Bidiagonal, B::AbstractVecOrMat)
 end
 # B .= D * B
 function lmul!(D::Diagonal, B::Bidiagonal)
-    _muldiag_size_check(size(D), size(B))
+    matmul_size_check(size(D), size(B))
     (; dv, ev) = B
     isL = B.uplo == 'L'
     dv[1] = D.diag[1] * dv[1]
@@ -530,7 +530,7 @@ function lmul!(D::Diagonal, B::Bidiagonal)
 end
 # B .= B * A
 function rmul!(B::AbstractMatrix, A::Bidiagonal)
-    _muldiag_size_check(size(A), size(B))
+    matmul_size_check(size(A), size(B))
     (; dv, ev) = A
     if A.uplo == 'U'
         for k in reverse(axes(dv,1)[2:end])
@@ -555,7 +555,7 @@ function rmul!(B::AbstractMatrix, A::Bidiagonal)
 end
 # B .= B * D
 function rmul!(B::Bidiagonal, D::Diagonal)
-    _muldiag_size_check(size(B), size(D))
+    matmul_size_check(size(B), size(D))
     (; dv, ev) = B
     isU = B.uplo == 'U'
     dv[1] *= D.diag[1]

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -411,15 +411,15 @@ lmul!(A, B)
 _vec_or_mat_str(s::Tuple{Any}) = "vector"
 _vec_or_mat_str(s::Tuple{Any,Any}) = "matrix"
 @noinline function matmul_size_check(sizeA::Tuple{Integer,Vararg{Integer}}, sizeB::Tuple{Integer,Vararg{Integer}})
-    strA = _vec_or_mat_str(sizeA)
-    strB = _vec_or_mat_str(sizeB)
     szA2 = get(sizeA, 2, 1)
-    B_size_len = length(sizeB) == 1 ? sizeB[1] : sizeB
-    size_or_len_str_B = B_size_len isa Integer ? "length" : "size"
-    dim_or_len_str_B = B_size_len isa Integer ? "length" : "first dimension"
-    pos_str_A = (length(sizeA) == length(sizeB) ? "first " : "")*strA
-    pos_str_B = (length(sizeA) == length(sizeB) ? "second " : "")*strB
     if szA2 != sizeB[1]
+        strA = _vec_or_mat_str(sizeA)
+        strB = _vec_or_mat_str(sizeB)
+        B_size_len = length(sizeB) == 1 ? sizeB[1] : sizeB
+        size_or_len_str_B = B_size_len isa Integer ? "length" : "size"
+        dim_or_len_str_B = B_size_len isa Integer ? "length" : "first dimension"
+        pos_str_A = LazyString(length(sizeA) == length(sizeB) ? "first " : "", strA)
+        pos_str_B = LazyString(length(sizeA) == length(sizeB) ? "second " : "", strB)
         throw(DimensionMismatch(
             LazyString(
                 lazy"incompatible dimensions for matrix multiplication: ",
@@ -432,13 +432,13 @@ _vec_or_mat_str(s::Tuple{Any,Any}) = "matrix"
     return nothing
 end
 @noinline function matmul_size_check(sizeC::Tuple{Integer,Vararg{Integer}}, sizeA::Tuple{Integer,Vararg{Integer}}, sizeB::Tuple{Integer,Vararg{Integer}})
-    strA = _vec_or_mat_str(sizeA)
-    strB = _vec_or_mat_str(sizeB)
-    strC = _vec_or_mat_str(sizeC)
+    matmul_size_check(sizeA, sizeB)
     szB2 = get(sizeB, 2, 1)
     szC2 = get(sizeC, 2, 1)
-    matmul_size_check(sizeA, sizeB)
     if sizeC[1] != sizeA[1] || szC2 != szB2
+        strA = _vec_or_mat_str(sizeA)
+        strB = _vec_or_mat_str(sizeB)
+        strC = _vec_or_mat_str(sizeC)
         C_size_len = length(sizeC) == 1 ? sizeC[1] : sizeC
         size_or_len_str_C = C_size_len isa Integer ? "length" : "size"
         B_size_len = length(sizeB) == 1 ? sizeB[1] : sizeB

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1071,8 +1071,9 @@ function __matmul_checks(C, A, B, sz)
     if C === A || B === C
         throw(ArgumentError("output matrix must not be aliased with input matrix"))
     end
-    if !(size(A) == size(B) == size(C) == sz)
-        throw(DimensionMismatch(lazy"expected size: $sz, but got $(size(A))"))
+    if !(size(A) == size(B) == sz) # if A and B are both of size sz, C must also be of size sz for the matmul_size_check to pass
+        pos, mismatched_sz = size(A) != sz ? ("first", size(A)) : ("second", size(B))
+        throw(DimensionMismatch(lazy"expected size: $sz, but got size $mismatched_sz for the $pos matrix"))
     end
     return nothing
 end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -408,15 +408,24 @@ julia> lmul!(F.Q, B)
 """
 lmul!(A, B)
 
-_vec_or_mat_str(s::Tuple{Any}) = :vector
-_vec_or_mat_str(s::Tuple{Any,Any}) = :matrix
+_vec_or_mat_str(s::Tuple{Any}) = "vector"
+_vec_or_mat_str(s::Tuple{Any,Any}) = "matrix"
 @noinline function matmul_size_check(sizeA::Tuple{Integer,Vararg{Integer}}, sizeB::Tuple{Integer,Vararg{Integer}})
     strA = _vec_or_mat_str(sizeA)
     strB = _vec_or_mat_str(sizeB)
     szA2 = get(sizeA, 2, 1)
+    B_size_len = length(sizeB) == 1 ? sizeB[1] : sizeB
+    size_or_len_str_B = B_size_len isa Integer ? "length" : "size"
+    dim_or_len_str_B = B_size_len isa Integer ? "length" : "first dimension"
+    pos_str_A = (length(sizeA) == length(sizeB) ? "first " : "")*strA
+    pos_str_B = (length(sizeA) == length(sizeB) ? "second " : "")*strB
     if szA2 != sizeB[1]
         throw(DimensionMismatch(
-            lazy"incompatible dimensions for matrix multiplication: tried to multiply a $strA of size $sizeA with a $strB of size $sizeB.",
+            LazyString(
+                lazy"incompatible dimensions for matrix multiplication: ",
+                lazy"tried to multiply a $strA of size $sizeA with a $strB of $size_or_len_str_B $B_size_len. ",
+                lazy"The second dimension of the $pos_str_A: $szA2, does not match the $dim_or_len_str_B of the $pos_str_B: $(sizeB[1])."
+            )
             )
         )
     end
@@ -425,16 +434,22 @@ end
 @noinline function matmul_size_check(sizeC::Tuple{Integer,Vararg{Integer}}, sizeA::Tuple{Integer,Vararg{Integer}}, sizeB::Tuple{Integer,Vararg{Integer}})
     strA = _vec_or_mat_str(sizeA)
     strB = _vec_or_mat_str(sizeB)
+    strC = _vec_or_mat_str(sizeC)
     szB2 = get(sizeB, 2, 1)
     szC2 = get(sizeC, 2, 1)
     matmul_size_check(sizeA, sizeB)
     if sizeC[1] != sizeA[1] || szC2 != szB2
-        destsize = length(sizeB) == length(sizeC) == 1 ? (sizeA[1],) : (sizeA[1], szB2)
+        C_size_len = length(sizeC) == 1 ? sizeC[1] : sizeC
+        size_or_len_str_C = C_size_len isa Integer ? "length" : "size"
+        B_size_len = length(sizeB) == 1 ? sizeB[1] : sizeB
+        size_or_len_str_B = B_size_len isa Integer ? "length" : "size"
+        destsize = length(sizeB) == length(sizeC) == 1 ? sizeA[1] : (sizeA[1], szB2)
+        size_or_len_str_dest = destsize isa Integer ? "length" : "size"
         throw(DimensionMismatch(
                 LazyString(
                 "incompatible destination size: ",
-                lazy"the destination of size $sizeC is incomatible with the multiplication of a $strA of size $(sizeA) and a $strB of size $(sizeB). ",
-                lazy"The destination must be of size $destsize."
+                lazy"the destination $strC of $size_or_len_str_C $C_size_len is incomatible with the product of a $strA of size $sizeA and a $strB of $size_or_len_str_B $B_size_len. ",
+                lazy"The destination must be of $size_or_len_str_dest $destsize."
                )
             )
         )

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1094,7 +1094,7 @@ end
 
 for TC in (:AbstractVector, :AbstractMatrix)
     @eval @inline function _mul!(C::$TC, A::AbstractTriangular, B::AbstractVector, alpha::Number, beta::Number)
-        check_A_mul_B!_sizes(size(C), size(A), size(B))
+        matmul_size_check(size(C), size(A), size(B))
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
@@ -1107,7 +1107,7 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
                     (:AbstractTriangular, :AbstractTriangular)
                 )
     @eval @inline function _mul!(C::AbstractMatrix, A::$TA, B::$TB, alpha::Number, beta::Number)
-        check_A_mul_B!_sizes(size(C), size(A), size(B))
+        matmul_size_check(size(C), size(A), size(B))
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
@@ -1341,7 +1341,7 @@ end
 ## Generic triangular multiplication
 function generic_trimatmul!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractVecOrMat)
     require_one_based_indexing(C, A, B)
-    check_A_mul_B!_sizes(size(C), size(A), size(B))
+    matmul_size_check(size(C), size(A), size(B))
     oA = oneunit(eltype(A))
     unit = isunitc == 'U'
     @inbounds if uploc == 'U'
@@ -1394,7 +1394,7 @@ end
 # conjugate cases
 function generic_trimatmul!(C::AbstractVecOrMat, uploc, isunitc, ::Function, xA::AdjOrTrans, B::AbstractVecOrMat)
     require_one_based_indexing(C, xA, B)
-    check_A_mul_B!_sizes(size(C), size(xA), size(B))
+    matmul_size_check(size(C), size(xA), size(B))
     A = parent(xA)
     oA = oneunit(eltype(A))
     unit = isunitc == 'U'
@@ -1424,7 +1424,7 @@ end
 
 function generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     require_one_based_indexing(C, A, B)
-    check_A_mul_B!_sizes(size(C), size(A), size(B))
+    matmul_size_check(size(C), size(A), size(B))
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'
     @inbounds if uploc == 'U'
@@ -1477,7 +1477,7 @@ end
 # conjugate cases
 function generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, ::Function, A::AbstractMatrix, xB::AdjOrTrans)
     require_one_based_indexing(C, A, xB)
-    check_A_mul_B!_sizes(size(C), size(A), size(xB))
+    matmul_size_check(size(C), size(A), size(xB))
     B = parent(xB)
     oB = oneunit(eltype(B))
     unit = isunitc == 'U'

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1158,6 +1158,9 @@ end
     @test_throws "incompatible destination size" mul!(zeros(1,0), zeros(1,5), zeros(5,2))
     @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5))
     @test_throws "incompatible destination size" mul!(zeros(0), zeros(1,5), zeros(5))
+
+    @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(2,2), 'N', 'N', zeros(2,3), zeros(3,2))
+    @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(2,3), 'N', 'N', zeros(2,2), zeros(2,3))
 end
 
 end # module TestMatmul

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1148,4 +1148,15 @@ end
     @test A * A ≈ M * M
 end
 
+@testset "issue #1147: error messages in matmul" begin
+    @test_throws "incompatible dimensions for matrix multiplication" zeros(0,0) * zeros(1,5)
+    @test_throws "incompatible dimensions for matrix multiplication" zeros(0,0) * zeros(1)
+    @test_throws "incompatible dimensions for matrix multiplication" zeros(0) * zeros(2,5)
+    @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(5), zeros(5))
+    @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(1,5), zeros(0,0))
+    @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5,2))
+    @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5))
+    @test_throws "incompatible destination size" mul!(zeros(0), zeros(1,5), zeros(5))
+end
+
 end # module TestMatmul

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1154,7 +1154,8 @@ end
     @test_throws "incompatible dimensions for matrix multiplication" zeros(0) * zeros(2,5)
     @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(5), zeros(5))
     @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(1,5), zeros(0,0))
-    @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5,2))
+    @test_throws "incompatible destination size" mul!(zeros(0,2), zeros(1,5), zeros(5,2))
+    @test_throws "incompatible destination size" mul!(zeros(1,0), zeros(1,5), zeros(5,2))
     @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5))
     @test_throws "incompatible destination size" mul!(zeros(0), zeros(1,5), zeros(5))
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1149,18 +1149,22 @@ end
 end
 
 @testset "issue #1147: error messages in matmul" begin
-    @test_throws "incompatible dimensions for matrix multiplication" zeros(0,0) * zeros(1,5)
-    @test_throws "incompatible dimensions for matrix multiplication" zeros(0,0) * zeros(1)
-    @test_throws "incompatible dimensions for matrix multiplication" zeros(0) * zeros(2,5)
-    @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(5), zeros(5))
-    @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(0,0), zeros(1,5), zeros(0,0))
-    @test_throws "incompatible destination size" mul!(zeros(0,2), zeros(1,5), zeros(5,2))
-    @test_throws "incompatible destination size" mul!(zeros(1,0), zeros(1,5), zeros(5,2))
-    @test_throws "incompatible destination size" mul!(zeros(0,0), zeros(1,5), zeros(5))
-    @test_throws "incompatible destination size" mul!(zeros(0), zeros(1,5), zeros(5))
+    for T in (Int, Float64, ComplexF64)
+        for f in (identity, Symmetric)
+            @test_throws "incompatible dimensions for matrix multiplication" f(zeros(T,0,0)) * zeros(T,1,5)
+            @test_throws "incompatible dimensions for matrix multiplication" f(zeros(T,0,0)) * zeros(T,1)
+            @test_throws "incompatible dimensions for matrix multiplication" zeros(T,0) * f(zeros(T,2,2))
+            @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(T,0,0), zeros(T,5), zeros(T,5))
+            @test_throws "incompatible dimensions for matrix multiplication" mul!(zeros(T,0,0), f(zeros(T,1,1)), zeros(T,0,0))
+            @test_throws "incompatible destination size" mul!(zeros(T,0,2), f(zeros(T,1,1)), zeros(T,1,2))
+            @test_throws "incompatible destination size" mul!(zeros(T,1,0), f(zeros(T,1,1)), zeros(T,1,2))
+            @test_throws "incompatible destination size" mul!(zeros(T,0,0), f(zeros(T,1,1)), zeros(T,1))
+            @test_throws "incompatible destination size" mul!(zeros(T,0), f(zeros(T,1,1)), zeros(T,1))
+        end
 
-    @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(2,2), 'N', 'N', zeros(2,3), zeros(3,2))
-    @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(2,3), 'N', 'N', zeros(2,2), zeros(2,3))
+        @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(T,2,2), 'N', 'N', zeros(T,2,3), zeros(T,3,2))
+        @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(T,2,3), 'N', 'N', zeros(T,2,2), zeros(T,2,3))
+    end
 end
 
 end # module TestMatmul

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1429,4 +1429,18 @@ end
     @test rdiv!(B2v, U) ≈ rdiv!(B2vc, U)
 end
 
+@testset "error messages in matmul with mismatched matrix sizes" begin
+    for T in (Int, Float64)
+        A = UpperTriangular(ones(T,2,2))
+        B = ones(T,3,3)
+        C = similar(B)
+        @test_throws "incompatible dimensions for matrix multiplication" mul!(C, A, B)
+        @test_throws "incompatible dimensions for matrix multiplication" mul!(C, B, A)
+        B = Array(A)
+        C = similar(B, (4,4))
+        @test_throws "incompatible destination size" mul!(C, A, B)
+        @test_throws "incompatible destination size" mul!(C, B, A)
+    end
+end
+
 end # module TestTriangular


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/1147, and makes the error messages more verbose.

Before
```julia
julia> zeros(0,4) * zeros(1)
ERROR: DimensionMismatch: second dimension of matrix, 4, does not match length of input vector, 1
[...]

julia> mul!(zeros(0), zeros(2,2), zeros(2))
ERROR: DimensionMismatch: first dimension of matrix, 2, does not match length of output vector, 0
[...]
```
After
```julia
julia> zeros(0,4) * zeros(1)
ERROR: DimensionMismatch: incompatible dimensions for matrix multiplication: tried to multiply a matrix of size (0, 4) with a vector of length 1. The second dimension of the matrix: 4, does not match the length of the vector: 1.
[...]

julia> zeros(0,4) * zeros(1,1)
ERROR: DimensionMismatch: incompatible dimensions for matrix multiplication: tried to multiply a matrix of size (0, 4) with a matrix of size (1, 1). The second dimension of the first matrix: 4, does not match the first dimension of the second matrix: 1.
[...]

julia> mul!(zeros(0), zeros(2,2), zeros(2))
ERROR: DimensionMismatch: incompatible destination size: the destination vector of length 0 is incomatible with the product of a matrix of size (2, 2) and a vector of length 2. The destination must be of length 2.
[...]

julia> mul!(zeros(0,1), zeros(3,2), zeros(2,3))
ERROR: DimensionMismatch: incompatible destination size: the destination matrix of size (0, 1) is incomatible with the product of a matrix of size (3, 2) and a matrix of size (2, 3). The destination must be of size (3, 3).
[...]
```