### PR TITLE
Initial implementation of lazy JLLs for LinearAlgebra

### DIFF
--- a/src/blas.jl
+++ b/src/blas.jl
@@ -162,7 +162,9 @@ get_num_threads()::Int = lbt_get_num_threads()
 function check()
     # TODO: once we have bitfields of the BLAS functions that are actually forwarded,
     # ensure that we have a complete set here (warning on an incomplete BLAS implementation)
-    config = get_config()
+    # We don't use `get_config()` here because we are invoked in the onload callback and
+    # we don't want to take any locks.
+    config = LBTConfig(unsafe_load(ccall((:lbt_get_config, libblastrampoline), Ptr{lbt_config_t}, ())))
 
     # Ensure that one of our loaded libraries satisfies our interface requirement
     interface = USE_BLAS64 ? :ilp64 : :lp64

--- a/src/lbt.jl
+++ b/src/lbt.jl
@@ -228,10 +228,14 @@ function lbt_set_num_threads(nthreads)
     return ccall((:lbt_set_num_threads, libblastrampoline), Cvoid, (Int32,), nthreads)
 end
 
+function lbt_forward_ccall(path::AbstractString; clear::Bool = false, verbose::Bool = false, suffix_hint::Union{String,Nothing} = nothing)
+    return ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring),
+                     path, clear ? 1 : 0, verbose ? 1 : 0, something(suffix_hint, C_NULL))
+end
+
 function lbt_forward(path::AbstractString; clear::Bool = false, verbose::Bool = false, suffix_hint::Union{String,Nothing} = nothing)
     _clear_config_with() do
-        return ccall((:lbt_forward, libblastrampoline), Int32, (Cstring, Int32, Int32, Cstring),
-                     path, clear ? 1 : 0, verbose ? 1 : 0, something(suffix_hint, C_NULL))
+        lbt_forward_ccall(path; clear, verbose, suffix_hint)
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -325,6 +325,10 @@ end
             @test 0 == @allocations mul!(C, At, Bt)
         end
         # syrk/herk
+        mul!(C, transpose(A), A)
+        mul!(C, adjoint(A), A)
+        mul!(C, A, transpose(A))
+        mul!(C, A, adjoint(A))
         @test 0 == @allocations mul!(C, transpose(A), A)
         @test 0 == @allocations mul!(C, adjoint(A), A)
         @test 0 == @allocations mul!(C, A, transpose(A))
@@ -334,6 +338,7 @@ end
         Ac = complex(A)
         for t in (identity, adjoint, transpose)
             Bt = t(B)
+            mul!(Cc, Ac, Bt)
             @test 0 == @allocations mul!(Cc, Ac, Bt)
         end
     end
@@ -356,6 +361,9 @@ end
         A = rand(-10:10, n, n)
         B = ones(Float64, n, n)
         C = zeros(Float64, n, n)
+        mul!(C, A, B)
+        mul!(C, A, transpose(B))
+        mul!(C, adjoint(A), B)
         @test 0 == @allocations mul!(C, A, B)
         @test 0 == @allocations mul!(C, A, transpose(B))
         @test 0 == @allocations mul!(C, adjoint(A), B)


### PR DESCRIPTION
This alters CompilerSupportLibraries_jll, OpenBLAS_jll and libblastrampoline_jll to use `LazyLibrary` objects and thereby be loaded only upon first `dlopen()` or `ccall()` to the individual library objects.  Note that this is one of the more complicated cases, as `libblastrampoline` must have OpenBLAS_jll added as a dynamic dependency (as it does not actually have it listed in its shared object headers) and also has some on-load callbacks that must be invoked.

This must be paired with the appropriate base Julia changes [0].

[0] https://github.com/JuliaLang/julia/pull/57719