### PR TITLE
Simplify `bkcopy_oftype` for complex Symmetric matrices

### DIFF
--- a/src/bunchkaufman.jl
+++ b/src/bunchkaufman.jl
@@ -128,7 +128,7 @@ function bunchkaufman!(A::StridedMatrix{<:BlasFloat}, rook::Bool = false; check:
 end
 
 bkcopy_oftype(A, S) = eigencopy_oftype(A, S)
-bkcopy_oftype(A::Symmetric{<:Complex}, S) = copyto!(similar(A, S), A)
+bkcopy_oftype(A::Symmetric{<:Complex}, S) = copymutable_oftype(A, S)
 
 """
     bunchkaufman(A, rook::Bool=false; check = true) -> S::BunchKaufman

--- a/src/bunchkaufman.jl
+++ b/src/bunchkaufman.jl
@@ -128,7 +128,7 @@ function bunchkaufman!(A::StridedMatrix{<:BlasFloat}, rook::Bool = false; check:
 end
 
 bkcopy_oftype(A, S) = eigencopy_oftype(A, S)
-bkcopy_oftype(A::Symmetric{<:Complex}, S) = Symmetric(copytrito!(similar(parent(A), S, size(A)), A.data, A.uplo), sym_uplo(A.uplo))
+bkcopy_oftype(A::Symmetric{<:Complex}, S) = copyto!(similar(A, S), A)
 
 """
     bunchkaufman(A, rook::Bool=false; check = true) -> S::BunchKaufman

--- a/test/bunchkaufman.jl
+++ b/test/bunchkaufman.jl
@@ -257,4 +257,10 @@ end
     @test B.U * B.D * B.U' ≈ S
 end
 
+@testset "complex Symmetric" begin
+    S = Symmetric(rand(ComplexF64,4,4))
+    B = bunchkaufman(S)
+    @test B.U * B.D * transpose(B.U) ≈ B.P * S * transpose(B.P)
+end
+
 end # module TestBunchKaufman


### PR DESCRIPTION
`copyto!` for `Symmetric` matrices calls `copytrito!` internally, so we may use the higher-level api here.