### PR TITLE
Return view in `_diag` for `Bidiagonal`

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -583,7 +583,7 @@ function _diag(A::Bidiagonal, k)
     elseif k == _offdiagind(A.uplo)
         return A.ev
     else
-        return diag(A, k)
+        return diagview(A, k)
     end
 end
 


### PR DESCRIPTION
Since the idea of the function is to avoid allocations, we should be returning a view here.