### PR TITLE
use smaller matrix size in `peakflops` on 32-bit

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -726,6 +726,8 @@ end
 (\)(F::TransposeFactorization{T,<:LU}, B::VecOrMat{Complex{T}}) where {T<:BlasReal} =
     ldiv(F, B)
 
+const default_peakflops_size = Int === Int32 ? 2048 : 4096
+
 """
     LinearAlgebra.peakflops(n::Integer=4096; eltype::DataType=Float64, ntrials::Integer=3, parallel::Bool=false)
 
@@ -750,7 +752,7 @@ of the problem that is solved on each processor.
     This function requires at least Julia 1.1. In Julia 1.0 it is available from
     the standard library `InteractiveUtils`.
 """
-function peakflops(n::Integer=4096; eltype::DataType=Float64, ntrials::Integer=3, parallel::Bool=false)
+function peakflops(n::Integer=default_peakflops_size; eltype::DataType=Float64, ntrials::Integer=3, parallel::Bool=false)
     t = zeros(Float64, ntrials)
     for i=1:ntrials
         a = ones(eltype,n,n)


### PR DESCRIPTION
This might help prevent failures like https://buildkite.com/julialang/julia-master/builds/46307#0195de97-a496-4daa-b71e-3124e3592505. Allocating several 128MB arrays on 32-bit certainly sounds like asking for an OOM.