### PR TITLE
Destination zeros from eltype in zero-length generic_matvecmul

### DIFF
--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -955,7 +955,7 @@ function __generic_matvecmul!(::typeof(identity), C::AbstractVector, A::Abstract
             if !iszero(beta)
                 C[i] *= beta
             elseif length(B) == 0
-                C[i] = false
+                C[i] = zero(eltype(C))
             else
                 C[i] = zero(A[i]*B[1] + A[i]*B[1])
             end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -932,7 +932,7 @@ function __generic_matvecmul!(f::F, C::AbstractVector, A::AbstractVecOrMat, B::A
     @inbounds begin
         if length(B) == 0
             for k = eachindex(C)
-                @stable_muladdmul _modify!(MulAddMul(alpha,beta), false, C, k)
+                @stable_muladdmul _modify!(MulAddMul(alpha,beta), zero(eltype(C)), C, k)
             end
         else
             for k = eachindex(C)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1182,7 +1182,7 @@ end
 end
 
 @testset "zero-length generic matvec" begin
-    m = SizedArrays.SizedArray{(2,2)}(reshape(1:4, 2, 2))
+    m = SizedArrays.SizedArray{(2,2)}(ones(2,2))
     A = fill(m, 2, 0)
     v = fill(m, size(A,2))
     w = similar(v, size(A,1))

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1188,6 +1188,9 @@ end
     w = similar(v, size(A,1))
     mul!(w, A, v)
     @test all(iszero, w)
+    A = fill(m, 0, 2)
+    mul!(w, A', v)
+    @test all(iszero, w)
 end
 
 end # module TestMatmul

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -6,6 +6,11 @@ using Base: rtoldefault
 using Test, LinearAlgebra, Random
 using LinearAlgebra: mul!, Symmetric, Hermitian
 
+const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+
+isdefined(Main, :SizedArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "SizedArrays.jl"))
+using .Main.SizedArrays
+
 ## Test Julia fallbacks to BLAS routines
 
 mul_wrappers = [
@@ -1174,6 +1179,15 @@ end
         @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(T,2,2), 'N', 'N', zeros(T,2,3), zeros(T,3,2))
         @test_throws "expected size: (2, 2)" LinearAlgebra.matmul2x2!(zeros(T,2,3), 'N', 'N', zeros(T,2,2), zeros(T,2,3))
     end
+end
+
+@testset "zero-length generic matvec" begin
+    m = SizedArrays.SizedArray{(2,2)}(reshape(1:4, 2, 2))
+    A = fill(m, 2, 0)
+    v = fill(m, size(A,2))
+    w = similar(v, size(A,1))
+    mul!(w, A, v)
+    @test all(iszero, w)
 end
 
 end # module TestMatmul


### PR DESCRIPTION
This fixes issues like
```julia
julia> A = fill(@SMatrix(zeros(2,2)), 4, 0)
4×0 Matrix{SMatrix{2, 2, Float64, 4}}

julia> v = fill(@SMatrix(zeros(2,2)), size(A,2))
SMatrix{2, 2, Float64, 4}[]

julia> A * v
ERROR: MethodError: Cannot `convert` an object of type Bool to an object of type SMatrix{2, 2, Float64, 4}
The function `convert` exists, but no method is defined for this combination of argument types.
[...]
```