### PR TITLE
`istril`/`istriu` for opposite triangularity

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -376,9 +376,9 @@ istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)
 istriu(A::Adjoint, k::Integer=0) = istril(A.parent, -k)
 istriu(A::Transpose, k::Integer=0) = istril(A.parent, -k)
 
-istril(U::UpperTriangular, k::Integer=0) = istril(parent(U), max(0, k))
+istril(U::UpperTriangular, k::Integer=0) = istril(parent(U), max(-1, k))
 istril(U::UnitUpperTriangular, k::Integer=0) = k < 0 ? false : istril(parent(U), k)
-istriu(U::LowerTriangular, k::Integer=0) = istriu(parent(U), min(0, k))
+istriu(U::LowerTriangular, k::Integer=0) = istriu(parent(U), min(1, k))
 istriu(U::UnitLowerTriangular, k::Integer=0) = k > 0 ? false : istriu(parent(U), k)
 
 function tril!(A::UpperTriangular{T}, k::Integer=0) where {T}

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -376,6 +376,11 @@ istril(A::Transpose, k::Integer=0) = istriu(A.parent, -k)
 istriu(A::Adjoint, k::Integer=0) = istril(A.parent, -k)
 istriu(A::Transpose, k::Integer=0) = istril(A.parent, -k)
 
+istril(U::UpperTriangular, k::Integer=0) = istril(parent(U), max(0, k))
+istril(U::UnitUpperTriangular, k::Integer=0) = k < 0 ? false : istril(parent(U), k)
+istriu(U::LowerTriangular, k::Integer=0) = istriu(parent(U), min(0, k))
+istriu(U::UnitLowerTriangular, k::Integer=0) = k > 0 ? false : istriu(parent(U), k)
+
 function tril!(A::UpperTriangular{T}, k::Integer=0) where {T}
     if k < 0
         fill!(A.data, zero(T))

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -202,9 +202,25 @@ end
         UA = Array(U)
         L = LowerTriangular(A)
         LA = Array(L)
+        UU = UnitUpperTriangular(A)
+        UUA = Array(UU)
+        UL = UnitLowerTriangular(A)
+        ULA = Array(UL)
         for k in -size(A,1):size(A,2)
             @test istril(U, k) == istril(UA, k)
             @test istriu(L, k) == istriu(LA, k)
+            @test istril(UU, k) == istril(UUA, k)
+            @test istriu(UL, k) == istriu(ULA, k)
+        end
+    end
+    for (T, f) in ((UnitUpperTriangular, istril), (UnitLowerTriangular, istriu))
+        A = Matrix{BigFloat}(undef, 2, 2)
+        isupper = T === UnitUpperTriangular
+        A[1+!isupper, 1+isupper] = 3
+        UU = T(A)
+        UUA = Array(UU)
+        for k in -size(A,1):size(A,2)
+            @test f(UU, k) == f(UUA, k)
         end
     end
 end

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -197,7 +197,7 @@ end
     @test !isdiag(UpperTriangular(rand(4, 4)))
     @test !isdiag(LowerTriangular(rand(4, 4)))
 
-    for A in [rand(4,4), zeros(4,4)]
+    for A in [rand(4,4), zeros(4,4), diagm(1=>1:3), diagm(-2=>2:3)]
         U = UpperTriangular(A)
         UA = Array(U)
         L = LowerTriangular(A)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -196,6 +196,17 @@ end
     @test isdiag(LowerTriangular(diagm(0 => [1,2,3,4])))
     @test !isdiag(UpperTriangular(rand(4, 4)))
     @test !isdiag(LowerTriangular(rand(4, 4)))
+
+    for A in [rand(4,4), zeros(4,4)]
+        U = UpperTriangular(A)
+        UA = Array(U)
+        L = LowerTriangular(A)
+        LA = Array(L)
+        for k in -size(A,1):size(A,2)
+            @test istril(U, k) == istril(UA, k)
+            @test istriu(L, k) == istriu(LA, k)
+        end
+    end
 end
 
 # Test throwing in fallbacks for non BlasFloat/BlasComplex in A_rdiv_Bx!


### PR DESCRIPTION
This adds specializations for `istril(::UpperTriangular)` and `istriu(::LowerTriangular)`, and similarly for the unit triangular matrices. By forwarding the operations to the parent, we may improve performance:
```julia
julia> Z = zeros(400,400);

julia> @btime istril(UpperTriangular($Z));
  115.105 μs (0 allocations: 0 bytes) # master
  20.188 μs (0 allocations: 0 bytes) # this PR
```