### PR TITLE
Clean up `herk_wrapper!` and add 5-arg tests

### DIFF
--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -542,6 +542,16 @@ end
     @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
 end
 
+@testset "5-arg syrk! & herk!" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64), A in (randn(T, 5), randn(T, 5, 5))
+        B = A' * A
+        C = B isa Number ? [B;;] : Matrix(Hermitian(B))
+        @test mul!(copy(C), A', A, true, 2) ≈ 3C
+        D = Matrix(Hermitian(A * A'))
+        @test mul!(copy(D), A, A', true, 3) ≈ 4D
+    end
+end
+
 @testset "matmul for types w/o sizeof (issue #1282)" begin
     AA = fill(complex(1, 1), 10, 10)
     for A in (copy(AA), view(AA, 1:10, 1:10))

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -539,7 +539,7 @@ end
 
     A5x5, A6x5 = Matrix{Float64}.(undef, ((5, 5), (6, 5)))
     @test_throws DimensionMismatch LinearAlgebra.syrk_wrapper!(A5x5, 'N', A6x5)
-    @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(A5x5, 'N', A6x5)
+    @test_throws DimensionMismatch LinearAlgebra.herk_wrapper!(complex(A5x5), 'N', complex(A6x5))
 end
 
 @testset "5-arg syrk! & herk!" begin


### PR DESCRIPTION
This method can only be reached with complex eltypes, and after promotion of alpha and beta, they cannot be `Bool` anymore. Also, this adds 5-arg `mul!` of which I'm not sure we had some (even though coverage said it was covered, which is strange because it shouldn't due to the issue fixed in #1247).