### PR TITLE
Fix exponentiation with immutable matrix

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -720,7 +720,7 @@ julia> ℯ^[1 2; 0 3]
  0.0      20.0855
 ```
 """
-Base.:^(b::Number, A::AbstractMatrix) = exp!(log(b)*A)
+Base.:^(b::Number, A::AbstractMatrix) = exp_maybe_inplace(log(b)*A)
 # method for ℯ to explicitly elide the log(b) multiplication
 Base.:^(::Irrational{:ℯ}, A::AbstractMatrix) = exp(A)
 

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -10,6 +10,9 @@ const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :FillArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FillArrays.jl"))
 import Main.FillArrays
 
+isdefined(Main, :SizedArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "SizedArrays.jl"))
+using Main.SizedArrays
+
 @testset "Check that non-floats are correctly promoted" begin
     @test [1 0 0; 0 1 0]\[1,1] ≈ [1;1;0]
 end
@@ -1396,6 +1399,11 @@ end
     end
 
     @test_throws ArgumentError LinearAlgebra.copytri_maybe_inplace(Rc, 'X')
+end
+
+@testset "matrix exponentiation for immutable" begin
+    A = SizedArray{(2,2)}(reshape(1:4,2,2))
+    @test 2^A == 2^Matrix(A)
 end
 
 end # module TestDense


### PR DESCRIPTION
The following works after this:
```julia
julia> using LinearAlgebra, StaticArrays

julia> S = @SMatrix [1 2; 3 4]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  2
 3  4

julia> 2^S
2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
 10.4827  14.1519
 21.2278  31.7106
```