### PR TITLE
Inline `generic_matmatmul!` branch in strided triangular matmul

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -144,6 +144,8 @@ const LowerOrUnitLowerTriangular{T,S<:AbstractMatrix{T}} = Union{LowerTriangular
 const UpperOrLowerTriangular{T,S<:AbstractMatrix{T}} = Union{UpperOrUnitUpperTriangular{T,S}, LowerOrUnitLowerTriangular{T,S}}
 const UnitUpperOrUnitLowerTriangular{T,S<:AbstractMatrix{T}} = Union{UnitUpperTriangular{T,S}, UnitLowerTriangular{T,S}}
 
+const UpperOrLowerTriangularStrided{T,S<:StridedMatrix{T}} = UpperOrLowerTriangular{T,S}
+
 uppertriangular(M) = UpperTriangular(M)
 lowertriangular(M) = LowerTriangular(M)
 
@@ -1116,9 +1118,18 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
-            return generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
+            return generic_matmatmulNN!(C, A, B, alpha, beta)
         end
     end
+end
+
+generic_matmatmulNN!(C, A, B, alpha, beta) = generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
+# Optimization for strided matrices, where we know that _generic_matmatmul! will be taken 
+for (TA, TB) in ((:UpperOrLowerTriangularStrided, :StridedMatrix),
+                    (:StridedMatrix, :UpperOrLowerTriangularStrided),
+                    (:UpperOrLowerTriangularStrided, :UpperOrLowerTriangularStrided)
+                )
+    @eval generic_matmatmulNN!(C, A::$TA, B::$TB, alpha, beta) = _generic_matmatmul!(C, A, B, alpha, beta)
 end
 
 ldiv!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = _ldiv!(C, A, B)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1118,18 +1118,18 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
         if isone(alpha) && iszero(beta)
             return _trimul!(C, A, B)
         else
-            return generic_matmatmulNN!(C, A, B, alpha, beta)
+            return generic_matmatmul_NN!(C, A, B, alpha, beta)
         end
     end
 end
 
-generic_matmatmulNN!(C, A, B, alpha, beta) = generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
+generic_matmatmul_NN!(C, A, B, alpha, beta) = generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
 # Optimization for strided matrices, where we know that _generic_matmatmul! will be taken 
 for (TA, TB) in ((:UpperOrLowerTriangularStrided, :StridedMatrix),
                     (:StridedMatrix, :UpperOrLowerTriangularStrided),
                     (:UpperOrLowerTriangularStrided, :UpperOrLowerTriangularStrided)
                 )
-    @eval generic_matmatmulNN!(C, A::$TA, B::$TB, alpha, beta) = _generic_matmatmul!(C, A, B, alpha, beta)
+    @eval generic_matmatmul_NN!(C, A::$TA, B::$TB, alpha, beta) = _generic_matmatmul!(C, A, B, alpha, beta)
 end
 
 ldiv!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = _ldiv!(C, A, B)


### PR DESCRIPTION
For combinations of strided matrices and strided triangular matrices, we would end up taking the methods defined in `LinearAlgebra`, so we may avoid the constant-propagation and hardcode the `_generic_matmatmul!` call. This improves TTFX, as the no-op but expensive-to-compile `wrap` call is elided.

```julia
julia> using LinearAlgebra

julia> A = zeros(4,4);

julia> @time A * UpperTriangular(A);
  0.458913 seconds (1.22 M allocations: 59.769 MiB, 51.63% gc time, 97.84% compilation time: 4% of which was recompilation) # master
  0.077198 seconds (174.52 k allocations: 8.683 MiB, 92.75% compilation time) # this PR
```