### PR TITLE
remove copy-allocation on accessing `cholesky` factors (`.L`, `.U`)

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -65,7 +65,7 @@ julia> C.U
   ⋅    ⋅    3.0
 
 julia> C.L
-3×3 LowerTriangular{Float64, Matrix{Float64}}:
+3×3 LowerTriangular{Float64, Adjoint{Matrix{Float64}}}:
   2.0   ⋅    ⋅
   6.0  1.0   ⋅
  -8.0  5.0  3.0
@@ -530,7 +530,7 @@ julia> C.U
   ⋅    ⋅    3.0
 
 julia> C.L
-3×3 LowerTriangular{Float64, Matrix{Float64}}:
+3×3 LowerTriangular{Float64, Adjoint{Matrix{Float64}}}:
   2.0   ⋅    ⋅
   6.0  1.0   ⋅
  -8.0  5.0  3.0
@@ -668,14 +668,14 @@ function _choleskyUfactor(Cfactors, Cuplo)
     if Cuplo === 'U'
         return UpperTriangular(Cfactors)
     else
-        return copy(LowerTriangular(Cfactors)')
+        return LowerTriangular(Cfactors)'
     end
 end
 function _choleskyLfactor(Cfactors, Cuplo)
     if Cuplo === 'L'
         return LowerTriangular(Cfactors)
     else
-        return copy(UpperTriangular(Cfactors)')
+        return UpperTriangular(Cfactors)'
     end
 end
 

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -595,9 +595,9 @@ end
     B = cholesky(A)
     B32 = cholesky(Float32.(A))
     @test B isa Cholesky{Float16, Matrix{Float16}}
-    @test B.U isa UpperTriangular{Float16, Matrix{Float16}}
-    @test B.L isa LowerTriangular{Float16, Matrix{Float16}}
-    @test B.UL isa UpperTriangular{Float16, Matrix{Float16}}
+    @test B.U isa UpperTriangular{Float16, <:AbstractMatrix{Float16}}
+    @test B.L isa LowerTriangular{Float16, <:AbstractMatrix{Float16}}
+    @test B.UL isa UpperTriangular{Float16, <:AbstractMatrix{Float16}}
     @test B.U ≈ B32.U
     @test B.L ≈ B32.L
     @test B.UL ≈ B32.UL
@@ -655,6 +655,24 @@ end
         C = cholesky(P)
         CC = cholesky(C)
         @test C == CC
+    end
+end
+
+@testset "accessing both L and U factors should avoid allocations" begin
+    n = 30
+    A = rand(n, n)
+    Apd = A'A
+    allowed_cost_of_overhead = 32
+    @assert sizeof(Apd) > 4allowed_cost_of_overhead  # ensure that we could positively identify extra copies
+
+    for uplo in (:L, :U)
+        C = Symmetric(Apd, uplo)
+        for val in (Val(true), Val(false))
+            B = cholesky(C, val)
+            B.L, B.U  # access once to ensure the accessor is compiled already
+            @test (@allocated B.L) <= allowed_cost_of_overhead
+            @test (@allocated B.U) <= allowed_cost_of_overhead
+        end
     end
 end
 

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -604,9 +604,9 @@ end
     @test Matrix(B) ≈ A
     B = cholesky(A, RowMaximum())
     B32 = cholesky(Float32.(A), RowMaximum())
-    @test B isa CholeskyPivoted{Float16,Matrix{Float16}}
-    @test B.U isa UpperTriangular{Float16, Matrix{Float16}}
-    @test B.L isa LowerTriangular{Float16, Matrix{Float16}}
+    @test B isa CholeskyPivoted{Float16, <:AbstractMatrix{Float16}}
+    @test B.U isa UpperTriangular{Float16, <:AbstractMatrix{Float16}}
+    @test B.L isa LowerTriangular{Float16, <:AbstractMatrix{Float16}}
     @test B.U ≈ B32.U
     @test B.L ≈ B32.L
     @test Matrix(B) ≈ A
@@ -667,7 +667,7 @@ end
 
     for uplo in (:L, :U)
         C = Symmetric(Apd, uplo)
-        for val in (Val(true), Val(false))
+        for val in (NoPivot(), RowMaximum())
             B = cholesky(C, val)
             B.L, B.U  # access once to ensure the accessor is compiled already
             @test (@allocated B.L) <= allowed_cost_of_overhead


### PR DESCRIPTION
(Port of https://github.com/JuliaLang/julia/pull/42920)

In master, accessing fields L or U of Cholesky or CholeskyPivoted calls copy() on the transpose. Here I add tests thayt check that the accessors don't allocate more memory than is needed for e.g. the Adjoint() construction, and remove the unnecessary copy(). Generally julia seems to be trying hard to avoid unnecessary allocations, so I would consider this to be a bugfix, not a breaking change.

There is a related discourse thread: https://discourse.julialang.org/t/implementation-for-accessing-cholesky-factors/56219

Side note 1: there is also a copy() in the definition of _chol!(A::AbstractMatrix, ::Type{UpperTriangular}) - it's a bit less clear to me in what cases this will get run and whether it's okay to remove the copy(), so let me know if you think it'd be worth spending the time to go deeper into that also.

Side note 2: some of the code tests uplo using Cuplo === char_uplo(d), some of it using sym_uplo(Cuplo) == d, is there any particular reason for this, or would it be worth unifying it?
