### PR TITLE
Branch on `Bool` `alpha` in diagonal matmul

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -438,10 +438,13 @@ function _lmul!(D::Diagonal, A::UpperOrLowerTriangular)
     return TriWrapper(P)
 end
 
+@inline _modify_nonzeroalpha!(x, out, ind, alpha, beta) = @stable_muladdmul _modify!(MulAddMul(alpha,beta), x, out, ind)
+@inline _modify_nonzeroalpha!(x, out, ind, ::Bool, beta) = @stable_muladdmul _modify!(MulAddMul(true,beta), x, out, ind)
+
 @inline function __muldiag_nonzeroalpha!(out, D::Diagonal, B, alpha::Number, beta::Number)
     @inbounds for j in axes(B, 2)
         @simd for i in axes(B, 1)
-            @stable_muladdmul _modify!(MulAddMul(alpha,beta), D.diag[i] * B[i,j], out, (i,j))
+            _modify_nonzeroalpha!(D.diag[i] * B[i,j], out, (i,j), alpha, beta)
         end
     end
     return out
@@ -484,9 +487,12 @@ function __muldiag_nonzeroalpha!(out, D::Diagonal, B::UpperOrLowerTriangular, al
     return out
 end
 
+@inline _djalpha_nonzero(dj, alpha) = @stable_muladdmul MulAddMul(alpha,false)(dj)
+@inline _djalpha_nonzero(dj, ::Bool) = dj
+
 @inline function __muldiag_nonzeroalpha_right!(out, A, D::Diagonal, alpha::Number, beta::Number)
     @inbounds for j in axes(A, 2)
-        dja = @stable_muladdmul MulAddMul(alpha,false)(D.diag[j])
+        dja = _djalpha_nonzero(D.diag[j], alpha)
         @simd for i in axes(A, 1)
             @stable_muladdmul _modify!(MulAddMul(true,beta), A[i,j] * dja, out, (i,j))
         end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -438,8 +438,8 @@ function _lmul!(D::Diagonal, A::UpperOrLowerTriangular)
     return TriWrapper(P)
 end
 
-@inline _modify_nonzeroalpha!(x, out, ind, alpha, beta) = @stable_muladdmul _modify!(MulAddMul(alpha,beta), x, out, ind)
-@inline _modify_nonzeroalpha!(x, out, ind, ::Bool, beta) = @stable_muladdmul _modify!(MulAddMul(true,beta), x, out, ind)
+@propagate_inbounds _modify_nonzeroalpha!(x, out, ind, alpha, beta) = @stable_muladdmul _modify!(MulAddMul(alpha,beta), x, out, ind)
+@propagate_inbounds _modify_nonzeroalpha!(x, out, ind, ::Bool, beta) = @stable_muladdmul _modify!(MulAddMul(true,beta), x, out, ind)
 
 @inline function __muldiag_nonzeroalpha!(out, D::Diagonal, B, alpha::Number, beta::Number)
     @inbounds for j in axes(B, 2)


### PR DESCRIPTION
The idea is that if `alpha` is known to be non-zero and a `Bool`, it must be `true`. We may therefore hardcode the value to reduce the branches in `@stable_muladdmul`.

TTFX:
```julia
julia> using LinearAlgebra

julia> D = Diagonal(1:4); A = zeros(4,4);

julia> @time A * D;
  0.079938 seconds (139.62 k allocations: 6.952 MiB, 99.92% compilation time) # master
  0.058087 seconds (126.77 k allocations: 6.290 MiB, 99.88% compilation time) # this PR
```
The TTFX in `D * A` does not change by much, but the allocations go down.
```julia
julia> @time D * A;
  0.062484 seconds (176.66 k allocations: 8.696 MiB, 99.91% compilation time) # master
  0.059009 seconds (133.34 k allocations: 6.572 MiB, 99.91% compilation time) # this PR
```
