### PR TITLE
Fit broken matmul test

### DIFF
--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1217,8 +1217,8 @@ end
     A = ones(2,2)
     S = Symmetric(ones(2,2))
     @test mul!(similar(A), S, A, big(1), big(0)) ≈ S * A
-    C1 = mul!(similar(A), S, A, big(2), big(1))
-    C2 = mul!(similar(A), S, A, 2, 1)
+    C1 = mul!(zero(A), S, A, big(2), big(1))
+    C2 = mul!(zero(A), S, A, 2, 1)
     @test C1 ≈ C2
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1217,8 +1217,8 @@ end
     A = ones(2,2)
     S = Symmetric(ones(2,2))
     @test mul!(similar(A), S, A, big(1), big(0)) ≈ S * A
-    C1 = mul!(zero(A), S, A, big(2), big(1))
-    C2 = mul!(zero(A), S, A, 2, 1)
+    C1 = mul!(one(A), S, A, big(2), big(1))
+    C2 = mul!(one(A), S, A, 2, 1)
     @test C1 ≈ C2
 end
 


### PR DESCRIPTION
Since `similar` returns uninitialized memory, there is not reason to expect the two invocations to return the same values.

The broken test caused https://buildkite.com/julialang/linearalgebra-dot-jl/builds/517#0196337d-14ef-4846-be5c-85e92f72fd23/203-354