### PR TITLE
Test for `versioninfo` with `ENV` variable

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,4 +23,10 @@ end
                 r"OPENBLAS_NUM_THREADS = [0-9]+",
                 r"GOTO_NUM_THREADS = [0-9]+",
                 r"OMP_NUM_THREADS = [0-9]+", r"\[none\]"])
+
+    withenv("MKL_NUM_THREADS" => 1) do
+        vinfo = sprint(LinearAlgebra.versioninfo)
+        vars = strip(split(vinfo, "Relevant environment variables:")[end])
+        @test occursin("MKL_NUM_THREADS = 1", vars)
+    end
 end


### PR DESCRIPTION
Explicitly check that setting an environment variable updates the `versioninfo`.

One concern here is that `withenv` isn't thread-safe, but we're probably not running these tests multi threaded? In any case, it's unlikely that setting the number of MKL threads will impact anything.