### PR TITLE
Make `parentof_applytri` fully type-stable

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -315,7 +315,7 @@ function applytri(f, A::HermOrSym, B::HermOrSym)
 end
 _parent_tri(U::UpperOrLowerTriangular) = parent(U)
 _parent_tri(U) = U
-parentof_applytri(f, args...) = _parent_tri(applytri(f, args...))
+parentof_applytri(f, args...) = applytri(_parent_tri∘f, args...)
 
 isdiag(A::HermOrSym) = applytri(isdiag, A)
 


### PR DESCRIPTION
This should make each branch in `applytri` return the same type, as the `UpperTriangular` or `LowerTriangular` wrapper will be removed.