### PR TITLE
`convert` to banded matrix types from `AbstractMatrix`es

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -118,6 +118,13 @@ Bidiagonal(A::Bidiagonal) = A
 Bidiagonal{T}(A::Bidiagonal{T}) where {T} = A
 Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 
+function convert(::Type{T}, A::AbstractMatrix) where T<:Bidiagonal
+    checksquare(A)
+    isbanded(A, -1, 1) || throw(InexactError(:convert, T, A))
+    iszero(diagview(A, 1)) ? T(A, :L) :
+        iszero(diagview(A, -1)) ? T(A, :U) : throw(InexactError(:convert, T, A))
+end
+
 _offdiagind(uplo) = uplo == 'U' ? 1 : -1
 
 @inline function Base.isassigned(A::Bidiagonal, i::Int, j::Int)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -109,8 +109,8 @@ julia> Bidiagonal(A, :L) # contains the main diagonal and first subdiagonal of A
  ⋅  ⋅  4  4
 ```
 """
-function Bidiagonal(A::AbstractMatrix, uplo::Symbol)
-    Bidiagonal(diag(A, 0), diag(A, uplo === :U ? 1 : -1), uplo)
+function (::Type{Bi})(A::AbstractMatrix, uplo::Symbol) where {Bi<:Bidiagonal}
+    Bi(diag(A, 0), diag(A, uplo === :U ? 1 : -1), uplo)
 end
 
 

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -118,13 +118,6 @@ Bidiagonal(A::Bidiagonal) = A
 Bidiagonal{T}(A::Bidiagonal{T}) where {T} = A
 Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 
-function convert(::Type{T}, A::AbstractMatrix) where T<:Bidiagonal
-    checksquare(A)
-    isbanded(A, -1, 1) || throw(InexactError(:convert, T, A))
-    iszero(diagview(A, 1)) ? T(A, :L) :
-        iszero(diagview(A, -1)) ? T(A, :U) : throw(InexactError(:convert, T, A))
-end
-
 _offdiagind(uplo) = uplo == 'U' ? 1 : -1
 
 @inline function Base.isassigned(A::Bidiagonal, i::Int, j::Int)
@@ -227,7 +220,12 @@ promote_rule(::Type{<:Tridiagonal}, ::Type{<:Bidiagonal}) = Tridiagonal
 AbstractMatrix{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A)
 AbstractMatrix{T}(A::Bidiagonal{T}) where {T} = copy(A)
 
-convert(::Type{T}, m::AbstractMatrix) where {T<:Bidiagonal} = m isa T ? m : T(m)::T
+function convert(::Type{T}, A::AbstractMatrix) where T<:Bidiagonal
+    checksquare(A)
+    isbanded(A, -1, 1) || throw(InexactError(:convert, T, A))
+    iszero(diagview(A, 1)) ? T(A, :L) :
+        iszero(diagview(A, -1)) ? T(A, :U) : throw(InexactError(:convert, T, A))
+end
 
 similar(B::Bidiagonal, ::Type{T}) where {T} = Bidiagonal(similar(B.dv, T), similar(B.ev, T), B.uplo)
 similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = similar(B.dv, T, dims)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -99,9 +99,7 @@ julia> Diagonal(A)
  ⋅  5
 ```
 """
-Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
-Diagonal{T}(A::AbstractMatrix) where T = Diagonal{T}(diag(A))
-Diagonal{T,V}(A::AbstractMatrix) where {T,V<:AbstractVector{T}} = Diagonal{T,V}(diag(A))
+(::Type{D})(A::AbstractMatrix) where {D<:Diagonal} = D(diag(A))
 function convert(::Type{T}, A::AbstractMatrix) where T<:Diagonal
     checksquare(A)
     isdiag(A) ? T(A) : throw(InexactError(:convert, T, A))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -99,7 +99,9 @@ julia> Diagonal(A)
  ⋅  5
 ```
 """
-(::Type{D})(A::AbstractMatrix) where {D<:Diagonal} = D(diag(A))
+Diagonal(A::AbstractMatrix) = Diagonal(diag(A))
+Diagonal{T}(A::AbstractMatrix) where T = Diagonal{T}(diag(A))
+Diagonal{T,V}(A::AbstractMatrix) where {T,V<:AbstractVector{T}} = Diagonal{T,V}(diag(A))
 function convert(::Type{T}, A::AbstractMatrix) where T<:Diagonal
     checksquare(A)
     isdiag(A) ? T(A) : throw(InexactError(:convert, T, A))

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -111,7 +111,7 @@ function SymTridiagonal(A::AbstractMatrix)
     checksquare(A)
     du = diag(A, 1)
     d  = diag(A)
-    dl = diag(A,-1)
+    dl = diag(A, -1)
     if _checksymmetric(d, du, dl)
         SymTridiagonal(d, du)
     else

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -107,13 +107,13 @@ julia> SymTridiagonal(B)
  [1 2; 3 4]  [1 2; 2 3]
 ```
 """
-function SymTridiagonal(A::AbstractMatrix)
+function (::Type{SymTri})(A::AbstractMatrix) where {SymTri <: SymTridiagonal}
     checksquare(A)
     du = diag(A, 1)
     d  = diag(A)
     dl = diag(A, -1)
     if _checksymmetric(d, du, dl)
-        SymTridiagonal(d, du)
+        SymTri(d, du)
     else
         throw(ArgumentError("matrix is not symmetric; cannot convert to SymTridiagonal"))
     end

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -111,7 +111,7 @@ function SymTridiagonal(A::AbstractMatrix)
     checksquare(A)
     du = diag(A, 1)
     d  = diag(A)
-    dl  = diag(A,-1)
+    dl = diag(A,-1)
     if _checksymmetric(d, du, dl)
         SymTridiagonal(d, du)
     else

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -590,7 +590,7 @@ julia> Tridiagonal(A)
  ⋅  ⋅  3  4
 ```
 """
-Tridiagonal(A::AbstractMatrix) = Tridiagonal(diag(A,-1), diag(A,0), diag(A,1))
+(::Type{Tri})(A::AbstractMatrix) where {Tri<:Tridiagonal} = Tri(diag(A,-1), diag(A,0), diag(A,1))
 
 Tridiagonal(A::Tridiagonal) = A
 Tridiagonal{T}(A::Tridiagonal{T}) where {T} = A

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -109,9 +109,10 @@ julia> SymTridiagonal(B)
 """
 function SymTridiagonal(A::AbstractMatrix)
     checksquare(A)
-    if _checksymmetric(A)
-        du = diag(A, 1)
-        d  = diag(A)
+    du = diag(A, 1)
+    d  = diag(A)
+    dl  = diag(A,-1)
+    if _checksymmetric(d, du, dl)
         SymTridiagonal(d, du)
     else
         throw(ArgumentError("matrix is not symmetric; cannot convert to SymTridiagonal"))

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1158,4 +1158,15 @@ end
     @test opnorm(B, Inf) == opnorm(Matrix(B), Inf)
 end
 
+@testset "convert to Bidiagonal" begin
+    M = diagm(0 => [1,2,3], 1=>[4,5])
+    B = convert(Bidiagonal, M)
+    @test B == Bidiagonal(M, :U)
+    M = diagm(0 => [1,2,3], -1=>[4,5])
+    B = convert(Bidiagonal, M)
+    @test B == Bidiagonal(M, :L)
+    M = diagm(-1 => [1,2], 1=>[4,5])
+    @test_throws InexactError convert(Bidiagonal, M)
+end
+
 end # module TestBidiagonal

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1165,6 +1165,12 @@ end
     M = diagm(0 => [1,2,3], -1=>[4,5])
     B = convert(Bidiagonal, M)
     @test B == Bidiagonal(M, :L)
+    B = convert(Bidiagonal{Int8}, M)
+    @test B == M
+    @test B isa Bidiagonal{Int8, Vector{Int8}}
+    B = convert(Bidiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}, M)
+    @test B == M
+    @test B isa Bidiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}
     M = diagm(-1 => [1,2], 1=>[4,5])
     @test_throws InexactError convert(Bidiagonal, M)
 end

--- a/test/special.jl
+++ b/test/special.jl
@@ -79,7 +79,7 @@ Random.seed!(1)
     end
     A = UpperTriangular(triu(rand(n,n)))
     for newtype in [Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal]
-        @test_throws ArgumentError convert(newtype,A)
+        @test_throws Union{ArgumentError,InexactError} convert(newtype,A)
     end
 
 

--- a/test/special.jl
+++ b/test/special.jl
@@ -43,7 +43,7 @@ Random.seed!(1)
        @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     for newtype in [Diagonal, Bidiagonal]
-       @test_throws ArgumentError convert(newtype,A)
+       @test_throws Union{ArgumentError,InexactError} convert(newtype,A)
     end
     A = SymTridiagonal(a, zeros(n-1))
     @test Matrix(convert(Bidiagonal,A)) == Matrix(A)
@@ -57,7 +57,7 @@ Random.seed!(1)
        @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     for newtype in [Diagonal, Bidiagonal]
-        @test_throws ArgumentError convert(newtype,A)
+        @test_throws Union{ArgumentError,InexactError} convert(newtype,A)
     end
     A = Tridiagonal(zeros(n-1), [1.0:n;], fill(1., n-1)) #not morally Diagonal
     @test Matrix(convert(Bidiagonal, A)) == Matrix(A)

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1121,6 +1121,12 @@ end
             diagm(-1 => [1,2], 1=>[1,2])]
             B = convert(SymTridiagonal, M)
             @test B == SymTridiagonal(M)
+            B = convert(SymTridiagonal{Int8}, M)
+            @test B == M
+            @test B isa SymTridiagonal{Int8}
+            B = convert(SymTridiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}, M)
+            @test B == M
+            @test B isa SymTridiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}
         end
         @test_throws InexactError convert(SymTridiagonal, fill(5, 4, 4))
         @test_throws InexactError convert(SymTridiagonal, diagm(0=>fill(NaN,4)))

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1099,4 +1099,26 @@ end
     @test opnorm(S, Inf) == opnorm(Matrix(S), Inf)
 end
 
+@testset "convert to Tridiagonal/SymTridiagonal" begin
+    @testset "Tridiagonal" begin
+        for M in [diagm(0 => [1,2,3], 1=>[4,5]),
+                diagm(0 => [1,2,3], 1=>[4,5], -1=>[6,7]),
+                diagm(-1 => [1,2], 1=>[4,5])]
+            B = convert(Tridiagonal, M)
+            @test B == Tridiagonal(M)
+        end
+        @test_throws InexactError convert(Tridiagonal, fill(5, 4, 4))
+    end
+    @testset "SymTridiagonal" begin
+        for M in [diagm(0 => [1,2,3], 1=>[4,5], -1=>[4,5]),
+            diagm(0 => [1,2,3]),
+            diagm(-1 => [1,2], 1=>[1,2])]
+            B = convert(SymTridiagonal, M)
+            @test B == SymTridiagonal(M)
+        end
+        @test_throws InexactError convert(SymTridiagonal, fill(5, 4, 4))
+        @test_throws InexactError convert(SymTridiagonal, diagm(0=>fill(NaN,4)))
+    end
+end
+
 end # module TestTridiagonal

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1106,6 +1106,12 @@ end
                 diagm(-1 => [1,2], 1=>[4,5])]
             B = convert(Tridiagonal, M)
             @test B == Tridiagonal(M)
+            B = convert(Tridiagonal{Int8}, M)
+            @test B == M
+            @test B isa Tridiagonal{Int8}
+            B = convert(Tridiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}, M)
+            @test B == M
+            @test B isa Tridiagonal{Int8, OffsetVector{Int8, Vector{Int8}}}
         end
         @test_throws InexactError convert(Tridiagonal, fill(5, 4, 4))
     end


### PR DESCRIPTION
After this, the following work:
```julia
julia> M = diagm(0=>1:4, -1=>1:3)
4×4 Matrix{Int64}:
 1  0  0  0
 1  2  0  0
 0  2  3  0
 0  0  3  4

julia> convert(Bidiagonal, M)
4×4 Bidiagonal{Int64, Vector{Int64}}:
 1  ⋅  ⋅  ⋅
 1  2  ⋅  ⋅
 ⋅  2  3  ⋅
 ⋅  ⋅  3  4

julia> convert(Tridiagonal, M)
4×4 Tridiagonal{Int64, Vector{Int64}}:
 1  0  ⋅  ⋅
 1  2  0  ⋅
 ⋅  2  3  0
 ⋅  ⋅  3  4

julia> M = diagm(0=>1:4, -1=>1:3, 1=>1:3)
4×4 Matrix{Int64}:
 1  1  0  0
 1  2  2  0
 0  2  3  3
 0  0  3  4

julia> convert(SymTridiagonal, M)
4×4 SymTridiagonal{Int64, Vector{Int64}}:
 1  1  ⋅  ⋅
 1  2  2  ⋅
 ⋅  2  3  3
 ⋅  ⋅  3  4
```
These parallel the analogous `convert` method for `Diagonal` that already exists. The method for `Bidiagonal` detects the zero band and automatically chooses the `uplo` accordingly. This fixes the currently broken behavior, where the `uplo` was not provided to the constructor:
```julia
julia> convert(Bidiagonal, M)
ERROR: MethodError: no method matching Bidiagonal(::Matrix{Int64})
```