### PR TITLE
Remove specialized `issymmetric`/`ishermitian` for `Diagonal{<:Number}`

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -247,9 +247,7 @@ Base._reverse(A::Diagonal, dims) = reverse!(Matrix(A); dims)
 Base._reverse(A::Diagonal, ::Colon) = Diagonal(reverse(A.diag))
 Base._reverse!(A::Diagonal, ::Colon) = (reverse!(A.diag); A)
 
-ishermitian(D::Diagonal{<:Number}) = isreal(D.diag)
 ishermitian(D::Diagonal) = all(ishermitian, D.diag)
-issymmetric(D::Diagonal{<:Number}) = true
 issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
 

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1454,4 +1454,11 @@ end
     @test opnorm(D, Inf) == opnorm(A, Inf)
 end
 
+@testset "issymmetric with NaN" begin
+    D = Diagonal(fill(NaN,3))
+    A = Array(D)
+    @test issymmetric(D) == issymmetric(A)
+    @test ishermitian(D) == ishermitian(A)
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
Unfortunately, this definition doesn't work if the matrix contains `NaN`, as it is not equal to itself. It is better to fall back to checking each element by default.

This fixes the mismatch in
```julia
julia> D = Diagonal(fill(NaN,2))
2×2 Diagonal{Float64, Vector{Float64}}:
 NaN       ⋅ 
    ⋅   NaN

julia> issymmetric(D)
true

julia> issymmetric(Array(D))
false
```