### PR TITLE
Avoid copy in empty bidiag `ldiv!`

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1253,7 +1253,9 @@ function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
     N = size(A, 1)
     mb, nb = size(b, 1), size(b, 2)
     if N != mb
-        throw(DimensionMismatch(lazy"first dimension of A, $N, does not match first dimension of b, $mb"))
+        dimstr = b isa AbstractVector ? "length" : "first dimension"
+        throw(DimensionMismatch(LazyString(lazy"the first dimension of the Bidiagonal matrix, $N, ",
+            lazy"does not match the $dimstr of the right-hand-side, $mb")))
     end
     mc, nc = size(c, 1), size(c, 2)
     if mc != mb || nc != nb

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1250,19 +1250,17 @@ end
 ldiv!(A::Bidiagonal, b::AbstractVecOrMat) = @inline ldiv!(b, A, b)
 function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
     require_one_based_indexing(c, A, b)
-    N = size(A, 2)
+    N = size(A, 1)
     mb, nb = size(b, 1), size(b, 2)
     if N != mb
-        throw(DimensionMismatch(lazy"second dimension of A, $N, does not match first dimension of b, $mb"))
+        throw(DimensionMismatch(lazy"first dimension of A, $N, does not match first dimension of b, $mb"))
     end
     mc, nc = size(c, 1), size(c, 2)
     if mc != mb || nc != nb
-        throw(DimensionMismatch(lazy"size of result, ($mc, $nc), does not match the size of b, ($mb, $nb)"))
+        throw(DimensionMismatch(lazy"size of result, $(size(c)), does not match the size of b, $(size(b))"))
     end
 
-    if N == 0
-        return copyto!(c, b)
-    end
+    N == 0 && return c # in this case c and b are also empty
 
     zi = findfirst(iszero, A.dv)
     isnothing(zi) || throw(SingularException(zi))

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1180,4 +1180,15 @@ end
     @test !isreal(im*M)
 end
 
+@testset "ldiv! error message" begin
+    C = zeros(2)
+    B = Bidiagonal(1:0, 1:0, :U)
+    msg = "size of result, (2,), does not match the size of b, (0, 1)"
+    @test_throws msg ldiv!(C, B, zeros(0,1))
+    msg = "the first dimension of the Bidiagonal matrix, 0, does not match the length of the right-hand-side, 2"
+    @test_throws msg ldiv!(C, B, zeros(2))
+    msg = "the first dimension of the Bidiagonal matrix, 0, does not match the first dimension of the right-hand-side, 2"
+    @test_throws msg ldiv!(C, B, zeros(2,1))
+end
+
 end # module TestBidiagonal


### PR DESCRIPTION
If `N == 0`, the arrays are all empty, so there's nothing to copy. We may return the output array directly.