### PR TITLE
Avoid materializing `diag` in `Diagonal` `kron`

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -762,16 +762,16 @@ end
 kron(A::Diagonal, B::Diagonal) = Diagonal(kron(A.diag, B.diag))
 
 function kron(A::Diagonal, B::SymTridiagonal)
-    kdv = kron(diag(A), B.dv)
+    kdv = kron(A.diag, B.dv)
     # We don't need to drop the last element
-    kev = kron(diag(A), _pushzero(_evview(B)))
+    kev = kron(A.diag, _pushzero(_evview(B)))
     SymTridiagonal(kdv, kev)
 end
 function kron(A::Diagonal, B::Tridiagonal)
     # `_droplast!` is only guaranteed to work with `Vector`
-    kd = convert(Vector, kron(diag(A), B.d))
-    kdl = _droplast!(convert(Vector, kron(diag(A), _pushzero(B.dl))))
-    kdu = _droplast!(convert(Vector, kron(diag(A), _pushzero(B.du))))
+    kd = convert(Vector, kron(A.diag, B.d))
+    kdl = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.dl))))
+    kdu = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.du))))
     Tridiagonal(kdl, kd, kdu)
 end
 


### PR DESCRIPTION
This reduces allocations in `kron`
```julia
julia> using LinearAlgebra

julia> D = Diagonal(1:100);

julia> T = Tridiagonal(1:99, 1:100, 1:99);

julia> @b (D,T) kron(_[1], _[2])
14.162 μs (20 allocs: 239.164 KiB) # master
8.829 μs (14 allocs: 236.445 KiB) # this PR
```