### PR TITLE
backport: use the custom sysimage when running documentation (and doctests) as well 

### DIFF
--- a/.ci/create_sysimage.jl
+++ b/.ci/create_sysimage.jl
@@ -1,0 +1,16 @@
+using PackageCompiler, Libdl
+
+function create_sysimage_linear_algebra()
+    sysimage = tempname() * "." * Libdl.dlext
+
+    if haskey(ENV, "BUILDKITE")
+        ncores = Sys.CPU_THREADS
+    else
+        ncores = ceil(Int, Sys.CPU_THREADS / 2)
+    end
+
+    withenv("JULIA_IMAGE_THREADS" => ncores) do
+        create_sysimage(["LinearAlgebra", "Test", "Distributed", "Dates", "Printf", "Random"]; sysimage_path=sysimage, incremental=false, filter_stdlibs=true)
+    end
+    return sysimage, ncores
+end

--- a/.ci/create_sysimage_and_run_docs.jl
+++ b/.ci/create_sysimage_and_run_docs.jl
@@ -1,0 +1,6 @@
+include("create_sysimage.jl")
+sysimage, ncores = create_sysimage_linear_algebra()
+doc_file = joinpath(@__DIR__, "..", "docs", "make.jl")
+withenv("JULIA_NUM_THREADS" => 1) do
+    run(`$(Base.julia_cmd()) --sysimage=$sysimage --project=$(dirname(doc_file)) $doc_file`)
+end

--- a/.ci/create_sysimage_and_run_tests.jl
+++ b/.ci/create_sysimage_and_run_tests.jl
@@ -1,17 +1,5 @@
-using PackageCompiler, Libdl
-
-sysimage = tempname() * "." * Libdl.dlext
-
-if haskey(ENV, "BUILDKITE")
-    ncores = Sys.CPU_THREADS
-else
-    ncores = ceil(Int, Sys.CPU_THREADS / 2)
-end
-
-withenv("JULIA_IMAGE_THREADS" => ncores) do
-    create_sysimage(["LinearAlgebra", "Test", "Distributed", "Dates", "Printf", "Random"]; sysimage_path=sysimage, incremental=false, filter_stdlibs=true)
-end
-
+include("create_sysimage.jl")
+sysimage, ncores = create_sysimage_linear_algebra()
 current_dir = @__DIR__
 cmd = """Base.runtests(["LinearAlgebra"]; propagate_project=true, ncores=$ncores)"""
 withenv("JULIA_NUM_THREADS" => 1) do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
           version: 'nightly'
       - name: Generate docs
         run: |
-          julia --project --color=yes -e ''
-          julia --project --color=yes -e 'using Pkg; Pkg.respect_sysimage_versions(false); Pkg.activate("docs"); Pkg.develop(PackageSpec(path = pwd()))'
-          julia --project=docs --color=yes docs/make.jl
+          julia --color=yes --project=.ci -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=docs -e 'using Pkg; Pkg.instantiate()'
+          julia --color=yes --project=.ci .ci/create_sysimage_and_run_docs.jl
         env:
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[sources]
+LinearAlgebra = {path = ".."}


### PR DESCRIPTION


(cherry picked from commit f781708fffbd7e74ff17686c334ddd4f22d75a2c)