### PR TITLE
add generic syrk/herk

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -280,6 +280,7 @@ julia> rmul!([NaN], 0.0)
 ```
 """
 function rmul!(X::AbstractArray, s::Number)
+    isone(s) && return X
     @simd for I in eachindex(X)
         @inbounds X[I] *= s
     end
@@ -318,6 +319,7 @@ julia> lmul!(0.0, [Inf])
 ```
 """
 function lmul!(s::Number, X::AbstractArray)
+    isone(s) && return X
     @simd for I in eachindex(X)
         @inbounds X[I] = s*X[I]
     end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -595,6 +595,7 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
 end
 
 function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
+    require_one_based_indexing(C, A)
     nC = checksquare(C)
     m, n = size(A, 1), size(A, 2)
     mA = aat ? m : n

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -593,8 +593,14 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
     return _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), α, β)
 end
 
-#if conjugate is true, computes A A' α + C β if aat is true, and A' A α + C β otherwise
-#if conjugate is false, computes A transpose(A) α + C β if aat is true, and tranpose(A) A α + C β otherwise
+"""
+    generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
+
+Computes syrk/herk for generic number types. If `conjugate` is false computes syrk, i.e.,
+``A transpose(A) α + C β`` if `aat` is true, and ``transpose(A) A α + C β`` otherwise.
+If `conjugate` is true computes herk, i.e., ``A A' α + C β`` if `aat` is true, and
+``A' A α + C β`` otherwise.
+"""
 function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
     require_one_based_indexing(C, A)
     nC = checksquare(C)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -593,6 +593,8 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
     return _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), α, β)
 end
 
+#if conjugate is true, computes A A' α + C β if aat is true, and A' A α + C β otherwise
+#if conjugate is false, computes A transpose(A) α + C β if aat is true, and tranpose(A) A α + C β otherwise
 function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
     require_one_based_indexing(C, A)
     nC = checksquare(C)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -782,8 +782,7 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
         else
             generic_syrk!(C, A, false, tA_uc == 'N', alpha, beta)
         end
-        copytri!(C, 'U')
-        return C
+        return copytri!(C, 'U')
     end
     return gemm_wrapper!(C, tA, tAt, A, A, α, β)
 end
@@ -829,10 +828,11 @@ Base.@constprop :aggressive function herk_wrapper!(C::Union{StridedMatrix{T}, St
                 stride(A, 1) == stride(C, 1) == 1 &&
                 _fullstride2(A) && _fullstride2(C)) &&
                 max(nA, mA) ≥ 4
-            return copytri!(BLAS.herk!('U', tA, alpha, A, beta, C), 'U', true)
+            BLAS.herk!('U', tA, alpha, A, beta, C)
         else
-            return copytri!(generic_syrk!(C, A, true, tA_uc == 'N', alpha, beta), 'U', true)
+            generic_syrk!(C, A, true, tA_uc == 'N', alpha, beta)
         end
+        return copytri!(C, 'U', true)
     end
     return gemm_wrapper!(C, tA, tAt, A, A, α, β)
 end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -594,9 +594,9 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
     return _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), α, β)
 end
 
-function generic_syrk!(C::StridedMatrix{T}, A::StridedMatrix{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
+function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
     nC = checksquare(C)
-    m, n = size(A)
+    m, n = size(A, 1), size(A, 2)
     mA = aat ? m : n
     if nC != mA
         throw(DimensionMismatch(lazy"output matrix has size: $(size(C)), but should have size $((mA, mA))"))

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -602,11 +602,7 @@ function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bo
         throw(DimensionMismatch(lazy"output matrix has size: $(size(C)), but should have size $((mA, mA))"))
     end
 
-    if iszero(β)
-        fill!(C, T(0))
-    elseif !isone(β)
-        C .*= β
-    end
+    _rmul_or_fill!(C, β)
     @inbounds if !conjugate
         if aat
             for k ∈ 1:n, j ∈ 1:m

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -832,7 +832,7 @@ Base.@constprop :aggressive function herk_wrapper!(C::Union{StridedMatrix{T}, St
     # Result array does not need to be initialized as long as beta==0
     #    C = Matrix{T}(undef, mA, mA)
 
-    if iszero(β) || issymmetric(C)
+    if iszero(β) || ishermitian(C)
         alpha, beta = promote(α, β, zero(T))
         if (alpha isa Union{Bool,T} &&
                 beta isa Union{Bool,T} &&

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -772,7 +772,7 @@ end
 # the aggressive constprop pushes tA and tB into gemm_wrapper!, which is needed for wrap calls within it
 # to be concretely inferred
 Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
-        alpha::Number, beta::Number) where {T<:BlasFloat}
+        α::Number, β::Number) where {T<:BlasFloat}
     nC = checksquare(C)
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
     if tA_uc == 'T'
@@ -788,16 +788,18 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
 
     # BLAS.syrk! only updates symmetric C
     # alternatively, make non-zero β a show-stopper for BLAS.syrk!
-    if iszero(beta) || issymmetric(C)
-        α, β = promote(alpha, beta, zero(T))
+    if iszero(β) || issymmetric(C)
+        alpha, beta = promote(α, β, zero(T))
         if (alpha isa Union{Bool,T} &&
                 beta isa Union{Bool,T} &&
                 stride(A, 1) == stride(C, 1) == 1 &&
                 _fullstride2(A) && _fullstride2(C))
             return copytri!(BLAS.syrk!('U', tA, alpha, A, beta, C), 'U')
+        else
+            return copytri!(generic_syrk!(C, A, false, tA_uc == 'N', alpha, beta), 'U')
         end
     end
-    return gemm_wrapper!(C, tA, tAt, A, A, alpha, beta)
+    return gemm_wrapper!(C, tA, tAt, A, A, α, β)
 end
 # legacy method
 syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T}, _add::MulAddMul = MulAddMul()) where {T<:BlasFloat} =
@@ -830,6 +832,8 @@ Base.@constprop :aggressive function herk_wrapper!(C::Union{StridedMatrix{T}, St
                 stride(A, 1) == stride(C, 1) == 1 &&
                 _fullstride2(A) && _fullstride2(C))
             return copytri!(BLAS.herk!('U', tA, alpha, A, beta, C), 'U', true)
+        else
+            return copytri!(generic_syrk!(C, A, true, tA_uc == 'N', alpha, beta), 'U', true)
         end
     end
     return gemm_wrapper!(C, tA, tAt, A, A, α, β)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -578,7 +578,6 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
         matmul_size_check(size(C), (mA, nA), (mB, nB))
         return _rmul_or_fill!(C, β)
     end
-    matmul2x2or3x3_nonzeroalpha!(C, tA, tB, A, B, α, β) && return C
 
     if A === B
         tA_uc = uppercase(tA) # potentially strip a WrapperChar

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -585,7 +585,7 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
         blasfn = _valtypeparam(val)
         if blasfn == BlasFlag.SYRK && T <: Union{Real,Complex} && (iszero(β) || issymmetric(C))
             return copytri!(generic_syrk!(C, A, false, aat, α, β), 'U')
-        elseif blasfn == BlasFlag.HERK && (iszero(β) || ishermitian(C))
+        elseif blasfn == BlasFlag.HERK && isreal(α) && isreal(β) && (iszero(β) || ishermitian(C))
             return copytri!(generic_syrk!(C, A, true, aat, α, β), 'U', true)
         end
     end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -575,7 +575,7 @@ end
 Computes syrk/herk for generic number types. If `conjugate` is false computes syrk, i.e.,
 ``A transpose(A) α + C β`` if `aat` is true, and ``transpose(A) A α + C β`` otherwise.
 If `conjugate` is true computes herk, i.e., ``A A' α + C β`` if `aat` is true, and
-``A' A α + C β`` otherwise.
+``A' A α + C β`` otherwise. Only the upper triangular is computed.
 """
 function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bool, aat::Bool, α, β) where {T<:Number}
     require_one_based_indexing(C, A)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -778,10 +778,12 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
                 stride(A, 1) == stride(C, 1) == 1 &&
                 _fullstride2(A) && _fullstride2(C)) &&
                 max(nA, mA) ≥ 4
-            return copytri!(BLAS.syrk!('U', tA, alpha, A, beta, C), 'U')
+            BLAS.syrk!('U', tA, alpha, A, beta, C)
         else
-            return copytri!(generic_syrk!(C, A, false, tA_uc == 'N', alpha, beta), 'U')
+            generic_syrk!(C, A, false, tA_uc == 'N', alpha, beta)
         end
+        copytri!(C, 'U')
+        return C
     end
     return gemm_wrapper!(C, tA, tAt, A, A, α, β)
 end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -607,7 +607,7 @@ function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bo
     @inbounds if !conjugate
         if aat
             for k ∈ 1:n, j ∈ 1:m
-                αA_jk = α * A[j, k]
+                αA_jk = A[j, k] * α
                 for i ∈ 1:j
                     C[i, j] += A[i, k] * αA_jk
                 end
@@ -618,17 +618,17 @@ function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bo
                 for k ∈ 2:m
                     temp += A[k, i] * A[k, j]
                 end
-                C[i, j] += α * temp
+                C[i, j] += temp * α
             end
         end
     else
         if aat
             for k ∈ 1:n, j ∈ 1:m
-                αA_jk_bar = α * conj(A[j, k])
+                αA_jk_bar = conj(A[j, k]) * α
                 for i ∈ 1:j-1
                     C[i, j] += A[i, k] * αA_jk_bar
                 end
-                C[j, j] += α * abs2(A[j, k])
+                C[j, j] += abs2(A[j, k]) * α
             end
         else
             for j ∈ 1:n
@@ -637,13 +637,13 @@ function generic_syrk!(C::StridedMatrix{T}, A::StridedVecOrMat{T}, conjugate::Bo
                     for k ∈ 2:m
                         temp += conj(A[k, i]) * A[k, j]
                     end
-                    C[i, j] += α * temp
+                    C[i, j] += temp * α
                 end
                 temp = abs2(A[1, j])
                 for k ∈ 2:m
                     temp += abs2(A[k, j])
                 end
-                C[j, j] += α * temp
+                C[j, j] += temp * α
             end
         end
     end

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -123,6 +123,31 @@ end
     @test_throws DimensionMismatch axpy!(α, x, Vector(1:3), y, Vector(1:5))
 end
 
+@testset "generic syrk & herk" begin
+    for T ∈ (BigFloat, Complex{BigFloat}, Quaternion{Float64})
+        α = randn(T)
+        a = randn(T, 3, 4)
+        csmall = similar(a, 3, 3)
+        csmall_fallback = similar(a, 3, 3)
+        cbig = similar(a, 4, 4)
+        cbig_fallback = similar(a, 4, 4)
+        mul!(csmall, a, a', real(α), false)
+        LinearAlgebra._generic_matmatmul!(csmall_fallback, a, a', real(α), false)
+        @test ishermitian(csmall)
+        @test csmall ≈ csmall_fallback
+        mul!(cbig, a', a, real(α), false)
+        LinearAlgebra._generic_matmatmul!(cbig_fallback, a', a, real(α), false)
+        @test ishermitian(cbig)
+        @test cbig ≈ cbig_fallback
+        mul!(csmall, a, transpose(a), α, false)
+        LinearAlgebra._generic_matmatmul!(csmall_fallback, a, transpose(a), α, false)
+        @test csmall ≈ csmall_fallback
+        mul!(cbig, transpose(a), a, α, false)
+        LinearAlgebra._generic_matmatmul!(cbig_fallback, transpose(a), a, α, false)
+        @test cbig ≈ cbig_fallback
+    end
+end
+
 @test !issymmetric(fill(1,5,3))
 @test !ishermitian(fill(1,5,3))
 @test (x = fill(1,3); cross(x,x) == zeros(3))

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -145,6 +145,17 @@ end
         mul!(cbig, transpose(a), a, α, false)
         LinearAlgebra._generic_matmatmul!(cbig_fallback, transpose(a), a, α, false)
         @test cbig ≈ cbig_fallback
+        if T <: Union{Real, Complex}
+            @test issymmetric(csmall)
+            @test issymmetric(cbig)
+        end
+        #make sure generic herk is not called for non-real α
+        mul!(csmall, a, a', α, false)
+        LinearAlgebra._generic_matmatmul!(csmall_fallback, a, a', α, false)
+        @test csmall ≈ csmall_fallback
+        mul!(cbig, a', a, α, false)
+        LinearAlgebra._generic_matmatmul!(cbig_fallback, a', a, α, false)
+        @test cbig ≈ cbig_fallback
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -542,13 +542,13 @@ end
         a = randn(T, 3, 4)
         csmall = similar(a, 3, 3)
         cbig = similar(a, 4, 4)
-        _generic_matmatmul!(csmall, a, a', true, false)
+        LinearAlgebra._generic_matmatmul!(csmall, a, a', true, false)
         @test csmall ≈ a * a'
-        _generic_matmatmul!(csmall, a, transpose(a), true, false)
+        LinearAlgebra._generic_matmatmul!(csmall, a, transpose(a), true, false)
         @test csmall ≈ a * transpose(a)
-        _generic_matmatmul!(cbig, a', a, true, false)
+        LinearAlgebra._generic_matmatmul!(cbig, a', a, true, false)
         @test cbig ≈ a' * a
-        _generic_matmatmul!(cbig, transpose(a), a, true, false)
+        LinearAlgebra._generic_matmatmul!(cbig, transpose(a), a, true, false)
         @test cbig ≈ transpose(a) * a
     end
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -537,22 +537,6 @@ end
     @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
 end
 
-@testset "generic syrk & herk" begin
-    for T ∈ (BigFloat, Complex{BigFloat})
-        a = randn(T, 3, 4)
-        csmall = similar(a, 3, 3)
-        cbig = similar(a, 4, 4)
-        LinearAlgebra._generic_matmatmul!(csmall, a, a', true, false)
-        @test csmall ≈ a * a'
-        LinearAlgebra._generic_matmatmul!(csmall, a, transpose(a), true, false)
-        @test csmall ≈ a * transpose(a)
-        LinearAlgebra._generic_matmatmul!(cbig, a', a, true, false)
-        @test cbig ≈ a' * a
-        LinearAlgebra._generic_matmatmul!(cbig, transpose(a), a, true, false)
-        @test cbig ≈ transpose(a) * a
-    end
-end
-
 @testset "matmul for types w/o sizeof (issue #1282)" begin
     AA = fill(complex(1, 1), 10, 10)
     for A in (copy(AA), view(AA, 1:10, 1:10))

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -537,7 +537,7 @@ end
     @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
 end
 
-@testset "generic syrk & herk"
+@testset "generic syrk & herk" begin
     for T ∈ (BigFloat, Complex{BigFloat})
         a = randn(T, 3, 4)
         csmall = similar(a, 3, 3)
@@ -549,7 +549,7 @@ end
         _generic_matmatmul!(cbig, a', a, true, false)
         @test cbig ≈ a' * a
         _generic_matmatmul!(cbig, transpose(a), a, true, false)
-        @test cbig ≈ tranpose(a) * a
+        @test cbig ≈ transpose(a) * a
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -537,6 +537,22 @@ end
     @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
 end
 
+@testset "generic syrk & herk"
+    for T ∈ (BigFloat, Complex{BigFloat})
+        a = randn(T, 3, 4)
+        csmall = similar(a, 3, 3)
+        cbig = similar(a, 4, 4)
+        _generic_matmatmul!(csmall, a, a', true, false)
+        @test csmall ≈ a * a'
+        _generic_matmatmul!(csmall, a, transpose(a), true, false)
+        @test csmall ≈ a * transpose(a)
+        _generic_matmatmul!(cbig, a', a, true, false)
+        @test cbig ≈ a' * a
+        _generic_matmatmul!(cbig, transpose(a), a, true, false)
+        @test cbig ≈ tranpose(a) * a
+    end
+end
+
 @testset "matmul for types w/o sizeof (issue #1282)" begin
     AA = fill(complex(1, 1), 10, 10)
     for A in (copy(AA), view(AA, 1:10, 1:10))


### PR DESCRIPTION
I've added an implementation of syrk/herk for generic types, in order to avoid falling back to `_generic_matmatmul!`, as it's rather slow. I didn't do anything fancy, no multithreading or anything, but this gives a 1.5x to 2x speedup for `Int` and `BigFloat`, for example.

The generic version of syrk only works for real and complex numbers, but funnily enough herk works for anything that respects `conj(a*b) == conj(b)*conj(a)`, which as far as I can tell is any subtype of `Number`, including quaternions and octonions.

I've ran the tests locally by reverting to the commit before the lazy JLLs one, and they pass.