### PR TITLE
`sqrt`, `cbrt` and `log` for dense diagonal matrices

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -890,7 +890,9 @@ julia> log(A)
 """
 function log(A::AbstractMatrix)
     # If possible, use diagonalization
-    if ishermitian(A)
+    if isdiag(A)
+        return applydiagonal(log, A)
+    elseif ishermitian(A)
         logHermA = log(Hermitian(A))
         return ishermitian(logHermA) ? copytri!(parent(logHermA), 'U', true) : parent(logHermA)
     elseif istriu(A)
@@ -969,7 +971,9 @@ sqrt(::AbstractMatrix)
 
 function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
     if checksquare(A) == 0
-        return copy(A)
+        return copy(float(A))
+    elseif isdiag(A)
+        return applydiagonal(sqrt, A)
     elseif ishermitian(A)
         sqrtHermA = sqrt(Hermitian(A))
         return ishermitian(sqrtHermA) ? copytri!(parent(sqrtHermA), 'U', true) : parent(sqrtHermA)
@@ -1035,7 +1039,9 @@ true
 """
 function cbrt(A::AbstractMatrix{<:Real})
     if checksquare(A) == 0
-        return copy(A)
+        return copy(float(A))
+    elseif isdiag(A)
+        return applydiagonal(cbrt, A)
     elseif issymmetric(A)
         return cbrt(Symmetric(A, :U))
     else

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1282,6 +1282,7 @@ end
     T = cbrt(Symmetric(S,:U))
     @test T*T*T ≈ S
     @test eltype(S) == eltype(T)
+    @test cbrt(Array(Symmetric(S,:U))) == T
     # Real valued symmetric
     S =  (A -> (A+A')/2)(randn(N,N))
     T = cbrt(Symmetric(S,:L))

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -814,6 +814,7 @@ end
 
     A13 = convert(Matrix{elty}, [2 0; 0 2])
     @test typeof(log(A13)) == Array{elty, 2}
+    @test exp(log(A13)) ≈ log(exp(A13)) ≈ A13
 
     T = elty == Float64 ? Symmetric : Hermitian
     @test typeof(log(T(A13))) == T{elty, Array{elty, 2}}
@@ -964,6 +965,10 @@ end
         @test sqrt(A8)^2 ≈ A8
         @test typeof(sqrt(A8)) == Matrix{elty}
     end
+end
+@testset "sqrt for diagonal" begin
+    A = diagm(0 => [1, 2, 3])
+    @test sqrt(A)^2 ≈ A
 end
 
 @testset "issue #40141" begin
@@ -1297,6 +1302,10 @@ end
     T = cbrt(A)
     @test T*T*T ≈ A
     @test eltype(A) == eltype(T)
+    @testset "diagonal" begin
+        A = diagm(0 => [1, 2, 3])
+        @test cbrt(A)^3 ≈ A
+    end
 end
 
 @testset "tr" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1306,6 +1306,12 @@ end
         A = diagm(0 => [1, 2, 3])
         @test cbrt(A)^3 ≈ A
     end
+    @testset "empty" begin
+        A = Matrix{Float64}(undef, 0, 0)
+        @test cbrt(A) == A
+        A = Matrix{Int}(undef, 0, 0)
+        @test cbrt(A) isa Matrix{Float64}
+    end
 end
 
 @testset "tr" begin


### PR DESCRIPTION
This PR improves performance by only applying the functions to the diagonal elements:
```julia
julia> A = diagm(0=>ones(100));

julia> @btime log($A);
  364.163 μs (22 allocations: 401.62 KiB) # master
  13.528 μs (7 allocations: 80.02 KiB) # this PR
```
Similar improvements for `sqrt` and `cbrt` as well.