### PR TITLE
Explicit loop in `_iszero` for strided views

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1358,7 +1358,7 @@ ishermitian(x::Number) = (x == conj(x))
 _iszero(V) = iszero(V)
 # A Base.FastContiguousSubArray view of a StridedArray
 FastContiguousSubArrayStrided{T,N,P<:StridedArray,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
-# Reducing over the entire array instead of all permits vectorization
+# Reducing over the entire array instead of calling `all` within `iszero` permits vectorization
 # The loop is equivalent to a mapreduce, but is faster to compile
 function _iszero(V::FastContiguousSubArrayStrided)
     ret = true

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1358,7 +1358,8 @@ ishermitian(x::Number) = (x == conj(x))
 _iszero(V) = iszero(V)
 # A Base.FastContiguousSubArray view of a StridedArray
 FastContiguousSubArrayStrided{T,N,P<:StridedArray,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
-# using mapreduce instead of all permits vectorization
+# Reducing over the entire array instead of all permits vectorization
+# The loop is equivalent to a mapreduce, but is faster to compile
 function _iszero(V::FastContiguousSubArrayStrided)
     ret = true
     for i in eachindex(V)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1359,7 +1359,13 @@ _iszero(V) = iszero(V)
 # A Base.FastContiguousSubArray view of a StridedArray
 FastContiguousSubArrayStrided{T,N,P<:StridedArray,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
 # using mapreduce instead of all permits vectorization
-_iszero(V::FastContiguousSubArrayStrided) = mapreduce(iszero, &, V, init=true)
+function _iszero(V::FastContiguousSubArrayStrided)
+    ret = true
+    for i in eachindex(V)
+        ret &= iszero(@inbounds V[i])
+    end
+    ret
+end
 
 """
     istriu(A::AbstractMatrix, k::Integer = 0) -> Bool


### PR DESCRIPTION
This reduces TTFX
```julia
julia> using LinearAlgebra

julia> Z = zeros(4,4);

julia> @time istril(Z);
  0.152632 seconds (572.99 k allocations: 27.476 MiB, 99.98% compilation time) # master
  0.091427 seconds (177.39 k allocations: 8.688 MiB, 99.97% compilation time) # this PR
```