### PR TITLE
Verbose `showerror` for `SingularException`

### DIFF
--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -29,7 +29,7 @@ struct SingularException <: Exception
 end
 
 function Base.showerror(io::IO, ex::SingularException)
-    print(io, "SingularException: matrix is singular; factorization failed. Zero eigenvalue found at index ", ex.info)
+    print(io, "SingularException: matrix is singular; factorization failed. Zero pivot found at index ", ex.info)
 end
 
 """

--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -28,6 +28,10 @@ struct SingularException <: Exception
     info::BlasInt
 end
 
+function Base.showerror(io::IO, ex::SingularException)
+    print(io, "SingularException: matrix is singular; factorization failed. Zero eigenvalue found at index ", ex.info)
+end
+
 """
     PosDefException
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1366,4 +1366,9 @@ end
     @test !any(LinearAlgebra.getstructure(A))
 end
 
+@testset "SingularException show" begin
+    A = diagm(0=> [1, 0])
+    @test_throws "matrix is singular; factorization failed" inv(A)
+end
+
 end # module TestDense


### PR DESCRIPTION
Currently,
```julia
julia> A = diagm(0 => [1.0, 0.0])
2×2 Matrix{Float64}:
 1.0  0.0
 0.0  0.0

julia> inv(A)
ERROR: SingularException(2)
[...]
```
After this,
```julia
julia> inv(A)
ERROR: SingularException: matrix is singular; factorization failed. Zero eigenvalue found at index 2
[...]
```