### PR TITLE
Add fast path in generic matmul

### DIFF
--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1021,6 +1021,7 @@ function _generic_matmatmul_nonadjtrans!(C, A, B, alpha, beta)
     @inbounds for n in axes(B, 2), k in axes(B, 1)
         # Balpha = B[k,n] * alpha, but we skip the multiplication in case isone(alpha)
         Balpha = @stable_muladdmul MulAddMul(alpha, false)(B[k,n])
+        iszero(Balpha) && continue
         @simd for m in axes(A, 1)
             C[m,n] = muladd(A[m,k], Balpha, C[m,n])
         end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1021,7 +1021,7 @@ function _generic_matmatmul_nonadjtrans!(C, A, B, alpha, beta)
     @inbounds for n in axes(B, 2), k in axes(B, 1)
         # Balpha = B[k,n] * alpha, but we skip the multiplication in case isone(alpha)
         Balpha = @stable_muladdmul MulAddMul(alpha, false)(B[k,n])
-        iszero(Balpha) && continue
+        !ismissing(Balpha) && iszero(Balpha) && continue
         @simd for m in axes(A, 1)
             C[m,n] = muladd(A[m,k], Balpha, C[m,n])
         end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -767,6 +767,7 @@ import LinearAlgebra: Adjoint, Transpose
 (*)(x::RootInt, y::Integer) = x.i * y
 adjoint(x::RootInt) = x
 transpose(x::RootInt) = x
+Base.zero(::RootInt) = RootInt(0)
 
 @test Base.promote_op(*, RootInt, RootInt) === Int
 


### PR DESCRIPTION
This manually adds the critical optimisation investigated in https://github.com/JuliaLang/julia/issues/56954. While we could rely on LLVM to continue doing this optimisation, it's more robust to add it manually.