### PR TITLE
Matrix constructor for triangular

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2079,20 +2079,28 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     A = Base.unalias(B, A)
     if uplo == 'U'
         LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
-        # extract the parents for UpperTriangular matrices
-        Bv, Av = uppertridata(B), uppertridata(A)
-        for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
-            @inbounds Bv[i,j] = Av[i,j]
-        end
+        copytrito_upper!(B, A)
     else # uplo == 'L'
         LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
-        # extract the parents for LowerTriangular matrices
-        Bv, Av = lowertridata(B), lowertridata(A)
-        for j in axes(A,2), i in axes(A,1)[j:end]
-            @inbounds Bv[i,j] = Av[i,j]
-        end
+        copytrito_lower!(B, A)
     end
     return B
+end
+@inline function copytrito_upper!(B, A)
+    # extract the parents for UpperTriangular matrices
+    Bv, Av = uppertridata(B), uppertridata(A)
+    for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
+        @inbounds Bv[i,j] = Av[i,j]
+    end
+    B
+end
+@inline function copytrito_lower!(B, A)
+    # extract the parents for LowerTriangular matrices
+    Bv, Av = lowertridata(B), lowertridata(A)
+    for j in axes(A,2), i in axes(A,1)[j:end]
+        @inbounds Bv[i,j] = Av[i,j]
+    end
+    B
 end
 # Forward LAPACK-compatible strided matrices to lacpy
 function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2079,20 +2079,28 @@ function copytrito!(B::AbstractMatrix, A::AbstractMatrix, uplo::AbstractChar)
     A = Base.unalias(B, A)
     if uplo == 'U'
         LAPACK.lacpy_size_check(size(B), (n < m ? n : m, n))
-        for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
-            # extract the parents for UpperTriangular matrices
-            Bv, Av = uppertridata(B), uppertridata(A)
-            @inbounds Bv[i,j] = Av[i,j]
-        end
+        copytrito_upper!(B, A)
     else # uplo == 'L'
         LAPACK.lacpy_size_check(size(B), (m, m < n ? m : n))
-        for j in axes(A,2), i in axes(A,1)[j:end]
-            # extract the parents for LowerTriangular matrices
-            Bv, Av = lowertridata(B), lowertridata(A)
-            @inbounds Bv[i,j] = Av[i,j]
-        end
+        copytrito_lower!(B, A)
     end
     return B
+end
+@inline function copytrito_upper!(B, A)
+    # extract the parents for UpperTriangular matrices
+    Bv, Av = uppertridata(B), uppertridata(A)
+    for j in axes(A,2), i in axes(A,1)[begin : min(j,end)]
+        @inbounds Bv[i,j] = Av[i,j]
+    end
+    B
+end
+@inline function copytrito_lower!(B, A)
+    # extract the parents for LowerTriangular matrices
+    Bv, Av = lowertridata(B), lowertridata(A)
+    for j in axes(A,2), i in axes(A,1)[j:end]
+        @inbounds Bv[i,j] = Av[i,j]
+    end
+    B
 end
 # Forward LAPACK-compatible strided matrices to lacpy
 function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -641,14 +641,14 @@ end
     dest[col, col] = U[BandIndex(0,col)]
     dest
 end
-@propagate_inbounds function copy_unaliased_stored!(dest, U::LowerTriangular, col)
+@propagate_inbounds function copy_unaliased_stored!(dest, L::LowerTriangular, col)
     for row in col:lastindex(dest,1)
         dest[row,col] = L.data[row,col]
     end
     dest
 end
-@propagate_inbounds function copy_unaliased_stored!(dest, U::UnitLowerTriangular, col)
-    dest[col, col] = U[BandIndex(0,col)]
+@propagate_inbounds function copy_unaliased_stored!(dest, L::UnitLowerTriangular, col)
+    dest[col, col] = L[BandIndex(0,col)]
     for row in col+1:lastindex(dest,1)
         dest[row,col] = L.data[row,col]
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -154,7 +154,7 @@ Base.dataids(A::UpperOrLowerTriangular) = Base.dataids(A.data)
 
 function Matrix{T}(U::UpperOrLowerTriangular) where {T}
     M = Matrix{T}(undef, size(U))
-    copyto_unaliased!(M, U)
+    _copyto!(M, U)
     return M
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -152,6 +152,12 @@ lowertriangular(U::LowerOrUnitLowerTriangular) = U
 
 Base.dataids(A::UpperOrLowerTriangular) = Base.dataids(A.data)
 
+function Matrix{T}(U::UpperOrLowerTriangular) where {T}
+    M = Matrix{T}(undef, size(U))
+    copyto_unaliased!(M, U)
+    return M
+end
+
 imag(A::UpperTriangular) = UpperTriangular(imag(A.data))
 imag(A::LowerTriangular) = LowerTriangular(imag(A.data))
 imag(A::UpperTriangular{<:Any,<:StridedMaybeAdjOrTransMat}) = imag.(A)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -154,7 +154,7 @@ Base.dataids(A::UpperOrLowerTriangular) = Base.dataids(A.data)
 
 function Matrix{T}(U::UpperOrLowerTriangular) where {T}
     M = Matrix{T}(undef, size(U))
-    _copyto!(M, U)
+    copy!(M, U)
     return M
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -628,29 +628,49 @@ end
 end
 # for strided matrices, we explicitly loop over the arrays to improve cache locality
 # This fuses the copytrito! for the two halves
+@propagate_inbounds function copy_unaliased_stored!(dest, U::UpperTriangular, col)
+    for row in firstindex(dest,1):col
+        dest[row,col] = U.data[row,col]
+    end
+    dest
+end
+@propagate_inbounds function copy_unaliased_stored!(dest, U::UnitUpperTriangular, col)
+    for row in firstindex(dest,1):col-1
+        dest[row,col] = U.data[row,col]
+    end
+    dest[col, col] = U[BandIndex(0,col)]
+    dest
+end
+@propagate_inbounds function copy_unaliased_stored!(dest, U::LowerTriangular, col)
+    for row in col:lastindex(dest,1)
+        dest[row,col] = L.data[row,col]
+    end
+    dest
+end
+@propagate_inbounds function copy_unaliased_stored!(dest, U::UnitLowerTriangular, col)
+    dest[col, col] = U[BandIndex(0,col)]
+    for row in col+1:lastindex(dest,1)
+        dest[row,col] = L.data[row,col]
+    end
+    dest
+end
 @inline function copy_unaliased!(dest::StridedMatrix, U::UpperOrUnitUpperTriangular{<:Any, <:StridedMatrix})
     @boundscheck checkbounds(dest, axes(U)...)
-    isunit = U isa UnitUpperTriangular
     for col in axes(dest,2)
-        for row in firstindex(dest,1):col-isunit
-            @inbounds dest[row,col] = U.data[row,col]
-        end
-        for row in col+!isunit:lastindex(dest,1)
-            @inbounds dest[row,col] = U[row,col]
+        @inbounds copy_unaliased_stored!(dest, U, col)
+        for row in col+1:lastindex(dest,1)
+            @inbounds dest[row,col] = diagzero(U,row,col)
         end
     end
     return dest
 end
 @inline function copy_unaliased!(dest::StridedMatrix, L::LowerOrUnitLowerTriangular{<:Any, <:StridedMatrix})
     @boundscheck checkbounds(dest, axes(L)...)
-    isunit = L isa UnitLowerTriangular
     for col in axes(dest,2)
-        for row in firstindex(dest,1):col-!isunit
-            @inbounds dest[row,col] = L[row,col]
+        for row in firstindex(dest,1):col-1
+            @inbounds dest[row,col] = diagzero(L,row,col)
         end
-        for row in col+isunit:lastindex(dest,1)
-            @inbounds dest[row,col] = L.data[row,col]
-        end
+        @inbounds copy_unaliased_stored!(dest, L, col)
     end
     return dest
 end


### PR DESCRIPTION
This reduces TTFX as well as improves performance. This is because we add specialized functions to avoid the branches in `getindex` for a triangular matrix. 
```julia
julia> using LinearAlgebra

julia> U4 = UpperTriangular(ones(4,4));

julia> @time Array(U4); # TTFX
  0.087534 seconds (193.27 k allocations: 9.706 MiB, 99.88% compilation time) # nightly
  0.049869 seconds (91.45 k allocations: 4.531 MiB, 99.78% compilation time) # this PR

julia> U = UpperTriangular(ones(2000,2000));

julia> @btime Array($U);
  3.205 ms (3 allocations: 30.52 MiB) # master
  2.764 ms (3 allocations: 30.52 MiB) # this PR
```