### PR TITLE
Specialize `isreal` for banded matrices

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -13,7 +13,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     copy, copyto!, copymutable, cos, cosh, cot, coth, csc, csch, eltype, exp, fill!, floor,
     getindex, hcat, getproperty, imag, inv, invpermuterows!, isapprox, isequal, isone, iszero,
     IndexStyle, kron, kron!, length, log, map, ndims, one, oneunit, parent, permutecols!,
-    permutedims, permuterows!, power_by_squaring, promote_rule, real, sec, sech, setindex!,
+    permutedims, permuterows!, power_by_squaring, promote_rule, real, isreal, sec, sech, setindex!,
     show, similar, sin, sincos, sinh, size, sqrt, strides, stride, tan, tanh, transpose, trunc,
     typed_hcat, vec, view, zero
 import Base: AbstractArray, AbstractMatrix, Array, Matrix

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -286,7 +286,7 @@ axes(M::Bidiagonal) = (ax = axes(M.dv, 1); (ax, ax))
 for func in (:conj, :copy, :real, :imag)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.uplo)
 end
-isreal(M::Bidiagonal) = isreal(B.dv) && isreal(B.ev)
+isreal(M::Bidiagonal) = isreal(M.dv) && isreal(M.ev)
 
 adjoint(B::Bidiagonal{<:Number}) = Bidiagonal(vec(adjoint(B.dv)), vec(adjoint(B.ev)), B.uplo == 'U' ? :L : :U)
 adjoint(B::Bidiagonal{<:Number, <:Base.ReshapedArray{<:Number,1,<:Adjoint}}) =

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -286,6 +286,7 @@ axes(M::Bidiagonal) = (ax = axes(M.dv, 1); (ax, ax))
 for func in (:conj, :copy, :real, :imag)
     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.uplo)
 end
+isreal(M::Bidiagonal) = isreal(B.dv) && isreal(B.ev)
 
 adjoint(B::Bidiagonal{<:Number}) = Bidiagonal(vec(adjoint(B.dv)), vec(adjoint(B.ev)), B.uplo == 'U' ? :L : :U)
 adjoint(B::Bidiagonal{<:Number, <:Base.ReshapedArray{<:Number,1,<:Adjoint}}) =

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -256,6 +256,8 @@ factorize(D::Diagonal) = D
 real(D::Diagonal) = Diagonal(real(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 
+isreal(D::Diagonal) = isreal(D.diag)
+
 iszero(D::Diagonal) = all(iszero, D.diag)
 isone(D::Diagonal) = all(isone, D.diag)
 isdiag(D::Diagonal) = all(isdiag, D.diag)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -173,6 +173,7 @@ _copyto_banded!(dest::SymTridiagonal, src::SymTridiagonal) =
 for func in (:conj, :copy, :real, :imag)
     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
 end
+isreal(S::SymTridiagonal) = isreal(S.dv) && isreal(S.ev)
 
 transpose(S::SymTridiagonal) = S
 adjoint(S::SymTridiagonal{<:Number}) = SymTridiagonal(vec(adjoint(S.dv)), vec(adjoint(S.ev)))
@@ -667,6 +668,7 @@ for func in (:conj, :copy, :real, :imag)
         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du))
     end
 end
+isreal(T::Tridiagonal) = isreal(T.dl) && isreal(T.d) && isreal(T.du)
 
 adjoint(S::Tridiagonal{<:Number}) = Tridiagonal(vec(adjoint(S.du)), vec(adjoint(S.d)), vec(adjoint(S.dl)))
 adjoint(S::Tridiagonal{<:Number, <:Base.ReshapedArray{<:Number,1,<:Adjoint}}) =

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1172,4 +1172,12 @@ end
     @test_throws InexactError convert(Bidiagonal, M)
 end
 
+@testset "isreal" begin
+    M = Bidiagonal(ones(2), ones(1), :U)
+    @test @inferred((M -> Val(isreal(M)))(M)) == Val(true)
+    M = complex.(M)
+    @test isreal(M)
+    @test !isreal(im*M)
+end
+
 end # module TestBidiagonal

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1481,4 +1481,12 @@ end
     @test ishermitian(D) == ishermitian(A)
 end
 
+@testset "isreal" begin
+    D = Diagonal(ones(2))
+    @test @inferred((D -> Val(isreal(D)))(D)) == Val(true)
+    D = complex.(D)
+    @test isreal(D)
+    @test !isreal(im*D)
+end
+
 end # module TestDiagonal

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1162,4 +1162,14 @@ end
     end
 end
 
+@testset "isreal" begin
+    for M in (SymTridiagonal(ones(2), ones(1)),
+            Tridiagonal(ones(2), ones(3), ones(2)))
+        @test @inferred((M -> Val(isreal(M)))(M)) == Val(true)
+        M = complex.(M)
+        @test isreal(M)
+        @test !isreal(im*M)
+    end
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
This makes the check O(n) from O(n^2). It should still be evaluated at compile-time for matrices with `Real` `eltype`s.