### PR TITLE
Reduce `stable_muladdmul` branches in `generic matvecmul!`

### DIFF
--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -962,7 +962,7 @@ function __generic_matvecmul!(::typeof(identity), C::AbstractVector, A::Abstract
         end
         for k = eachindex(B)
             aoffs = (k-1)*Astride
-            b = @stable_muladdmul MulAddMul(alpha,beta)(B[k])
+            b = @stable_muladdmul MulAddMul(alpha,false)(B[k])
             for i = eachindex(C)
                 C[i] += A[aoffs + i] * b
             end


### PR DESCRIPTION
Since `beta` is not used in this operation, we may set it to a constant to eliminate two of the branches generated by `@stable_muladdmul`.