### PR TITLE
Avoid accessing unset indices in symmetric copyto!

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -352,7 +352,7 @@ function copyto!(dest::Symmetric, src::Symmetric)
     elseif src.uplo == dest.uplo
         copytrito!(dest.data, src.data, src.uplo)
     else
-        transpose!(dest.data, Base.unalias(dest.data, src.data))
+        copytrito!(dest.data, transpose(Base.unalias(dest.data, src.data)), dest.uplo)
     end
     return dest
 end
@@ -363,7 +363,7 @@ function copyto!(dest::Hermitian, src::Hermitian)
     elseif src.uplo == dest.uplo
         copytrito!(dest.data, src.data, src.uplo)
     else
-        adjoint!(dest.data, Base.unalias(dest.data, src.data))
+        copytrito!(dest.data, adjoint(Base.unalias(dest.data, src.data)), dest.uplo)
     end
     return dest
 end

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1163,4 +1163,19 @@ end
     end
 end
 
+@testset "copyto! with mismatched uplo" begin
+    for (S,tf) in ((Symmetric, transpose), (Hermitian, adjoint))
+        for (uplo1,uplo2) in [(:U,:L), (:L, :U)]
+            M = Matrix{Complex{BigFloat}}(undef, 2, 2)
+            M[1,1] = M[2,2] = 3
+            isupper = uplo1 == :U
+            M[1+!isupper, 1+isupper] = 4+3im
+            H1 = S(M, uplo1)
+            H2 = 2 * S(tf(M), uplo2)
+            copyto!(H2, H1)
+            @test H2 == H1
+        end
+    end
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
Currently, copying `Symmetric`/`Hermitian` matrices with mismatched `uplo`s might access unset indices. In this PR, we fix this by ensuring that we always use `copytrito!`, and only access the triangular half of the parent that `uplo` corresponds to.
On master,
```julia
julia> using LinearAlgebra

julia> M = Matrix{Complex{BigFloat}}(undef, 2, 2)
2×2 Matrix{Complex{BigFloat}}:
 #undef  #undef
 #undef  #undef

julia> M[1,1] = M[2,2] = 3
3

julia> uplo1, uplo2 = :U, :L
(:U, :L)

julia> isupper = uplo1 == :U
true

julia> M[1+!isupper, 1+isupper] = 4+3im
4 + 3im

julia> M
2×2 Matrix{Complex{BigFloat}}:
 3.0+0.0im  4.0+3.0im
  #undef    3.0+0.0im

julia> H1 = Hermitian(M, uplo1)
2×2 Hermitian{Complex{BigFloat}, Matrix{Complex{BigFloat}}}:
 3.0+0.0im  4.0+3.0im
 4.0-3.0im  3.0+0.0im

julia> H2 = Hermitian(M', uplo2)
2×2 Hermitian{Complex{BigFloat}, Adjoint{Complex{BigFloat}, Matrix{Complex{BigFloat}}}}:
 3.0+0.0im  4.0+3.0im
 4.0-3.0im  3.0+0.0im

julia> copyto!(H1, H2)
ERROR: UndefRefError: access to undefined reference
[...]
```
After this PR,
```julia
julia> copyto!(H1, H2)
2×2 Hermitian{Complex{BigFloat}, Matrix{Complex{BigFloat}}}:
 3.0+0.0im  4.0+3.0im
 4.0-3.0im  3.0+0.0im
```