### PR TITLE
Let `cond` of an empty square matrix return zero

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1779,6 +1779,10 @@ Condition number of the matrix `M`, computed using the operator `p`-norm. Valid 
 """
 function cond(A::AbstractMatrix, p::Real=2)
     if p == 2
+        if isempty(A)
+            checksquare(A)
+            return zero(real(eigtype(eltype(A))))
+        end
         v = svdvals(A)
         maxv = maximum(v)
         return iszero(maxv) ? oftype(real(maxv), Inf) : maxv / minimum(v)

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -57,23 +57,16 @@ Random.seed!(1234323)
         @test cond(Mars, Inf) ≈ 7.1
     end
     @testset "Empty matrices" begin
-        # zero for square (i.e. 0×0) matrices
-        @test cond(zeros(Int, 0, 0), 1) === 0.0
-        @test cond(zeros(Int, 0, 0), 2) === 0.0
-        @test cond(zeros(Int, 0, 0), Inf) === 0.0
-        @test cond(zeros(0, 0), 1) === 0.0
-        @test cond(zeros(0, 0), 2) === 0.0
-        @test cond(zeros(0, 0), Inf) === 0.0
-        @test cond(zeros(ComplexF64, 0, 0), 1) === 0.0
-        @test cond(zeros(ComplexF64, 0, 0), 2) === 0.0
-        @test cond(zeros(ComplexF64, 0, 0), Inf) === 0.0
-        # error for non-square matrices
-        @test_throws DimensionMismatch cond(zeros(10, 0), 1)
-        @test_throws DimensionMismatch cond(zeros(0, 10), 1)
-        @test_throws DimensionMismatch cond(zeros(10, 0), 2)
-        @test_throws DimensionMismatch cond(zeros(0, 10), 2)
-        @test_throws DimensionMismatch cond(zeros(10, 0), Inf)
-        @test_throws DimensionMismatch cond(zeros(0, 10), Inf)
+        for norm in (1,2,Inf)
+            # zero for square (i.e. 0×0) matrices
+            @test cond(zeros(Int, 0, 0), norm) === 0.0
+            @test cond(zeros(0, 0), norm) === 0.0
+            @test cond(zeros(ComplexF64, 0, 0), norm) === 0.0
+            # error for non-square matrices
+            for size in ((10,0), (0,10))
+                @test_throws DimensionMismatch cond(zeros(size...), norm)
+            end
+        end
     end
 end
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -56,6 +56,25 @@ Random.seed!(1234323)
         @test cond(Mars, 2)   ≈ 6.181867355918493
         @test cond(Mars, Inf) ≈ 7.1
     end
+    @testset "Empty matrices" begin
+        # zero for square (i.e. 0×0) matrices
+        @test cond(zeros(Int, 0, 0), 1) === 0.0
+        @test cond(zeros(Int, 0, 0), 2) === 0.0
+        @test cond(zeros(Int, 0, 0), Inf) === 0.0
+        @test cond(zeros(0, 0), 1) === 0.0
+        @test cond(zeros(0, 0), 2) === 0.0
+        @test cond(zeros(0, 0), Inf) === 0.0
+        @test cond(zeros(ComplexF64, 0, 0), 1) === 0.0
+        @test cond(zeros(ComplexF64, 0, 0), 2) === 0.0
+        @test cond(zeros(ComplexF64, 0, 0), Inf) === 0.0
+        # error for non-square matrices
+        @test_throws DimensionMismatch cond(zeros(10, 0), 1)
+        @test_throws DimensionMismatch cond(zeros(0, 10), 1)
+        @test_throws DimensionMismatch cond(zeros(10, 0), 2)
+        @test_throws DimensionMismatch cond(zeros(0, 10), 2)
+        @test_throws DimensionMismatch cond(zeros(10, 0), Inf)
+        @test_throws DimensionMismatch cond(zeros(0, 10), Inf)
+    end
 end
 
 areal = randn(n,n)/2

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -57,14 +57,14 @@ Random.seed!(1234323)
         @test cond(Mars, Inf) ≈ 7.1
     end
     @testset "Empty matrices" begin
-        for norm in (1,2,Inf)
+        for p in (1,2,Inf)
             # zero for square (i.e. 0×0) matrices
-            @test cond(zeros(Int, 0, 0), norm) === 0.0
-            @test cond(zeros(0, 0), norm) === 0.0
-            @test cond(zeros(ComplexF64, 0, 0), norm) === 0.0
+            @test cond(zeros(Int, 0, 0), p) === 0.0
+            @test cond(zeros(0, 0), p) === 0.0
+            @test cond(zeros(ComplexF64, 0, 0), p) === 0.0
             # error for non-square matrices
             for size in ((10,0), (0,10))
-                @test_throws DimensionMismatch cond(zeros(size...), norm)
+                @test_throws DimensionMismatch cond(zeros(size...), p)
             end
         end
     end


### PR DESCRIPTION
Transfer of https://github.com/JuliaLang/julia/pull/38372. Summary of the discussion there:
We have this inconsistency:
```julia
julia> cond(ones(0,0), 1)
0.0

julia> cond(ones(0,0), 2)
ERROR: ArgumentError: reducing over an empty collection is not allowed; consider supplying `init` to the reducer

julia> cond(ones(0,0), Inf)
0.0
```
If it wasn't breaking, making all cases throw would be acceptable behavior. This PR goes the other way, making the `p==2` case also return zero. Although met with some skepticism, if there is to be chosen a value, zero is probably it.

I think the main question is whether the inconsistency or the somewhat dubious return-value is the lesser evil. Mainly porting this over as a reminder to reach a decision. Either way we should probably close #778; either by resolving it with this PR or as won't-fix.

Fixes #778.