### PR TITLE
Fix `lmul!`/`rmul!` for 0-sized matrices

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -539,8 +539,8 @@ function lmul!(D::Diagonal, B::Bidiagonal)
     (; dv, ev) = B
     isL = B.uplo == 'L'
     iszero(size(D,1)) && return B
-    dv[1] = D.diag[1] * dv[1]
-    for i in axes(ev,1)
+    @inbounds dv[1] = D.diag[1] * dv[1]
+    @inbounds for i in axes(ev,1)
         ev[i] = D.diag[i + isL] * ev[i]
         dv[i+1] = D.diag[i+1] * dv[i+1]
     end
@@ -577,8 +577,8 @@ function rmul!(B::Bidiagonal, D::Diagonal)
     (; dv, ev) = B
     isU = B.uplo == 'U'
     iszero(size(D,1)) && return B
-    dv[1] *= D.diag[1]
-    for i in axes(ev,1)
+    @inbounds dv[1] *= D.diag[1]
+    @inbounds for i in axes(ev,1)
         ev[i] *= D.diag[i + isU]
         dv[i+1] *= D.diag[i+1]
     end

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -538,6 +538,7 @@ function lmul!(D::Diagonal, B::Bidiagonal)
     matmul_size_check(size(D), size(B))
     (; dv, ev) = B
     isL = B.uplo == 'L'
+    iszero(size(D,1)) && return B
     dv[1] = D.diag[1] * dv[1]
     for i in axes(ev,1)
         ev[i] = D.diag[i + isL] * ev[i]
@@ -575,6 +576,7 @@ function rmul!(B::Bidiagonal, D::Diagonal)
     matmul_size_check(size(B), size(D))
     (; dv, ev) = B
     isU = B.uplo == 'U'
+    iszero(size(D,1)) && return B
     dv[1] *= D.diag[1]
     for i in axes(ev,1)
         ev[i] *= D.diag[i + isU]

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1192,4 +1192,13 @@ end
     @test_throws msg ldiv!(C, B, zeros(2,1))
 end
 
+@testset "l/rmul with 0-sized matrices" begin
+    n = 0
+    B = Bidiagonal(ones(n), ones(max(n-1,0)), :U)
+    B2 = copy(B)
+    D = Diagonal(ones(n))
+    @test lmul!(D, B) == B2
+    @test rmul!(B, D) == B2
+end
+
 end # module TestBidiagonal


### PR DESCRIPTION
Fixes scaling `Bidiaognal` matrices by `Diagonal` ones when they're both empty.