### PR TITLE
Ensure positive-definite matrix in lapack posv test

### DIFF
--- a/test/lapack.jl
+++ b/test/lapack.jl
@@ -687,11 +687,7 @@ end
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         local n = 10
         a = randn(elty, n, n)
-        # generate a symmetric positive definite matrix as Q*D*Q',
-        # where Q is orthogonal, and D contains the eigenvalues
-        Q, _ = qr(a)
-        D = Diagonal(rand(real(elty), n) .+ real(oneunit(elty)))
-        A = Matrix(Hermitian(Q*D*Q')) # ensure that the matrix is exactly hermitian
+        A = a'*a + I
         B = rand(elty, n, n)
         D = copy(A)
         C = copy(B)

--- a/test/lapack.jl
+++ b/test/lapack.jl
@@ -687,7 +687,11 @@ end
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         local n = 10
         a = randn(elty, n, n)
-        A = a'*a
+        # generate a symmetric positive definite matrix as Q*D*Q',
+        # where Q is orthogonal, and D contains the eigenvalues
+        Q, _ = qr(a)
+        D = Diagonal(rand(real(elty), n) .+ real(oneunit(elty)))
+        A = Matrix(Hermitian(Q*D*Q')) # ensure that the matrix is exactly hermitian
         B = rand(elty, n, n)
         D = copy(A)
         C = copy(B)


### PR DESCRIPTION
The test failure in https://buildkite.com/julialang/linearalgebra-dot-jl/builds/330#01954c88-5de5-42fb-a0b4-e10f487d934e is because the matrix is not positive-definite. Since we construct the matrix by ourselves, we may ensure that the eigenvalues are all positive by defining it as ~~`Q*D*Q'` for an orthogonal `Q`~~ `A'A + I`. This way we avoid such floating-point issues.