### PR TITLE
Don't mutate arrays in symmetric trig functions

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -887,9 +887,6 @@ for func in (:exp, :cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :atanh,
         function ($func)(A::Hermitian{<:Complex})
             F = eigen(A)
             retmat = (F.vectors * Diagonal(($func).(F.values))) * F.vectors'
-            for i in diagind(retmat, IndexStyle(retmat))
-                retmat[i] = real(retmat[i])
-            end
             return Hermitian(retmat)
         end
     end
@@ -919,9 +916,6 @@ for func in (:acos, :asin)
             F = eigen(A)
             if all(λ -> -1 ≤ λ ≤ 1, F.values)
                 retmat = (F.vectors * Diagonal(($func).(F.values))) * F.vectors'
-                for i in diagind(retmat, IndexStyle(retmat))
-                    retmat[i] = real(retmat[i])
-                end
                 return Hermitian(retmat)
             else
                 return (F.vectors * Diagonal(($func).(complex.(F.values)))) * F.vectors'
@@ -942,9 +936,6 @@ function acosh(A::Hermitian{<:Complex})
     F = eigen(A)
     if all(λ -> λ ≥ 1, F.values)
         retmat = (F.vectors * Diagonal(acosh.(F.values))) * F.vectors'
-        for i in diagind(retmat, IndexStyle(retmat))
-            retmat[i] = real(retmat[i])
-        end
         return Hermitian(retmat)
     else
         return (F.vectors * Diagonal(acosh.(complex.(F.values)))) * F.vectors'
@@ -998,9 +989,6 @@ for func in (:log, :sqrt)
             λ₀ = $rtolval # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff
             if all(λ -> λ ≥ λ₀, F.values)
                 retmat = (F.vectors * Diagonal(($func).(max.(0, F.values)))) * F.vectors'
-                for i in diagind(retmat, IndexStyle(retmat))
-                    retmat[i] = real(retmat[i])
-                end
                 return Hermitian(retmat)
             else
                 retmat = (F.vectors * Diagonal(($func).(complex.(F.values)))) * F.vectors'


### PR DESCRIPTION
Since these functions act on arbitrary `AbstractArray`s, we should ideally not assume mutability of the intermediate array `retmat`. Instead, we may rely on the fact that the `Hermitian` wrapper implicitly sets the imaginary components of the diagonal elements to zero. This change will mean that the parents do have non-zero imaginary components, but this may be seen as an implementation detail.

Alternately, if this is not desired, we may explicitly set the diagonal elements for `StridedArray`s, which are usually mutable.

This PR will get the following to work, e.g.:
```julia
julia> A = complex.(SMatrix{4,4}(diagm(0=>[2,4,8,16])))
4×4 SMatrix{4, 4, Complex{Int64}, 16} with indices SOneTo(4)×SOneTo(4):
 2+0im  0+0im  0+0im   0+0im
 0+0im  4+0im  0+0im   0+0im
 0+0im  0+0im  8+0im   0+0im
 0+0im  0+0im  0+0im  16+0im

julia> exp(Hermitian(A))
4×4 Hermitian{ComplexF64, Matrix{ComplexF64}}:
 7.38906+0.0im      0.0+0.0im      0.0+0.0im        0.0+0.0im
     0.0-0.0im  54.5982+0.0im      0.0+0.0im        0.0+0.0im
     0.0-0.0im      0.0-0.0im  2980.96+0.0im        0.0+0.0im
     0.0-0.0im      0.0-0.0im      0.0-0.0im  8.88611e6+0.0im
```
Prior to this, the method call errors, as an `SMatrix` doesn't support `setindex!`.

Adding tests for this change is a little tricky, now that this repo is separated from julia, and the test helpers lie in the main julia repo. Any suggestions?