### PR TITLE
Add `getindex` for `SymTridiagonal` using a `BandIndex`

### DIFF
--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -475,7 +475,7 @@ end
 end
 
 @inline function getindex(A::SymTridiagonal, b::BandIndex)
-    @boundscheck checkbounds(A, i, j)
+    @boundscheck checkbounds(A, b)
     if b.band == 0
         return symmetric((@inbounds A.dv[b.index]), :U)::symmetric_type(eltype(A.dv))
     elseif b.band == -1

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -474,6 +474,19 @@ end
     end
 end
 
+@inline function getindex(A::SymTridiagonal, b::BandIndex)
+    @boundscheck checkbounds(A, i, j)
+    if b.band == 0
+        return symmetric((@inbounds A.dv[b.index]), :U)::symmetric_type(eltype(A.dv))
+    elseif b.band == -1
+        return copy(transpose(@inbounds A.ev[b.index])) # materialized for type stability
+    elseif b.band == 1
+        return @inbounds A.ev[b.index]
+    else
+        return diagzero(A, b)
+    end
+end
+
 Base._reverse(A::SymTridiagonal, dims) = reverse!(Matrix(A); dims)
 Base._reverse(A::SymTridiagonal, dims::Colon) = SymTridiagonal(reverse(A.dv), reverse(A.ev))
 Base._reverse!(A::SymTridiagonal, dims::Colon) = (reverse!(A.dv); reverse!(A.ev); A)


### PR DESCRIPTION
This specialized method was missing for a `SymTridiagonal`. This improves performance:
```julia
julia> S = SymTridiagonal(1:4000, 1:3999);

julia> @btime $S .+ $S;
  15.217 μs (6 allocations: 62.64 KiB) # master
  3.789 μs (6 allocations: 62.64 KiB) # this PR
``` 