### PR TITLE
stop assuming that you can mutate data structures in other packages at precompile time

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -840,7 +840,10 @@ function lbt_openblas_onload_callback()
     end
 end
 
-# If users want to lazily load a different BLAS, they'd need to either change this call, or
-# clear the datastructures modified by this call and call it again with their own.
-libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, lbt_openblas_onload_callback)
+function __init__()
+    # If users want to lazily load a different BLAS, they'd need to either change this call, or
+    # clear the datastructures modified by this call and call it again with their own.
+    libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, lbt_openblas_onload_callback)
+end
+
 end # module LinearAlgebra


### PR DESCRIPTION
This code pattern is not valid w.r.t precompilation. It breaks if you build a sysimage and happen to have a valid precomple file locally for `libblastrampoline_jll`, it also doesn't work if the involved packages are used like normal packages (and are not in a sysimage).

fixes #1246 