### PR TITLE
Call `lmul!`/`rmul!` recursively in scalings

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -454,8 +454,8 @@ function rmul!(B::Bidiagonal, x::Number)
         iszero(y) || throw(ArgumentError(LazyString(lazy"cannot set index ($row, $col) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    @. B.dv *= x
-    @. B.ev *= x
+    rmul!(B.dv, x)
+    rmul!(B.ev, x)
     return B
 end
 function lmul!(x::Number, B::Bidiagonal)
@@ -467,8 +467,8 @@ function lmul!(x::Number, B::Bidiagonal)
         iszero(y) || throw(ArgumentError(LazyString(lazy"cannot set index ($row, $col) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    @. B.dv = x * B.dv
-    @. B.ev = x * B.ev
+    lmul!(x, B.dv)
+    lmul!(x, B.ev)
     return B
 end
 /(A::Bidiagonal, B::Number) = Bidiagonal(A.dv/B, A.ev/B, A.uplo)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -298,7 +298,7 @@ function lmul!(x::Number, D::Diagonal)
         iszero(y) || throw(ArgumentError(LazyString("cannot set index (2, 1) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    @. D.diag = x * D.diag
+    lmul!(x, D.diag)
     return D
 end
 function rmul!(D::Diagonal, x::Number)
@@ -308,7 +308,7 @@ function rmul!(D::Diagonal, x::Number)
         iszero(y) || throw(ArgumentError(LazyString("cannot set index (2, 1) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    @. D.diag *= x
+    rmul!(D.diag, x)
     return D
 end
 (/)(D::Diagonal, x::Number) = Diagonal(D.diag / x)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -227,8 +227,8 @@ function rmul!(A::SymTridiagonal, x::Number)
         iszero(y) || throw(ArgumentError(LazyString("cannot set index (3, 1) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    A.dv .*= x
-    _evview(A) .*= x
+    rmul!(A.dv, x)
+    rmul!(_evview(A), x)
     return A
 end
 function lmul!(x::Number, B::SymTridiagonal)
@@ -238,9 +238,8 @@ function lmul!(x::Number, B::SymTridiagonal)
         iszero(y) || throw(ArgumentError(LazyString("cannot set index (3, 1) off ",
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
-    @. B.dv = x * B.dv
-    ev = _evview(B)
-    @. ev = x * ev
+    lmul!(x, B.dv)
+    lmul!(x, _evview(B))
     return B
 end
 /(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv/B, A.ev/B)


### PR DESCRIPTION
Avoiding broadcasting helps with performance in certain cases:
```julia
julia> using LinearAlgebra, SparseArrays

julia> D = Diagonal(sprand(1000, 0.01));

julia> @b D lmul!(2.0, _)
88.674 ns (4 allocs: 384 bytes) # master
10.025 ns # this PR
```
Similar performance boosts for the other banded matrices.