### PR TITLE
Use `BandIndex` directly in `diagzero` call in `getindex`

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -161,7 +161,7 @@ end
         # we explicitly compare the possible bands as b.band may be constant-propagated
         return @inbounds A.ev[b.index]
     else
-        return diagzero(A, Tuple(_cartinds(b))...)
+        return diagzero(A, b)
     end
 end
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -213,7 +213,7 @@ zeroslike(::Type{M}, sz::Tuple{Integer, Vararg{Integer}}) where {M<:AbstractMatr
     if b.band == 0
         @inbounds r = D.diag[b.index]
     else
-        r = diagzero(D, Tuple(_cartinds(b))...)
+        r = diagzero(D, b)
     end
     r
 end


### PR DESCRIPTION
We use `to_indices` in `diagzero`, which should take care of the conversion. This would simplify the code in the `diagzero` calls.