### PR TITLE
Fix docstring for reflectorApply!

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1758,7 +1758,7 @@ end
 """
     reflectorApply!(x, τ, A)
 
-Multiplies `A` in-place by a Householder reflection on the left. It is equivalent to `A .= (I - conj(τ)*[1; x[2:end]]*[1; x[2:end]]')*A`.
+Multiplies `A` in-place by a Householder reflection on the left. It is equivalent to `A .= (I - [1; x[2:end]] * conj(τ) * [1; x[2:end]]') * A`.
 """
 @inline function reflectorApply!(x::AbstractVector, τ::Number, A::AbstractVecOrMat)
     require_one_based_indexing(x, A)


### PR DESCRIPTION
The `τ` should go between the vectors. This can be confirmed from applying the reflector to a matrix of quaternions.