### PR TITLE
Branch on `Bool` `alpha` in scaling `mul!`

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -202,23 +202,36 @@ _lscale_add!(C::StridedArray, s::Number, X::StridedArray, alpha::Number, beta::N
     generic_mul!(C, s, X, alpha, beta)
 @inline function _lscale_add!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
     if axes(C) == axes(X)
-        if isone(alpha)
-            if iszero(beta)
-                @. C = s * X
-            else
-                @. C = s * X + C * beta
-            end
-        else
-            if iszero(beta)
-                @. C = s * X * alpha
-            else
-                @. C = s * X * alpha + C * beta
-            end
-        end
+        iszero(alpha) && return _rmul_or_fill!(C, beta)
+        _lscale_add_nonzeroalpha!(C, s, X, alpha, beta)
     else
         generic_mul!(C, s, X, alpha, beta)
     end
     return C
+end
+function _lscale_add_nonzeroalpha!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
+    if isone(alpha)
+        if iszero(beta)
+            @. C = s * X
+        else
+            @. C = s * X + C * beta
+        end
+    else
+        if iszero(beta)
+            @. C = s * X * alpha
+        else
+            @. C = s * X * alpha + C * beta
+        end
+    end
+    C
+end
+function _lscale_add_nonzeroalpha!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Bool, beta::Number)
+    if iszero(beta)
+        @. C = s * X
+    else
+        @. C = s * X + C * beta
+    end
+    C
 end
 @inline mul!(C::AbstractArray, X::AbstractArray, s::Number, alpha::Number, beta::Number) =
     _rscale_add!(C, X, s, alpha, beta)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -211,11 +211,9 @@ _lscale_add!(C::StridedArray, s::Number, X::StridedArray, alpha::Number, beta::N
 end
 function _lscale_add_nonzeroalpha!(C::AbstractArray, s::Number, X::AbstractArray, alpha::Number, beta::Number)
     if isone(alpha)
-        if iszero(beta)
-            @. C = s * X
-        else
-            @. C = s * X + C * beta
-        end
+        # since alpha is unused, we might as well set to `true` to avoid recompiling
+        # the branch if a different type is used
+        _lscale_add_nonzeroalpha!(C, s, X, true, beta)
     else
         if iszero(beta)
             @. C = s * X * alpha

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -865,8 +865,12 @@ end
     # 5-arg equivalent to the 3-arg method, but with non-Bool alpha
     @test mul!(copy!(similar(v), v), 2, v, 1, 0) == 2v
     @test mul!(copy!(similar(v), v), v, 2, 1, 0) == 2v
+    # 5-arg tests with alpha::Bool
     @test mul!(copy!(similar(v), v), 2, v, true, 1) == 3v
     @test mul!(copy!(similar(v), v), v, 2, true, 1) == 3v
+    @test mul!(copy!(similar(v), v), 2, v, false, 2) == 2v
+    @test mul!(copy!(similar(v), v), v, 2, false, 2) == 2v
+    # 5-arg tests
     @test mul!(copy!(similar(v), v), 2, v, 1, 3) == 5v
     @test mul!(copy!(similar(v), v), v, 2, 1, 3) == 5v
     @test mul!(copy!(similar(v), v), 2, v, 2, 3) == 7v

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -857,4 +857,17 @@ end
     end
 end
 
+@testset "scaling mul" begin
+    v = 1:4
+    w = similar(v)
+    @test mul!(w, 2, v) == 2v
+    @test mul!(w, v, 2) == 2v
+    @test mul!(copy!(similar(v), v), 2, v, 1, 3) == 5v
+    @test mul!(copy!(similar(v), v), v, 2, 1, 3) == 5v
+    @test mul!(copy!(similar(v), v), 2, v, 2, 3) == 7v
+    @test mul!(copy!(similar(v), v), v, 2, 2, 3) == 7v
+    @test mul!(copy!(similar(v), v), 2, v, 2, 0) == 4v
+    @test mul!(copy!(similar(v), v), v, 2, 2, 0) == 4v
+end
+
 end # module TestGeneric

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -862,6 +862,11 @@ end
     w = similar(v)
     @test mul!(w, 2, v) == 2v
     @test mul!(w, v, 2) == 2v
+    # 5-arg equivalent to the 3-arg method, but with non-Bool alpha
+    @test mul!(copy!(similar(v), v), 2, v, 1, 0) == 2v
+    @test mul!(copy!(similar(v), v), v, 2, 1, 0) == 2v
+    @test mul!(copy!(similar(v), v), 2, v, true, 1) == 3v
+    @test mul!(copy!(similar(v), v), v, 2, true, 1) == 3v
     @test mul!(copy!(similar(v), v), 2, v, 1, 3) == 5v
     @test mul!(copy!(similar(v), v), v, 2, 1, 3) == 5v
     @test mul!(copy!(similar(v), v), 2, v, 2, 3) == 7v


### PR DESCRIPTION
By dealing with the `alpha == 0` case separately, we ensure that if `alpha::Bool`, it must be `true`. This reduces the branches in `_lscale_add` from 4 to 2 in the common case of 3-argument `mul!`. This leads to a latency reduction, as each branch has to compile a different broadcast expression, and we currently compile four but use only one. Primarily, this PR leads to a reduction in allocations.

```julia
julia> using LinearAlgebra

julia> v = 1:4; w = similar(v);

julia> @time mul!(w, 1, v);
  0.171120 seconds (1.04 M allocations: 52.799 MiB, 99.98% compilation time) # nightly
  0.163178 seconds (702.63 k allocations: 35.533 MiB, 99.98% compilation time) # this PR
```

Something similar usually doesn't lead to a big gain in the `_rscale_add` method, as `s * alpha` often has the same type as `s`, and therefore the branches on `alpha` compile the same code.