### PR TITLE
test: use `BLAS.libblastrampoline`

### DIFF
--- a/test/blas.jl
+++ b/test/blas.jl
@@ -776,7 +776,7 @@ end
 # Make sure we can use `Base.libblas_name`.  Avoid causing
 # https://github.com/JuliaLang/julia/issues/48427 again.
 @testset "libblas_name" begin
-    dot_sym = dlsym(dlopen(Base.libblas_name), "cblas_ddot" * (Sys.WORD_SIZE == 64 ? "64_" : ""))
+    dot_sym = dlsym(dlopen(BLAS.libblastrampoline), "cblas_ddot" * (Sys.WORD_SIZE == 64 ? "64_" : ""))
     @test 23.0 === @ccall $(dot_sym)(2::Int, [2.0, 3.0]::Ref{Cdouble}, 1::Int, [4.0, 5.0]::Ref{Cdouble}, 1::Int)::Cdouble
 end
 


### PR DESCRIPTION
`Base.libblas_name` will be removed in JuliaLang/julia#50699