### PR TITLE
Specialize `lmul!`/`rmul!` for strided triangular matrices

### DIFF
--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1197,11 +1197,11 @@ end
     outTri = similar(TriA)
     out = similar(A)
     # 2 args
-    for fun in (*, rmul!, rdiv!, /)
+    @testset for fun in (*, rmul!, rdiv!, /)
         @test fun(copy(TriA), D)::Tri == fun(Matrix(TriA), D)
         @test fun(copy(UTriA), D)::Tri == fun(Matrix(UTriA), D)
     end
-    for fun in (*, lmul!, ldiv!, \)
+    @testset for fun in (*, lmul!, ldiv!, \)
         @test fun(D, copy(TriA))::Tri == fun(D, Matrix(TriA))
         @test fun(D, copy(UTriA))::Tri == fun(D, Matrix(UTriA))
     end


### PR DESCRIPTION
This improves performance, as we only need to loop over one half of the matrix. On master, `rmul!` for an `UpperTriangular` forwards the multiplication to the parent, so the entire array is looped over. We therefore obtain identical performance for `rmul!(::Matrix, ::Diagonal)` and `rmul!(::UpperTriangular{<:Any, <:Matrix}, ::Diagonal)`.
```julia
julia> using LinearAlgebra, Chairmarks

julia> D = Diagonal(rand(4000));

julia> A = rand(size(D)...);

julia> U = UpperTriangular(A);

julia> @b (A, D) rmul!(_[1], _[2])
10.309 ms

julia> @b (U, D) rmul!(_[1], _[2])
10.370 ms
```
On this PR, the latter is faster, as the loop is only over half the indices:
```julia
julia> @b (U, D) rmul!(_[1], _[2])
7.216 ms
```