### PR TITLE
Explicit loop in converting `Bidiagonal`/`Tridiagonal` to `Matrix`

### DIFF
--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -635,11 +635,15 @@ axes(M::Tridiagonal) = (ax = axes(M.d,1); (ax, ax))
 
 function Matrix{T}(M::Tridiagonal) where {T}
     A = Matrix{T}(undef, size(M))
+    iszero(size(A,1)) && return A
     if haszero(T) # optimized path for types with zero(T) defined
         size(A,1) > 2 && fill!(A, zero(T))
-        copyto!(diagview(A), M.d)
-        copyto!(diagview(A,1), M.du)
-        copyto!(diagview(A,-1), M.dl)
+        for i in axes(M.dl,1)
+            A[i,i] = M.d[i]
+            A[i+1,i] = M.dl[i]
+            A[i,i+1] = M.du[i]
+        end
+        A[end,end] = M.d[end]
     else
         copyto!(A, M)
     end


### PR DESCRIPTION
This reduces TTFX.
```julia
julia> using LinearAlgebra

julia> T = Bidiagonal(ones(4), ones(3), :L);

julia> @time Matrix(T);
  0.073467 seconds (125.49 k allocations: 6.207 MiB, 99.83% compilation time) # nightly
  0.042144 seconds (46.61 k allocations: 2.310 MiB, 99.65% compilation time) # this PR
```
```julia
julia> T = Tridiagonal(ones(3), ones(4), ones(3));

julia> @time Matrix(T);
  0.077513 seconds (138.71 k allocations: 6.792 MiB, 99.85% compilation time) # master
  0.034220 seconds (37.27 k allocations: 1.867 MiB, 99.58% compilation time) # this PR
```

Performance is identical, as it's entirely dominated by setting the matrix to zero.