### PR TITLE
Add `diagm` example

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -399,6 +399,8 @@ Construct a matrix with elements of the vector as diagonal elements.
 By default, the matrix is square and its size is given by
 `length(v)`, but a non-square size `m`×`n` can be specified
 by passing `m,n` as the first arguments.
+If the diagonal of the matrix contains more elements than `v`,
+the trailing elements will be zeros.
 
 # Examples
 ```jldoctest
@@ -407,6 +409,13 @@ julia> diagm([1,2,3])
  1  0  0
  0  2  0
  0  0  3
+
+julia> diagm(4, 5, [1,2,3])
+4×5 Matrix{Int64}:
+ 1  0  0  0  0
+ 0  2  0  0  0
+ 0  0  3  0  0
+ 0  0  0  0  0
 ```
 """
 diagm(v::AbstractVector) = diagm(0 => v)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -399,8 +399,7 @@ Construct a matrix with elements of the vector as diagonal elements.
 By default, the matrix is square and its size is given by
 `length(v)`, but a non-square size `m`×`n` can be specified
 by passing `m,n` as the first arguments.
-If the diagonal of the matrix contains more elements than `v`,
-the trailing elements will be zeros.
+The diagonal will be zero-padded if necessary.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Add an example for the method `diagm(m, n, v)`, and clarify that zero-padding may be used for larger matrices.