### PR TITLE
Specialize `diag(::Diagonal)`

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -854,7 +854,9 @@ adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(axes(D), axes(D), perm); D)
 
-function diag(D::Diagonal, k::Integer=0)
+diag(D::Diagonal) = D.diag
+
+function diag(D::Diagonal, k::Integer)
     # every branch call similar(..., ::Int) to make sure the
     # same vector type is returned independent of k
     v = similar(D.diag, max(0, length(D.diag)-abs(k)))


### PR DESCRIPTION
The current implementation `diag(::Diagonal, k=0)`, for the sake of type stability, returns a `Vector` even when `D.diag` is lazy.
```julia
julia> diag(Diagonal(1:5))
5-element Vector{Int64}:
 1
 2
 3
 4
 5
```
This can cause bugs when one does want the result to be lazy:
```julia
julia> D1 = Diagonal(1:5)
5×5 Diagonal{Int64, UnitRange{Int64}}:
 1  ⋅  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅  ⋅
 ⋅  ⋅  3  ⋅  ⋅
 ⋅  ⋅  ⋅  4  ⋅
 ⋅  ⋅  ⋅  ⋅  5

julia> D2 = Diagonal(1.0:5.0)
5×5 Diagonal{Float64, StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}:
 1.0   ⋅    ⋅    ⋅    ⋅ 
  ⋅   2.0   ⋅    ⋅    ⋅
  ⋅    ⋅   3.0   ⋅    ⋅
  ⋅    ⋅    ⋅   4.0   ⋅
  ⋅    ⋅    ⋅    ⋅   5.0

julia> oftype(D2,D1)
ERROR: MethodError: Cannot `convert` an object of type Vector{Int64} to an object of type StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}
```