### PR TITLE
Speicalize `copy!` for triangular, and use `copy!` in `ldiv`

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -10,7 +10,7 @@ module LinearAlgebra
 import Base: \, /, //, *, ^, +, -, ==
 import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, asec, asech,
     asin, asinh, atan, atanh, axes, big, broadcast, cbrt, ceil, cis, collect, conj, convert,
-    copy, copyto!, copymutable, cos, cosh, cot, coth, csc, csch, eltype, exp, fill!, floor,
+    copy, copy!, copyto!, copymutable, cos, cosh, cot, coth, csc, csch, eltype, exp, fill!, floor,
     getindex, hcat, getproperty, imag, inv, invpermuterows!, isapprox, isequal, isone, iszero,
     IndexStyle, kron, kron!, length, log, map, ndims, one, oneunit, parent, permutecols!,
     permutedims, permuterows!, power_by_squaring, promote_rule, real, sec, sech, setindex!,
@@ -706,9 +706,9 @@ function ldiv(F::Factorization, B::AbstractVecOrMat)
 
     if n > size(B, 1)
         # Underdetermined
-        copyto!(view(BB, 1:m, :), B)
+        copy!(view(BB, axes(B,1), ntuple(_->:, ndims(B)-1)...), B)
     else
-        copyto!(BB, B)
+        copy!(BB, B)
     end
 
     ldiv!(FF, BB)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1260,7 +1260,7 @@ function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
     end
 
     if N == 0
-        return _copy_or_copyto!(c, b)
+        return copyto!(c, b)
     end
 
     zi = findfirst(iszero, A.dv)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1260,7 +1260,7 @@ function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
     end
 
     if N == 0
-        return copyto!(c, b)
+        return _copy_or_copyto!(c, b)
     end
 
     zi = findfirst(iszero, A.dv)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -178,7 +178,7 @@ end
 parent(A::UpperOrLowerTriangular) = A.data
 
 # For strided matrices, we may only loop over the filled triangle
-copy(A::UpperOrLowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = copyto!(similar(A), A)
+copy(A::UpperOrLowerTriangular{<:Any, <:StridedMaybeAdjOrTransMat}) = copy!(similar(A), A)
 
 # then handle all methods that requires specific handling of upper/lower and unit diagonal
 
@@ -651,7 +651,7 @@ Base.@constprop :aggressive function copytrito_triangular!(Bdata, Adata, uplo, u
         BLAS.chkuplo(uplo)
         LAPACK.lacpy_size_check(size(Bdata), sz)
         # only the diagonal is copied in this case
-        copyto!(diagview(Bdata), diagview(Adata))
+        copy!(diagview(Bdata), diagview(Adata))
     end
     return Bdata
 end
@@ -1061,15 +1061,17 @@ isunit_char(::UnitUpperTriangular) = 'U'
 isunit_char(::LowerTriangular) = 'N'
 isunit_char(::UnitLowerTriangular) = 'U'
 
+_copy_or_copyto!(dest, src) = ndims(dest) == ndims(src) ? copy!(dest, src) : copyto!(dest, src)
+
 # generic fallback for AbstractTriangular matrices outside of the four subtypes provided here
 _trimul!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVector) =
-    lmul!(A, copyto!(C, B))
+    lmul!(A, _copy_or_copyto!(C, B))
 _trimul!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractMatrix) =
-    lmul!(A, copyto!(C, B))
+    lmul!(A, copy!(C, B))
 _trimul!(C::AbstractMatrix, A::AbstractMatrix, B::AbstractTriangular) =
-    rmul!(copyto!(C, A), B)
+    rmul!(copy!(C, A), B)
 _trimul!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractTriangular) =
-    lmul!(A, copyto!(C, B))
+    lmul!(A, copy!(C, B))
 # redirect for UpperOrLowerTriangular
 _trimul!(C::AbstractVecOrMat, A::UpperOrLowerTriangular, B::AbstractVector) =
     generic_trimatmul!(C, uplo_char(A), isunit_char(A), wrapperop(parent(A)), _unwrap_at(parent(A)), B)
@@ -1130,9 +1132,9 @@ end
 ldiv!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = _ldiv!(C, A, B)
 # generic fallback for AbstractTriangular, directs to 2-arg [l/r]div!
 _ldiv!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) =
-    ldiv!(A, copyto!(C, B))
+    ldiv!(A, _copy_or_copyto!(C, B))
 _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::AbstractTriangular) =
-    rdiv!(copyto!(C, A), B)
+    rdiv!(copy!(C, A), B)
 # redirect for UpperOrLowerTriangular to generic_*div!
 _ldiv!(C::AbstractVecOrMat, A::UpperOrLowerTriangular, B::AbstractVecOrMat) =
     generic_trimatdiv!(C, uplo_char(A), isunit_char(A), wrapperop(parent(A)), _unwrap_at(parent(A)), B)
@@ -1210,7 +1212,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
             elseif p == Inf
                 return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
             else # use fallback
-                return cond(copyto!(similar(parent(A)), A), p)
+                return cond(copy!(similar(parent(A)), A), p)
             end
         end
     end
@@ -1236,7 +1238,7 @@ end
 # division
 function generic_trimatdiv!(C::StridedVecOrMat{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractVecOrMat{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
-        LAPACK.trtrs!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : copy!(C, B))
+        LAPACK.trtrs!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : _copy_or_copyto!(C, B))
     else # incompatible with LAPACK
         @invoke generic_trimatdiv!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractVecOrMat)
     end
@@ -1968,7 +1970,7 @@ function powm!(A0::UpperTriangular, p::Real)
         for i in axes(S,1)
             @inbounds S[i, i] = S[i, i] + 1
         end
-        copyto!(Stmp, S)
+        copy!(Stmp, S)
         mul!(S, A, c)
         ldiv!(Stmp, S)
 
@@ -1976,14 +1978,14 @@ function powm!(A0::UpperTriangular, p::Real)
         for i in axes(S,1)
             @inbounds S[i, i] = S[i, i] + 1
         end
-        copyto!(Stmp, S)
+        copy!(Stmp, S)
         mul!(S, A, c)
         ldiv!(Stmp, S)
     end
     for i in axes(S,1)
         S[i, i] = S[i, i] + 1
     end
-    copyto!(Stmp, S)
+    copy!(Stmp, S)
     mul!(S, A, -p)
     ldiv!(Stmp, S)
     for i in axes(S,1)
@@ -1993,7 +1995,7 @@ function powm!(A0::UpperTriangular, p::Real)
     blockpower!(A0, S, p/(2^s))
     for m = 1:s
         mul!(Stmp.data, S, S)
-        copyto!(S, Stmp)
+        copy!(S, Stmp)
         blockpower!(A0, S, p/(2^(s-m)))
     end
     rmul!(S, normA0^p)
@@ -2180,7 +2182,7 @@ function _find_params_log_quasitriu!(A)
             break
         end
         _sqrt_quasitriu!(A isa UpperTriangular ? parent(A) : A, A)
-        copyto!(AmI, A)
+        copy!(AmI, A)
         for i in axes(AmI,1)
             @inbounds AmI[i,i] -= 1
         end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1218,17 +1218,17 @@ end
 
 # multiplication
 generic_trimatmul!(c::StridedVector{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, b::AbstractVector{T}) where {T<:BlasFloat} =
-    BLAS.trmv!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, c === b ? c : copyto!(c, b))
+    BLAS.trmv!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, c === b ? c : copy!(c, b))
 function generic_trimatmul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
-        BLAS.trmm!('L', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), A, C === B ? C : copyto!(C, B))
+        BLAS.trmm!('L', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), A, C === B ? C : copy!(C, B))
     else # incompatible with BLAS
         @invoke generic_trimatmul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
 end
 function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
-        BLAS.trmm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
+        BLAS.trmm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copy!(C, A))
     else # incompatible with BLAS
         @invoke generic_mattrimul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
@@ -1236,14 +1236,14 @@ end
 # division
 function generic_trimatdiv!(C::StridedVecOrMat{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractVecOrMat{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
-        LAPACK.trtrs!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : copyto!(C, B))
+        LAPACK.trtrs!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : copy!(C, B))
     else # incompatible with LAPACK
         @invoke generic_trimatdiv!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractVecOrMat)
     end
 end
 function generic_mattridiv!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
-        BLAS.trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copyto!(C, A))
+        BLAS.trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copy!(C, A))
     else # incompatible with BLAS
         @invoke generic_mattridiv!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end


### PR DESCRIPTION
Currently, we specialize `copyto!` for a triangular source. However, this has two branches, depending on whether the axes match. In the branch where the axes do match, we may use `copy!` instead, and specialize this in terms of the internal `_copyto!` which is identical in implementation.

We also use `copy!` in `ldiv` instead of `copyto!`. These should be equivalent in most cases, barring one extra axes check in `copy!`, as the fallback method for `copy!` calls `copyto!` internally. However, the advantage comes for triangular matrices, where `copy!` doesn't have branches, as the axes necessarily match.

As a consequence, this reduces the TTFX in operations like
```julia
julia> using Random, LinearAlgebra

julia> A = rand(4,4);

julia> @time A \ UpperTriangular(A);
  0.598575 seconds (1.28 M allocations: 61.788 MiB, 98.57% compilation time: 3% of which was recompilation) # master
  0.487267 seconds (1.01 M allocations: 49.726 MiB, 3.54% gc time, 98.95% compilation time) # this PR
```
```julia
julia> @time UpperTriangular(A) / A;
  0.826212 seconds (1.45 M allocations: 71.427 MiB, 16.96% gc time, 84.47% compilation time) # master
  0.616258 seconds (1.28 M allocations: 63.135 MiB, 2.65% gc time, 99.19% compilation time) # this PR
```

I've renamed the internal functions as `_copyto!` -> `_copy!` and `copyto_unaliased!` -> `copy_unaliased!`, as these are closer to the meaning of `copy!` than to `copyto!`.