### PR TITLE
Unaliasing and short-circuiting in `copytrito!`

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2111,6 +2111,7 @@ end
 # Forward LAPACK-compatible strided matrices to lacpy
 function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}
     require_one_based_indexing(A, B)
+    BLAS.chkuplo(uplo)
     B === A && return B
     A = Base.unalias(B, A)
     LAPACK.lacpy!(B, A, uplo)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2111,7 +2111,6 @@ end
 # Forward LAPACK-compatible strided matrices to lacpy
 function copytrito!(B::StridedMatrixStride1{T}, A::StridedMatrixStride1{T}, uplo::AbstractChar) where {T<:BlasFloat}
     require_one_based_indexing(A, B)
-    BLAS.chkuplo(uplo)
     B === A && return B
     A = Base.unalias(B, A)
     LAPACK.lacpy!(B, A, uplo)

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -7176,6 +7176,7 @@ for (fn, elty) in ((:dlacpy_, :Float64),
         function lacpy!(B::AbstractMatrix{$elty}, A::AbstractMatrix{$elty}, uplo::AbstractChar)
             require_one_based_indexing(A, B)
             chkstride1(A, B)
+            chkuplo(uplo)
             m, n = size(A)
             m1, n1 = size(B)
             if uplo == 'U'

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -7176,7 +7176,6 @@ for (fn, elty) in ((:dlacpy_, :Float64),
         function lacpy!(B::AbstractMatrix{$elty}, A::AbstractMatrix{$elty}, uplo::AbstractChar)
             require_one_based_indexing(A, B)
             chkstride1(A, B)
-            chkuplo(uplo)
             m, n = size(A)
             m1, n1 = size(B)
             if uplo == 'U'

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -879,4 +879,13 @@ end
     @test mul!(copy!(similar(v), v), v, 2, 2, 0) == 4v
 end
 
+@testset "aliasing in copytrito! for strided matrices" begin
+    M = rand(4, 1)
+    A = view(M, 1:3, 1:1)
+    A2 = copy(A)
+    B = view(M, 2:4, 1:1)
+    copytrito!(B, A, 'L')
+    @test B == A2
+end
+
 end # module TestGeneric


### PR DESCRIPTION
The LAPACK function `lacpy!` seems to handle aliasing correctly already, but since the LAPACK documentation doesn't expect the output arguments to be aliased, it's best if we carry out the unaliasing by ourselves.

I've also added a quick return criterion if the two matrices are identical, in which case there is nothing to copy. This would be useful in copying elements between a triangular/symmetric matrix and its parent.