### PR TITLE
Skip symmetry check in converting Symmetric to SymTridiagonal

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -442,7 +442,7 @@ issymmetric(A::Hermitian{<:Complex}) = isreal(A)
 issymmetric(A::Symmetric) = true
 
 # check if the symmetry is known from the type
-_issymmetric(::Union{Symmetric, Hermitian{<:Real}}) = true
+_issymmetric(::Union{SymSymTri, Hermitian{<:Real}}) = true
 _issymmetric(::Any) = false
 
 adjoint(A::Hermitian) = A

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -441,6 +441,10 @@ issymmetric(A::Hermitian{<:Real}) = true
 issymmetric(A::Hermitian{<:Complex}) = isreal(A)
 issymmetric(A::Symmetric) = true
 
+# check if the symmetry is known from the type
+_issymmetric(::Union{Symmetric, Hermitian{<:Real}}) = true
+_issymmetric(::Any) = false
+
 adjoint(A::Hermitian) = A
 transpose(A::Symmetric) = A
 adjoint(A::Symmetric{<:Real}) = A

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -111,7 +111,7 @@ function (::Type{SymTri})(A::AbstractMatrix) where {SymTri <: SymTridiagonal}
     checksquare(A)
     du = diag(A, 1)
     d  = diag(A)
-    if !(A isa Symmetric || _checksymmetric(d, du, diag(A, -1)))
+    if !(_issymmetric(A) || _checksymmetric(d, du, diag(A, -1)))
         throw(ArgumentError("matrix is not symmetric; cannot convert to SymTridiagonal"))
     end
     return SymTri(d, du)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -111,12 +111,10 @@ function (::Type{SymTri})(A::AbstractMatrix) where {SymTri <: SymTridiagonal}
     checksquare(A)
     du = diag(A, 1)
     d  = diag(A)
-    dl = diag(A, -1)
-    if _checksymmetric(d, du, dl)
-        SymTri(d, du)
-    else
+    if !(A isa Symmetric || _checksymmetric(d, du, diag(A, -1)))
         throw(ArgumentError("matrix is not symmetric; cannot convert to SymTridiagonal"))
     end
+    return SymTri(d, du)
 end
 
 _checksymmetric(d, du, dl) = all(((x, y),) -> x == transpose(y), zip(du, dl)) && all(issymmetric, d)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -118,7 +118,7 @@ function (::Type{SymTri})(A::AbstractMatrix) where {SymTri <: SymTridiagonal}
 end
 
 _checksymmetric(d, du, dl) = all(((x, y),) -> x == transpose(y), zip(du, dl)) && all(issymmetric, d)
-_checksymmetric(A::AbstractMatrix) = _checksymmetric(diagview(A), diagview(A, 1), diagview(A, -1))
+_checksymmetric(A::AbstractMatrix) = _issymmetric(A) || _checksymmetric(diagview(A), diagview(A, 1), diagview(A, -1))
 
 SymTridiagonal{T,V}(S::SymTridiagonal{T,V}) where {T,V<:AbstractVector{T}} = S
 SymTridiagonal{T,V}(S::SymTridiagonal) where {T,V<:AbstractVector{T}} =

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1180,6 +1180,7 @@ end
     end
     ST = SymTridiagonal(S)
     @test ST == SymTridiagonal(diag(S), diag(S,1))
+    @test convert(SymTridiagonal, S) == ST
 end
 
 end # module TestTridiagonal

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1174,6 +1174,10 @@ end
 
 @testset "SymTridiagonal from Symmetric" begin
     S = Symmetric(reshape(1:9, 3, 3))
+    @testset "helper functions" begin
+        @test LinearAlgebra._issymmetric(S)
+        @test !LinearAlgebra._issymmetric(Array(S))
+    end
     ST = SymTridiagonal(S)
     @test ST == SymTridiagonal(diag(S), diag(S,1))
 end

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1180,7 +1180,8 @@ end
     end
     ST = SymTridiagonal(S)
     @test ST == SymTridiagonal(diag(S), diag(S,1))
-    @test convert(SymTridiagonal, S) == ST
+    S = Symmetric(Tridiagonal(1:3, 1:4, 1:3))
+    @test convert(SymTridiagonal, S) == S
 end
 
 end # module TestTridiagonal

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1172,4 +1172,10 @@ end
     end
 end
 
+@testset "SymTridiagonal from Symmetric" begin
+    S = Symmetric(reshape(1:9, 3, 3))
+    ST = SymTridiagonal(S)
+    @test ST == SymTridiagonal(diag(S), diag(S,1))
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
Since the symmetry check in the `SymTridiagonal` constructor is unnecessary if the argument is known to be symmetric from its type, we may skip it (as well as the extra allocation of the lower diagonal that is necessary for the check).