### PR TITLE
Specialize Diagonal * Adjoint

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -319,8 +319,8 @@ const AdjointAbsVec{T} = Adjoint{T,<:AbstractVector}
 const AdjointAbsMat{T} = Adjoint{T,<:AbstractMatrix}
 const TransposeAbsVec{T} = Transpose{T,<:AbstractVector}
 const TransposeAbsMat{T} = Transpose{T,<:AbstractMatrix}
-const AdjOrTransAbsVec{T} = AdjOrTrans{T,<:AbstractVector}
-const AdjOrTransAbsMat{T} = AdjOrTrans{T,<:AbstractMatrix}
+const AdjOrTransAbsVec{T,V<:AbstractVector} = AdjOrTrans{T,V}
+const AdjOrTransAbsMat{T,M<:AbstractMatrix} = AdjOrTrans{T,M}
 
 # for internal use below
 wrapperop(_) = identity

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -336,7 +336,7 @@ function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function _diag_adj_mul(A::AdjOrTransAbsMat{<:Any, <:StridedMatrix}, D::Diagonal)
+function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal)
     Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
     rmul!(Ac, D)
 end
@@ -344,7 +344,7 @@ function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
 end
-function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat{<:Any, <:StridedMatrix})
+function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
     Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
     lmul!(D, Ac)
 end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -333,10 +333,12 @@ function (*)(D::Diagonal, V::AbstractVector)
 end
 
 function (*)(A::AdjOrTransAbsMat, D::Diagonal)
-    copy((D' * A')')
+    adj = wrapperop(A)
+    copy(adj(adj(D) * adj(A)))
 end
 function (*)(D::Diagonal, A::AdjOrTransAbsMat)
-    copy((A' * D')')
+    adj = wrapperop(A)
+    copy(adj(adj(A) * adj(D)))
 end
 
 function rmul!(A::AbstractMatrix, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -338,8 +338,8 @@ function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
 end
 function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
     TS = promote_op(matprod, eltype(A), eltype(D))
-    Ac = copyto!(matprod_dest(A, D, TS), A)
-    rmul!(Ac, D)
+    C = matprod_dest(A, D, TS)
+    mul!(C, A, D)
 end
 function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
@@ -347,8 +347,8 @@ function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
 end
 function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
     T = promote_op(matprod, eltype(A), eltype(D))
-    Ac = copyto!(matprod_dest(D, A, TS), A)
-    lmul!(D, Ac)
+    C = matprod_dest(A, D, TS)
+    mul!(C, D, A)
 end
 
 function (*)(A::AdjOrTransAbsMat, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -336,7 +336,7 @@ function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal)
+function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
     Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
     rmul!(Ac, D)
 end
@@ -344,7 +344,7 @@ function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
 end
-function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
+function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
     Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
     lmul!(D, Ac)
 end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -337,7 +337,8 @@ function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     copy(adj(adj(D) * adj(A)))
 end
 function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    TS = promote_op(matprod, eltype(A), eltype(D))
+    Ac = copyto!(matprod_dest(A, D, TS), A)
     rmul!(Ac, D)
 end
 function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
@@ -345,7 +346,8 @@ function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     copy(adj(adj(A) * adj(D)))
 end
 function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    T = promote_op(matprod, eltype(A), eltype(D))
+    Ac = copyto!(matprod_dest(D, A, TS), A)
     lmul!(D, Ac)
 end
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,13 +332,28 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
-function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+function _diag_adj_mul(A::AdjOrTransAbsMat{<:Any, <:StridedMatrix}, D::Diagonal)
+    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    rmul!(Ac, D)
+end
+function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
+end
+function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat{<:Any, <:StridedMatrix})
+    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    lmul!(D, Ac)
+end
+
+function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+    _diag_adj_mul(A, D)
+end
+function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+    _diag_adj_mul(D, A)
 end
 
 function rmul!(A::AbstractMatrix, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -330,19 +330,26 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
-function mul(A::AdjOrTransAbsMat, D::Diagonal)
+function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
-    @invoke mul(A::AbstractMatrix, D::AbstractMatrix)
+function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
+    @invoke *(A::AbstractMatrix, D::AbstractMatrix)
 end
-function mul(D::Diagonal, A::AdjOrTransAbsMat)
+function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
 end
-function mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
-    @invoke mul(D::AbstractMatrix, A::AbstractMatrix)
+function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
+    @invoke *(D::AbstractMatrix, A::AbstractMatrix)
+end
+
+function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+    _diag_adj_mul(A, D)
+end
+function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+    _diag_adj_mul(D, A)
 end
 
 function rmul!(A::AbstractMatrix, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -449,10 +449,19 @@ function __muldiag_nonzeroalpha!(out, D::Diagonal, B::UpperOrLowerTriangular, al
 end
 
 @inline function __muldiag_nonzeroalpha_right!(out, A, D::Diagonal, alpha::Number, beta::Number)
-    @inbounds for j in axes(A, 2)
-        dja = @stable_muladdmul MulAddMul(alpha,false)(D.diag[j])
-        @simd for i in axes(A, 1)
-            @stable_muladdmul _modify!(MulAddMul(true,beta), A[i,j] * dja, out, (i,j))
+    if iszero(beta)
+        @inbounds for j in axes(A, 2)
+            dja = D.diag[j] * alpha
+            @simd for i in axes(A, 1)
+                out[i,j] = A[i,j] * dja
+            end
+        end
+    else
+        @inbounds for j in axes(A, 2)
+            dja = D.diag[j] * alpha
+            @simd for i in axes(A, 1)
+                out[i,j] = A[i,j] * dja + out[i,j] * beta
+            end
         end
     end
     return out

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -330,26 +330,19 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
-function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
+function mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
-    @invoke *(A::AbstractMatrix, D::AbstractMatrix)
+function mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
+    @invoke mul(A::AbstractMatrix, D::AbstractMatrix)
 end
-function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
+function mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
 end
-function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
-    @invoke *(D::AbstractMatrix, A::AbstractMatrix)
-end
-
-function (*)(A::AdjOrTransAbsMat, D::Diagonal)
-    _diag_adj_mul(A, D)
-end
-function (*)(D::Diagonal, A::AdjOrTransAbsMat)
-    _diag_adj_mul(D, A)
+function mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
+    @invoke mul(D::AbstractMatrix, A::AbstractMatrix)
 end
 
 function rmul!(A::AbstractMatrix, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -337,16 +337,18 @@ function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     copy(adj(adj(D) * adj(A)))
 end
 function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
-    rmul!(Ac, D)
+    TS = promote_op(matprod, eltype(A), eltype(D))
+    C = matprod_dest(A, D, TS)
+    mul!(C, A, D)
 end
 function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
 end
 function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
-    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
-    lmul!(D, Ac)
+    TS = promote_op(matprod, eltype(A), eltype(D))
+    C = matprod_dest(D, A, TS)
+    mul!(C, D, A)
 end
 
 function (*)(A::AdjOrTransAbsMat, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,13 +332,28 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
-function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+function _diag_adj_mul(A::AdjOrTransAbsMat, D::Diagonal)
     adj = wrapperop(A)
     copy(adj(adj(D) * adj(A)))
 end
-function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+function _diag_adj_mul(A::AdjOrTransAbsMat{<:Number, <:StridedMatrix}, D::Diagonal{<:Number})
+    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    rmul!(Ac, D)
+end
+function _diag_adj_mul(D::Diagonal, A::AdjOrTransAbsMat)
     adj = wrapperop(A)
     copy(adj(adj(A) * adj(D)))
+end
+function _diag_adj_mul(D::Diagonal{<:Number}, A::AdjOrTransAbsMat{<:Number, <:StridedMatrix})
+    Ac = copy_similar(A, promote_op(*, eltype(A), eltype(D)))
+    lmul!(D, Ac)
+end
+
+function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+    _diag_adj_mul(A, D)
+end
+function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+    _diag_adj_mul(D, A)
 end
 
 function rmul!(A::AbstractMatrix, D::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,6 +332,13 @@ function (*)(D::Diagonal, V::AbstractVector)
     return D.diag .* V
 end
 
+function (*)(A::AdjOrTransAbsMat, D::Diagonal)
+    copy((D' * A')')
+end
+function (*)(D::Diagonal, A::AdjOrTransAbsMat)
+    copy((A' * D')')
+end
+
 function rmul!(A::AbstractMatrix, D::Diagonal)
     matmul_size_check(size(A), size(D))
     for I in CartesianIndices(A)


### PR DESCRIPTION
This reinstates slightly altered versions of the methods that were removed in https://github.com/JuliaLang/julia/pull/52389. Sort of fixes #1205, although this doesn't recover the full performance. However, this version is more general, and works with the example presented in https://github.com/JuliaLang/julia/pull/52389. There's still a performance regression, but the full performance may only be obtained for mutable matrices, and we may not assume mutability in general.

Performance:
v1.10:

```julia
julia> n = 100
100

julia> A = adjoint(sparse(Float64, I, n, n));

julia> B = Diagonal(ones(n));

julia> @btime $A * $B;
  837.119 ns (5 allocations: 2.59 KiB)
```

This PR
```julia
julia> @btime $A * $B;
  1.106 μs (15 allocations: 5.56 KiB)
```
We need double the allocations here compared to earlier, as we firstly materialize `D' * A'`, and then we again copy the adjoint of this result. I wonder if this may be reduced.