### PR TITLE
Bounds-checking in triangular indexing branches

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -816,7 +816,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular, c::Nu
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, B[BandIndex(0,j)] *c, A, (j,j))
+        @inbounds _modify!(_add, B[BandIndex(0,j)] * c, A, (j,j))
         for i in (j + 1):lastindex(B.data,1)
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
         end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -837,7 +837,6 @@ end
 
 function _trirdiv!(A::UpperTriangular, B::UpperTriangular, c::Number)
     checksize1(A, B)
-    isunit = B isa UnitUpperTriangular
     for j in axes(B,2)
         for i in firstindex(B,1):j
             @inbounds A.data[i, j] = B.data[i, j] / c
@@ -847,7 +846,6 @@ function _trirdiv!(A::UpperTriangular, B::UpperTriangular, c::Number)
 end
 function _trirdiv!(A::LowerTriangular, B::LowerTriangular, c::Number)
     checksize1(A, B)
-    isunit = B isa UnitLowerTriangular
     for j in axes(B,2)
         for i in j:lastindex(B,1)
             @inbounds A.data[i, j] = B.data[i, j] / c
@@ -857,7 +855,6 @@ function _trirdiv!(A::LowerTriangular, B::LowerTriangular, c::Number)
 end
 function _trildiv!(A::UpperTriangular, c::Number, B::UpperTriangular)
     checksize1(A, B)
-    isunit = B isa UnitUpperTriangular
     for j in axes(B,2)
         for i in firstindex(B,1):j
             @inbounds A.data[i, j] = c \ B.data[i, j]
@@ -867,7 +864,6 @@ function _trildiv!(A::UpperTriangular, c::Number, B::UpperTriangular)
 end
 function _trildiv!(A::LowerTriangular, c::Number, B::LowerTriangular)
     checksize1(A, B)
-    isunit = B isa UnitLowerTriangular
     for j in axes(B,2)
         for i in j:lastindex(B,1)
             @inbounds A.data[i, j] = c \ B.data[i, j]

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -289,57 +289,65 @@ end
 end
 
 @propagate_inbounds function setindex!(A::UpperTriangular, x, i::Integer, j::Integer)
-    if i > j
+    if _shouldforwardindex(A, i, j)
+        A.data[i,j] = x
+    else
         @boundscheck checkbounds(A, i, j)
         # the value must be convertible to the eltype for setindex! to be meaningful
-        xT = convert(eltype(A), x)
-        iszero(xT) || throw_nonzeroerror(:UpperTriangular, x, i, j)
-    else
-        A.data[i,j] = x
+        # however, the converted value is unused, and the compiler is free to remove
+        # the conversion if the call is guaranteed to succeed
+        convert(eltype(A), x)
+        iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
     end
     return A
 end
 
 @propagate_inbounds function setindex!(A::UnitUpperTriangular, x, i::Integer, j::Integer)
-    if i >= j
+    if _shouldforwardindex(A, i, j)
+        A.data[i,j] = x
+    else
         @boundscheck checkbounds(A, i, j)
         # the value must be convertible to the eltype for setindex! to be meaningful
-        xT = convert(eltype(A), x)
+        # however, the converted value is unused, and the compiler is free to remove
+        # the conversion if the call is guaranteed to succeed
+        convert(eltype(A), x)
         if i > j
-            iszero(xT) || throw_nonzeroerror(:UnitUpperTriangular, x, i, j)
+            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
         else
-            xT == oneunit(eltype(A)) || throw_nonuniterror(:UnitUpperTriangular, x, i, j)
+            x == oneunit(eltype(A)) || throw_nonuniterror(nameof(typeof(A)), x, i, j)
         end
-    else
-        A.data[i,j] = x
     end
     return A
 end
 
 @propagate_inbounds function setindex!(A::LowerTriangular, x, i::Integer, j::Integer)
-    if i < j
+    if _shouldforwardindex(A, i, j)
+        A.data[i,j] = x
+    else
         @boundscheck checkbounds(A, i, j)
         # the value must be convertible to the eltype for setindex! to be meaningful
-        xT = convert(eltype(A), x)
-        iszero(xT) || throw_nonzeroerror(:LowerTriangular, x, i, j)
-    else
-        A.data[i,j] = x
+        # however, the converted value is unused, and the compiler is free to remove
+        # the conversion if the call is guaranteed to succeed
+        convert(eltype(A), x)
+        iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
     end
     return A
 end
 
 @propagate_inbounds function setindex!(A::UnitLowerTriangular, x, i::Integer, j::Integer)
-    if i <= j
+    if _shouldforwardindex(A, i, j)
+        A.data[i,j] = x
+    else
         @boundscheck checkbounds(A, i, j)
         # the value must be convertible to the eltype for setindex! to be meaningful
-        xT = convert(eltype(A), x)
+        # however, the converted value is unused, and the compiler is free to remove
+        # the conversion if the call is guaranteed to succeed
+        convert(eltype(A), x)
         if i < j
-            iszero(xT) || throw_nonzeroerror(:UnitLowerTriangular, x, i, j)
+            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
         else
-            xT == oneunit(eltype(A)) || throw_nonuniterror(:UnitLowerTriangular, x, i, j)
+            x == oneunit(eltype(A)) || throw_nonuniterror(nameof(typeof(A)), x, i, j)
         end
-    else
-        A.data[i,j] = x
     end
     return A
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -774,7 +774,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, B::UnitUpperTriangular, c::Nu
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, B[BandIndex(0,j)] * c, A, (j,j))
+        @inbounds _modify!(_add, c, A, (j,j))
         for i in firstindex(B.data,1):(j - 1)
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
         end
@@ -785,7 +785,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, c::Number, B::UnitUpperTriang
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c * B[BandIndex(0,j)], A, (j,j))
+        @inbounds _modify!(_add, c, A, (j,j))
         for i in firstindex(B.data,1):(j - 1)
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
         end
@@ -816,7 +816,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular, c::Nu
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, B[BandIndex(0,j)] *c, A, (j,j))
+        @inbounds _modify!(_add, c, A, (j,j))
         for i in (j + 1):lastindex(B.data,1)
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
         end
@@ -827,7 +827,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, c::Number, B::UnitLowerTriang
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c * B[BandIndex(0,j)], A, (j,j))
+        @inbounds _modify!(_add, c, A, (j,j))
         for i in (j + 1):lastindex(B.data,1)
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
         end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -316,10 +316,10 @@ end
         # however, the converted value is unused, and the compiler is free to remove
         # the conversion if the call is guaranteed to succeed
         convert(eltype(A), x)
-        if i > j
-            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
-        else
+        if i == j # diagonal
             x == oneunit(eltype(A)) || throw_nonuniterror(nameof(typeof(A)), x, i, j)
+        else
+            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
         end
     end
     return A
@@ -348,10 +348,10 @@ end
         # however, the converted value is unused, and the compiler is free to remove
         # the conversion if the call is guaranteed to succeed
         convert(eltype(A), x)
-        if i < j
-            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
-        else
+        if i == j  # diagonal
             x == oneunit(eltype(A)) || throw_nonuniterror(nameof(typeof(A)), x, i, j)
+        else
+            iszero(x) || throw_nonzeroerror(nameof(typeof(A)), x, i, j)
         end
     end
     return A

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -278,12 +278,17 @@ Base.@constprop :aggressive @propagate_inbounds function getindex(A::Union{Lower
     end
 end
 
-@noinline function throw_nonzeroerror(Tn, @nospecialize(x), i, j)
-    Ts = Tn in (:UpperTriangular, :UnitUpperTriangular) ? "lower" : "upper"
+@noinline function throw_nonzeroerror(Tn::Symbol, @nospecialize(x), i, j)
+    zero_half = Tn in (:UpperTriangular, :UnitUpperTriangular) ? "lower" : "upper"
+    nstr = Tn === :UpperTriangular ? "n" : ""
     throw(ArgumentError(
-        lazy"cannot set index in the $Ts triangular part ($i, $j) of a $Tn matrix to a nonzero value ($x)"))
+        LazyString(
+            lazy"cannot set index ($i, $j) in the $zero_half triangular part ",
+            lazy"of a$nstr $Tn matrix to a nonzero value ($x)")
+        )
+    )
 end
-@noinline function throw_nonuniterror(Tn, @nospecialize(x), i, j)
+@noinline function throw_nonuniterror(Tn::Symbol, @nospecialize(x), i, j)
     throw(ArgumentError(
         lazy"cannot set index ($i, $j) on the diagonal of a $Tn matrix to a non-unit value ($x)"))
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -774,7 +774,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, B::UnitUpperTriangular, c::Nu
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds _modify!(_add, B[BandIndex(0,j)] * c, A, (j,j))
         for i in firstindex(B.data,1):(j - 1)
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
         end
@@ -785,7 +785,7 @@ function _triscale!(A::UpperOrUnitUpperTriangular, c::Number, B::UnitUpperTriang
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds _modify!(_add, c * B[BandIndex(0,j)], A, (j,j))
         for i in firstindex(B.data,1):(j - 1)
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
         end
@@ -816,7 +816,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, B::UnitLowerTriangular, c::Nu
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds _modify!(_add, B[BandIndex(0,j)] *c, A, (j,j))
         for i in (j + 1):lastindex(B.data,1)
             @inbounds _modify!(_add, B.data[i,j] * c, A.data, (i,j))
         end
@@ -827,7 +827,7 @@ function _triscale!(A::LowerOrUnitLowerTriangular, c::Number, B::UnitLowerTriang
     checksize1(A, B)
     _iszero_alpha(_add) && return _rmul_or_fill!(A, _add.beta)
     for j in axes(B.data,2)
-        @inbounds _modify!(_add, c, A, (j,j))
+        @inbounds _modify!(_add, c * B[BandIndex(0,j)], A, (j,j))
         for i in (j + 1):lastindex(B.data,1)
             @inbounds _modify!(_add, c * B.data[i,j], A.data, (i,j))
         end

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -967,6 +967,7 @@ end
 end
 
 @testset "indexing checks" begin
+    P = [1 2; 3 4]
     @testset "getindex" begin
         U = UnitUpperTriangular(P)
         @test_throws BoundsError U[0,0]
@@ -989,7 +990,6 @@ end
         @test_throws BoundsError L[BandIndex(1,0)]
     end
     @testset "setindex!" begin
-        P = [1 2; 3 4]
         A = SizedArrays.SizedArray{(2,2)}(P)
         M = fill(A, 2, 2)
         U = UnitUpperTriangular(M)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -950,6 +950,10 @@ end
     @test 2\U == 2\M
     @test U*2 == M*2
     @test 2*U == 2*M
+
+    U2 = copy(U)
+    @test rmul!(U, 1) == U2
+    @test lmul!(1, U) == U2
 end
 
 @testset "scaling partly initialized unit triangular" begin

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -998,8 +998,21 @@ end
         M = fill(A, 2, 2)
         U = UnitUpperTriangular(M)
         @test_throws "Cannot `convert` an object of type $Int" U[1,1] = 1
+        non_unit_msg = "cannot set index $((1,1)) on the diagonal of a UnitUpperTriangular matrix to a non-unit value"
+        @test_throws non_unit_msg U[1,1] = A
         L = UnitLowerTriangular(M)
         @test_throws "Cannot `convert` an object of type $Int" L[1,1] = 1
+        non_unit_msg = "cannot set index $((1,1)) on the diagonal of a UnitLowerTriangular matrix to a non-unit value"
+        @test_throws non_unit_msg L[1,1] = A
+
+        for UT in (UnitUpperTriangular, UpperTriangular)
+            U = UT(M)
+            @test_throws "Cannot `convert` an object of type $Int" U[2,1] = 0
+        end
+        for LT in (UnitLowerTriangular, LowerTriangular)
+            L = LT(M)
+            @test_throws "Cannot `convert` an object of type $Int" L[1,2] = 0
+        end
 
         U = UnitUpperTriangular(P)
         @test_throws BoundsError U[0,0] = 1

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1013,4 +1013,15 @@ end
     end
 end
 
+@testset "unit triangular l/rdiv!" begin
+    A = rand(3,3)
+    @testset for (UT,T) in ((UnitUpperTriangular, UpperTriangular),
+                            (UnitLowerTriangular, LowerTriangular))
+        UnitTri = UT(A)
+        Tri = T(LinearAlgebra.full(UnitTri))
+        @test 2 \ UnitTri ≈ 2 \ Tri
+        @test UnitTri / 2 ≈ Tri / 2
+    end
+end
+
 end # module TestTriangular

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -993,9 +993,9 @@ end
         A = SizedArrays.SizedArray{(2,2)}(P)
         M = fill(A, 2, 2)
         U = UnitUpperTriangular(M)
-        @test_throws "Cannot `convert` an object of type Int64" U[1,1] = 1
+        @test_throws "Cannot `convert` an object of type $Int" U[1,1] = 1
         L = UnitLowerTriangular(M)
-        @test_throws "Cannot `convert` an object of type Int64" L[1,1] = 1
+        @test_throws "Cannot `convert` an object of type $Int" L[1,1] = 1
 
         U = UnitUpperTriangular(P)
         @test_throws BoundsError U[0,0] = 1

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -966,4 +966,51 @@ end
     end
 end
 
+@testset "indexing checks" begin
+    @testset "getindex" begin
+        U = UnitUpperTriangular(P)
+        @test_throws BoundsError U[0,0]
+        @test_throws BoundsError U[1,0]
+        @test_throws BoundsError U[BandIndex(0,0)]
+        @test_throws BoundsError U[BandIndex(-1,0)]
+
+        U = UpperTriangular(P)
+        @test_throws BoundsError U[1,0]
+        @test_throws BoundsError U[BandIndex(-1,0)]
+
+        L = UnitLowerTriangular(P)
+        @test_throws BoundsError L[0,0]
+        @test_throws BoundsError L[0,1]
+        @test_throws BoundsError U[BandIndex(0,0)]
+        @test_throws BoundsError U[BandIndex(1,0)]
+
+        L = LowerTriangular(P)
+        @test_throws BoundsError L[0,1]
+        @test_throws BoundsError L[BandIndex(1,0)]
+    end
+    @testset "setindex!" begin
+        P = [1 2; 3 4]
+        A = SizedArrays.SizedArray{(2,2)}(P)
+        M = fill(A, 2, 2)
+        U = UnitUpperTriangular(M)
+        @test_throws "Cannot `convert` an object of type Int64" U[1,1] = 1
+        L = UnitLowerTriangular(M)
+        @test_throws "Cannot `convert` an object of type Int64" L[1,1] = 1
+
+        U = UnitUpperTriangular(P)
+        @test_throws BoundsError U[0,0] = 1
+        @test_throws BoundsError U[1,0] = 0
+
+        U = UpperTriangular(P)
+        @test_throws BoundsError U[1,0] = 0
+
+        L = UnitLowerTriangular(P)
+        @test_throws BoundsError L[0,0] = 1
+        @test_throws BoundsError L[0,1] = 0
+
+        L = LowerTriangular(P)
+        @test_throws BoundsError L[0,1] = 0
+    end
+end
+
 end # module TestTriangular

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -641,11 +641,11 @@ end
         @testset "error message" begin
             A = UpperTriangular(Ap)
             B = UpperTriangular(Bp)
-            @test_throws "cannot set index in the lower triangular part" copyto!(A, B)
+            @test_throws "cannot set index (3, 1) in the lower triangular part" copyto!(A, B)
 
             A = LowerTriangular(Ap)
             B = LowerTriangular(Bp)
-            @test_throws "cannot set index in the upper triangular part" copyto!(A, B)
+            @test_throws "cannot set index (1, 2) in the upper triangular part" copyto!(A, B)
         end
     end
 


### PR DESCRIPTION
After this PR, calls like the following would throw:
```julia
julia> U = UpperTriangular([1 2; 3 4])
2×2 UpperTriangular{Int64, Matrix{Int64}}:
 1  2
 ⋅  4

julia> U[1,0]
0
```
Currently, there's no bounds-checking on the indices if they don't correspond to stored values.

Also, this PR checks for compatible types in assigning to the diagonal of unit triangular matrices. This fixes issues like, e.g.:
```julia
julia> A = @SMatrix [1 2; 3 4]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  2
 3  4

julia> M = fill(A, 2, 2)
2×2 Matrix{SMatrix{2, 2, Int64, 4}}:
 [1 2; 3 4]  [1 2; 3 4]
 [1 2; 3 4]  [1 2; 3 4]

julia> U = UnitUpperTriangular(M)
2×2 UnitUpperTriangular{SMatrix{2, 2, Int64, 4}, Matrix{SMatrix{2, 2, Int64, 4}}}:
 [1 0; 0 1]  [1 2; 3 4]
     ⋅       [1 0; 0 1]

julia> U[1,1] = 1
1
```
After this,
```julia
julia> U[1,1] = 1
ERROR: MethodError: Cannot `convert` an object of type Int64 to an object of type SMatrix{2, 2, Int64, 4}
```

However, this depends on https://github.com/JuliaLang/julia/pull/58209 for the `SizedArrays` tests to pass, as `oneunit` currently doesn't work with a `SizedArray`.