### PR TITLE
Branch on Bool alpha in bidiag matmul

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -625,7 +625,7 @@ _mul!(C::AbstractMatrix, A::BiTriSym, B::TriSym, _add::MulAddMul) =
     _bibimul!(C, A, B, _add)
 _mul!(C::AbstractMatrix, A::BiTriSym, B::Bidiagonal, _add::MulAddMul) =
     _bibimul!(C, A, B, _add)
-function _bibimul!(C, A, B, _add::MulAddMul)
+function _bibimul!(C, A, B, _add)
     require_one_based_indexing(C)
     matmul_size_check(size(C), size(A), size(B))
     n = size(A,1)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -711,9 +711,9 @@ function __bibimul!(C, A, B::Bidiagonal, _add)
     Al = _diag(A, -1)
     Ad = _diag(A, 0)
     Au = _diag(A, 1)
-    Bd = _diag(B, 0)
+    Bd = B.dv
     if B.uplo == 'U'
-        Bu = _diag(B, 1)
+        Bu = B.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋2j₋1 = Au[j-2]
@@ -732,7 +732,7 @@ function __bibimul!(C, A, B::Bidiagonal, _add)
             end
         end
     else # B.uplo == 'L'
-        Bl = _diag(B, -1)
+        Bl = B.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋1j   = Au[j-1]
@@ -758,9 +758,9 @@ function __bibimul!(C, A::Bidiagonal, B, _add)
     Bl = _diag(B, -1)
     Bd = _diag(B, 0)
     Bu = _diag(B, 1)
-    Ad = _diag(A, 0)
+    Ad = A.dv
     if A.uplo == 'U'
-        Au = _diag(A, 1)
+        Au = A.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋2j₋1 = Au[j-2]
@@ -780,7 +780,7 @@ function __bibimul!(C, A::Bidiagonal, B, _add)
             end
         end
     else # A.uplo == 'L'
-        Al = _diag(A, -1)
+        Al = A.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋1j₋1 = Ad[j-1]
@@ -804,11 +804,11 @@ function __bibimul!(C, A::Bidiagonal, B, _add)
 end
 function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
     n = size(A,1)
-    Ad = _diag(A, 0)
-    Bd = _diag(B, 0)
+    Ad = A.dv
+    Bd = B.dv
     if A.uplo == 'U' && B.uplo == 'U'
-        Au = _diag(A, 1)
-        Bu = _diag(B, 1)
+        Au = A.ev
+        Bu = B.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋2j₋1 = Au[j-2]
@@ -824,8 +824,8 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
             end
         end
     elseif A.uplo == 'U' && B.uplo == 'L'
-        Au = _diag(A, 1)
-        Bl = _diag(B, -1)
+        Au = A.ev
+        Bl = B.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋1j   = Au[j-1]
@@ -841,8 +841,8 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
             end
         end
     elseif A.uplo == 'L' && B.uplo == 'U'
-        Al = _diag(A, -1)
-        Bu = _diag(B, 1)
+        Al = A.ev
+        Bu = B.ev
         @inbounds begin
             for j in 3:n-2
                 Aj₋1j₋1 = Ad[j-1]
@@ -858,8 +858,8 @@ function __bibimul!(C, A::Bidiagonal, B::Bidiagonal, _add)
             end
         end
     else # A.uplo == 'L' && B.uplo == 'L'
-        Al = _diag(A, -1)
-        Bl = _diag(B, -1)
+        Al = A.ev
+        Bl = B.ev
         @inbounds begin
             for j in 3:n-2
                 Ajj     = Ad[j]

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -892,17 +892,20 @@ function __bibimul_bulk!(C, A::Bidiagonal, B::Bidiagonal, _add)
     C
 end
 
-function _mul!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, _add::MulAddMul)
+function _mul!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, alpha::Number, beta::Number)
     require_one_based_indexing(C)
     matmul_size_check(size(C), size(A), size(B))
     n = size(A,1)
     iszero(n) && return C
-    _rmul_or_fill!(C, _add.beta)  # see the same use above
-    iszero(_add.alpha) && return C
+    _rmul_or_fill!(C, beta)  # see the same use above
+    iszero(alpha) && return C
     # beta is unused in the _bidimul! call, so we set it to false
-    _add_nonzeroalpha = _MulAddMul_nonzeroalpha(_add, Val(false))
-    _bidimul!(C, A, B, _add_nonzeroalpha)
+    @stable_muladdmul _mul_nonzeroalpha!(C, A, B, MulAddMul(alpha, false))
     C
+end
+function _mul_nonzeroalpha!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, _add::MulAddMul)
+    _add_nonzeroalpha = _MulAddMul_nonzeroalpha(_add)
+    _bidimul!(C, A, B, _add_nonzeroalpha)
 end
 function _bidimul!(C::AbstractMatrix, A::BiTriSym, B::Diagonal, _add::MulAddMul)
     n = size(A,1)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -600,6 +600,17 @@ function _diag(A::Bidiagonal, k)
     end
 end
 
+"""
+    _MulAddMul_nonzeroalpha(_add::MulAddMul[, ::Val{false}])
+
+Return a new `MulAddMul` with the value of `alpha` potentially set to a literal non-zero
+value if permitted by the type (e.g., for `_add.alpha isa Bool`, in which case the `alpha` is
+set to `true` in the returned instance).
+In other cases, the single-argument call is a no-op and returns `_add` without modifications.
+
+In addition, if `Val(false)` is provided as the second argument,
+`beta` is set to `false` in the returned `MulAddMul` instance.
+"""
 _MulAddMul_nonzeroalpha(_add::MulAddMul) = _add
 function _MulAddMul_nonzeroalpha(_add::MulAddMul{ais1,bis0,A}, ::Val{false}) where {ais1,bis0,A}
     MulAddMul{ais1,true,A,Bool}(_add.alpha, false)
@@ -1144,6 +1155,7 @@ function _dibimul!(C, A, B, _add)
     # ensure that we fill off-band elements in the destination
     _rmul_or_fill!(C, _add.beta)
     _iszero_alpha(_add) && return C
+    # beta is unused in the _dibimul_nonzeroalpha! call, so we set it to false
     _add_nonzeroalpha = _MulAddMul_nonzeroalpha(_add, Val(false))
     _dibimul_nonzeroalpha!(C, A, B, _add_nonzeroalpha)
     C


### PR DESCRIPTION
Similar to https://github.com/JuliaLang/LinearAlgebra.jl/pull/1256, we may reduce branches in `@stable_muladdmul` for a non-zero `Bool` alpha in `Bidiagonal` matmul. The idea is that if `alpha::Bool` is non-zero, it must be `true`. We may therefore hardcode this value and reduce branches in `@stable_muladdmul`. In addition, if `beta` is unused in a method, we may hardcode `beta = false` as well, which further helps with compilation.

```julia
julia> using LinearAlgebra

julia> B = Bidiagonal(1:4, 1:3, :U); D = Diagonal(1:4); v = (1:4);
```
With this,
```julia
julia> @time B * B;
  0.406036 seconds (2.34 M allocations: 105.696 MiB, 4.31% gc time, 99.99% compilation time) # nightly
  0.141480 seconds (588.18 k allocations: 26.049 MiB, 99.95% compilation time) # This PR
```
The rest are mainly reductions in allocation:
```julia
julia> @time B * D;
  0.141903 seconds (487.43 k allocations: 24.557 MiB, 99.96% compilation time) # nightly
  0.147749 seconds (382.60 k allocations: 19.385 MiB, 99.96% compilation time) # this PR
```
```julia
julia> @time D * B;
  0.136308 seconds (491.83 k allocations: 24.782 MiB, 99.95% compilation time) # nightly
  0.136909 seconds (386.35 k allocations: 19.591 MiB, 99.94% compilation time) # this PR
```
```julia
julia> @time B * v;
  0.087207 seconds (428.64 k allocations: 21.620 MiB, 99.93% compilation time) # master
  0.089002 seconds (342.46 k allocations: 17.306 MiB, 99.92% compilation time) # this PR
```

This also improves performance for small `Bidiagonal` multiplication, as there are fewer operations to carry out.
```julia
julia> n = 1; T = Bidiagonal(ones(n), ones(max(n-1,0)), :U); C = Matrix(T);

julia> @btime mul!($C, $T, $T);
  33.360 ns (0 allocations: 0 bytes) # nightly
  23.773 ns (0 allocations: 0 bytes) # this PR

julia> n = 2; T = Bidiagonal(ones(n), ones(max(n-1,0)), :U); C = Matrix(T));

julia> @btime mul!($C, $T, $T);
  78.685 ns (0 allocations: 0 bytes) # nightly
  31.388 ns (0 allocations: 0 bytes) # this PR

julia> n = 3; T = Bidiagonal(ones(n), ones(max(n-1,0)), :U); C = Matrix(T);

julia> @btime mul!($C, $T, $T);
  161.577 ns (0 allocations: 0 bytes) # nightly
  41.256 ns (0 allocations: 0 bytes) # this PR
```