### PR TITLE
Check types locally in triangular tests

### DIFF
--- a/test/testtriag.jl
+++ b/test/testtriag.jl
@@ -4,6 +4,12 @@ using Test, LinearAlgebra
 using LinearAlgebra: BlasFloat, errorbounds, full!, transpose!,
     UpperOrUnitUpperTriangular, LowerOrUnitLowerTriangular, UnitUpperOrUnitLowerTriangular
 
+check_uplo(::Any, A1, A2) = false
+check_uplo(::typeof{==}, A1::UpperOrUnitUpperTriangular, A2::UpperOrUnitUpperTriangular) = true
+check_uplo(::typeof{==}, A1::LowerOrUnitLowerTriangular, A2::LowerOrUnitLowerTriangular) = true
+check_uplo(::typeof{!=}, A1::UpperOrUnitUpperTriangular, A2::LowerOrUnitLowerTriangular) = true
+check_uplo(::typeof{!=}, A1::LowerOrUnitLowerTriangular, A2::UpperOrUnitUpperTriangular) = true
+
 # The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
 function test_triangular(elty1_types)
     n = 9
@@ -409,17 +415,17 @@ function test_triangular(elty1_types)
                     @test_throws DimensionMismatch transpose(A2) * offsizeA
                     @test_throws DimensionMismatch A2' * offsizeA
                     @test_throws DimensionMismatch A2 * offsizeA
-                    if (uplo1 == uplo2 && eltype(A1) == elty2 != Int && !(A1 isa UnitUpperOrUnitLowerTriangular))
+                    if (check_uplo(==, A1, A2) && eltype(A1) == eltype(A2) != Int && !(A1 isa UnitUpperOrUnitLowerTriangular))
                         @test rdiv!(copy(A1), A2)::t1 ≈ A1 / A2 ≈ M1 / M2
                         @test ldiv!(A2, copy(A1))::t1 ≈ A2 \ A1 ≈ M2 \ M1
                     end
-                    if (uplo1 != uplo2 && eltype(A1) == elty2 != Int && !(A2 isa UnitUpperOrUnitLowerTriangular))
+                    if (check_uplo(!=, A1, A2) && eltype(A1) == eltype(A2) != Int && !(A2 isa UnitUpperOrUnitLowerTriangular))
                         @test lmul!(adjoint(A1), copy(A2)) ≈ A1' * A2 ≈ M1' * M2
                         @test lmul!(transpose(A1), copy(A2)) ≈ transpose(A1) * A2 ≈ transpose(M1) * M2
                         @test ldiv!(adjoint(A1), copy(A2)) ≈ A1' \ A2 ≈ M1' \ M2
                         @test ldiv!(transpose(A1), copy(A2)) ≈ transpose(A1) \ A2 ≈ transpose(M1) \ M2
                     end
-                    if (uplo1 != uplo2 && eltype(A1) == elty2 != Int && !(A1 isa UnitUpperOrUnitLowerTriangular))
+                    if (check_uplo(!=, A1, A2) && eltype(A1) == eltype(A2) != Int && !(A1 isa UnitUpperOrUnitLowerTriangular))
                         @test rmul!(copy(A1), adjoint(A2)) ≈ A1 * A2' ≈ M1 * M2'
                         @test rmul!(copy(A1), transpose(A2)) ≈ A1 * transpose(A2) ≈ M1 * transpose(M2)
                         @test rdiv!(copy(A1), adjoint(A2)) ≈ A1 / A2' ≈ M1 / M2'

--- a/test/testtriag.jl
+++ b/test/testtriag.jl
@@ -273,8 +273,8 @@ function test_triangular(elty1_types)
             # generalized dot
             for eltyb in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
                 b1 = convert(Vector{eltyb}, (eltype(A1) <: Complex ? real(A1) : A1) * fill(1.0, n))
-                b2 = convert(Vector{eltyb}, (eltype(A1) <: Complex ? real(A1) : A1) * randn(n))
-                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2) atol = sqrt(max(eps(real(float(one(eltype(A1))))), eps(real(float(one(eltyb)))))) * n * n
+                b2 = oftype(b1, (eltype(A1) <: Complex ? real(A1) : A1) * randn(n))
+                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2) atol = sqrt(max(eps(real(float(one(eltype(A1))))), eps(real(float(one(eltype(b1))))))) * n * n
             end
 
             # Binary operations

--- a/test/testtriag.jl
+++ b/test/testtriag.jl
@@ -4,11 +4,11 @@ using Test, LinearAlgebra
 using LinearAlgebra: BlasFloat, errorbounds, full!, transpose!,
     UpperOrUnitUpperTriangular, LowerOrUnitLowerTriangular, UnitUpperOrUnitLowerTriangular
 
-check_uplo(::Any, A1, A2) = false
-check_uplo(::typeof{==}, A1::UpperOrUnitUpperTriangular, A2::UpperOrUnitUpperTriangular) = true
-check_uplo(::typeof{==}, A1::LowerOrUnitLowerTriangular, A2::LowerOrUnitLowerTriangular) = true
-check_uplo(::typeof{!=}, A1::UpperOrUnitUpperTriangular, A2::LowerOrUnitLowerTriangular) = true
-check_uplo(::typeof{!=}, A1::LowerOrUnitLowerTriangular, A2::UpperOrUnitUpperTriangular) = true
+check_uplo(::Any, ::Any, ::Any) = false
+check_uplo(::typeof(==), ::UpperOrUnitUpperTriangular, ::UpperOrUnitUpperTriangular) = true
+check_uplo(::typeof(==), ::LowerOrUnitLowerTriangular, ::LowerOrUnitLowerTriangular) = true
+check_uplo(::typeof(!=), ::UpperOrUnitUpperTriangular, ::LowerOrUnitLowerTriangular) = true
+check_uplo(::typeof(!=), ::LowerOrUnitLowerTriangular, ::UpperOrUnitUpperTriangular) = true
 
 # The following test block tries to call all methods in base/linalg/triangular.jl in order for a combination of input element types. Keep the ordering when adding code.
 function test_triangular(elty1_types)
@@ -24,18 +24,18 @@ function test_triangular(elty1_types)
             A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo1 === :U ? t : copy(t')))
             M1 = Matrix(A1)
             @test t1(A1) === A1
-            @test t1{elty1}(A1) === A1
+            @test t1{eltype(A1)}(A1) === A1
             # test the ctor works for AbstractMatrix
             symm = Symmetric(rand(Int8, n, n))
-            t1s = t1{elty1}(symm)
-            @test typeof(t1s) == t1{elty1,Symmetric{elty1,Matrix{elty1}}}
-            t1t = t1{elty1}(t1(rand(Int8, n, n)))
-            @test typeof(t1t) == t1{elty1,Matrix{elty1}}
+            t1s = t1{eltype(A1)}(symm)
+            @test typeof(t1s) == t1{eltype(A1),Symmetric{eltype(A1),Matrix{eltype(A1)}}}
+            t1t = t1{eltype(A1)}(t1(rand(Int8, n, n)))
+            @test typeof(t1t) == t1{eltype(A1),Matrix{eltype(A1)}}
 
             # Convert
-            @test convert(AbstractMatrix{elty1}, A1) == A1
+            @test convert(AbstractMatrix{eltype(A1)}, A1) == A1
             @test convert(Matrix, A1) == A1
-            @test t1{elty1}(convert(AbstractMatrix{elty1}, A1)) == A1
+            @test t1{eltype(A1)}(convert(AbstractMatrix{eltype(A1)}, A1)) == A1
 
             # full!
             @test full!(copy(A1)) == A1
@@ -47,7 +47,7 @@ function test_triangular(elty1_types)
             simA1Int = similar(A1, Int)
             @test isa(simA1Int, t1)
             @test eltype(simA1Int) == Int
-            @test isa(similar(A1, (3, 2)), Matrix{elty1})
+            @test isa(similar(A1, (3, 2)), Matrix{eltype(A1)})
             @test isa(similar(A1, Int, (3, 2)), Matrix{Int})
 
             #copyto!
@@ -186,7 +186,7 @@ function test_triangular(elty1_types)
             @test diag(A1) == diagview(M1)
 
             # tr
-            @test tr(A1)::elty1 == tr(M1)
+            @test tr(A1)::eltype(A1) == tr(M1)
 
             # real
             @test real(A1) == real(M1)
@@ -225,7 +225,7 @@ function test_triangular(elty1_types)
             end
 
             #exp/log
-            if elty1 ∈ (Float32, Float64, ComplexF32, ComplexF64)
+            if eltype(A1) ∈ (Float32, Float64, ComplexF32, ComplexF64)
                 @test exp(Matrix(log(A1))) ≈ A1
             end
 
@@ -238,7 +238,7 @@ function test_triangular(elty1_types)
                     cr = 0.5
                 end
                 ci = cr * im
-                if elty1 <: Real
+                if eltype(A1) <: Real
                     A1tmp = copy(A1)
                     rmul!(A1tmp, cr)
                     @test A1tmp == cr * A1
@@ -272,9 +272,9 @@ function test_triangular(elty1_types)
 
             # generalized dot
             for eltyb in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFloat})
-                b1 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1) * fill(1.0, n))
-                b2 = convert(Vector{eltyb}, (elty1 <: Complex ? real(A1) : A1) * randn(n))
-                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2) atol = sqrt(max(eps(real(float(one(elty1)))), eps(real(float(one(eltyb)))))) * n * n
+                b1 = convert(Vector{eltyb}, (eltype(A1) <: Complex ? real(A1) : A1) * fill(1.0, n))
+                b2 = convert(Vector{eltyb}, (eltype(A1) <: Complex ? real(A1) : A1) * randn(n))
+                @test dot(b1, A1, b2) ≈ dot(A1'b1, b2) atol = sqrt(max(eps(real(float(one(eltype(A1))))), eps(real(float(one(eltyb)))))) * n * n
             end
 
             # Binary operations
@@ -290,44 +290,44 @@ function test_triangular(elty1_types)
             @test invA1 ≈ inv(M1) # issue #11298
             @test isa(invA1, t1)
             # make sure the call to LAPACK works right
-            if elty1 <: BlasFloat
-                @test LinearAlgebra.inv!(copy(A1)) ≈ inv(M1lu)
+            if eltype(A1) <: BlasFloat
+                @test LinearAlgebra.inv!(copy(A1)) ≈ inv(lu(M1))
             end
 
             # Determinant
             M1lu = lu(M1lu)
-            @test det(A1) ≈ det(M1lu) atol = sqrt(eps(real(float(one(elty1))))) * n * n
-            @test logdet(A1) ≈ logdet(M1lu) atol = sqrt(eps(real(float(one(elty1))))) * n * n
+            @test det(A1) ≈ det(M1lu) atol = sqrt(eps(real(float(one(eltype(A1)))))) * n * n
+            @test logdet(A1) ≈ logdet(M1lu) atol = sqrt(eps(real(float(one(eltype(A1)))))) * n * n
             lada, ladb = logabsdet(A1)
             flada, fladb = logabsdet(M1lu)
-            @test lada ≈ flada atol = sqrt(eps(real(float(one(elty1))))) * n * n
-            @test ladb ≈ fladb atol = sqrt(eps(real(float(one(elty1))))) * n * n
+            @test lada ≈ flada atol = sqrt(eps(real(float(one(eltype(A1)))))) * n * n
+            @test ladb ≈ fladb atol = sqrt(eps(real(float(one(eltype(A1)))))) * n * n
 
             # Matrix square root
             @test sqrt(A1) |> (t -> (t * t)::typeof(t)) ≈ A1
 
             # naivesub errors
-            @test_throws DimensionMismatch ldiv!(A1, Vector{elty1}(undef, n + 1))
+            @test_throws DimensionMismatch ldiv!(A1, Vector{eltype(A1)}(undef, n + 1))
 
             # eigenproblems
-            if !(elty1 in (BigFloat, Complex{BigFloat})) # Not handled yet
+            if !(eltype(A1) in (BigFloat, Complex{BigFloat})) # Not handled yet
                 vals, vecs = eigen(A1)
-                if (A1 isa UpperTriangular || A1 isa LowerTriangular) && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
+                if (A1 isa UpperTriangular || A1 isa LowerTriangular) && eltype(A1) != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
                     @test vecs * Diagonal(vals) ≈ A1 * vecs atol = sqrt(eps(float(real(one(vals[1]))))) * (opnorm(A1, Inf) * n)^2
                 end
             end
 
             # Condition number tests - can be VERY approximate
-            if elty1 <: BlasFloat
+            if eltype(A1) <: BlasFloat
                 for p in (1.0, Inf)
                     @test cond(A1, p) ≈ cond(A1, p) atol = (cond(A1, p) + cond(A1, p))
                 end
                 @test cond(A1, 2) == cond(M1, 2)
             end
 
-            if !(elty1 in (BigFloat, Complex{BigFloat})) # Not implemented yet
+            if !(eltype(A1) in (BigFloat, Complex{BigFloat})) # Not implemented yet
                 svd(A1)
-                elty1 <: BlasFloat && svd!(copy(A1))
+                eltype(A1) <: BlasFloat && svd!(copy(A1))
                 svdvals(A1)
             end
 
@@ -336,10 +336,10 @@ function test_triangular(elty1_types)
             @test ((A1 \ A1)::t1) ≈ M1 \ M1
 
             # Begin loop for second Triangular matrix
-            @testset for elty2 in push!(Set((ComplexF32, Int)), elty1)
+            @testset for elty2 in push!(Set((ComplexF32, Int)), eltype(A1))
                 # Only test methods for the same element type and a single combination of mixed element types
                 # to avoid too much compilation
-                if elty1 ∉ (elty2, ComplexF32, Int)
+                if eltype(A1) ∉ (elty2, ComplexF32, Int)
                     continue
                 end
                 @testset for (t2, uplo2) in ((UpperTriangular, :U),
@@ -350,10 +350,10 @@ function test_triangular(elty1_types)
                     A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo2 === :U ? t : copy(t')))
                     M2 = Matrix(A2)
                     # Convert
-                    if elty1 <: Real && !(elty2 <: Integer)
-                        @test convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
-                    elseif elty2 <: Real && !(elty1 <: Integer)
-                        @test_throws InexactError convert(AbstractMatrix{elty2}, A1) == t1(convert(Matrix{elty2}, A1.data))
+                    if eltype(A1) <: Real && !(eltype(A2) <: Integer)
+                        @test convert(AbstractMatrix{eltype(A2)}, A1) == t1(convert(Matrix{eltype(A2)}, A1.data))
+                    elseif eltype(A2) <: Real && !(eltype(A1) <: Integer)
+                        @test_throws InexactError convert(AbstractMatrix{eltype(A2)}, A1) == t1(convert(Matrix{eltype(A2)}, A1.data))
                     end
 
                     # Binary operations
@@ -434,20 +434,20 @@ function test_triangular(elty1_types)
                 end
             end
 
-            @testset for eltyB in push!(Set((ComplexF32,)), elty1)
+            @testset for eltyB in push!(Set((ComplexF32,)), eltype(A1))
                 # Only test methods for the same element type and a single combination of mixed element types
                 # to avoid too much compilation
-                if elty1 ∉ (eltyB, ComplexF32, Int)
+                if eltype(A1) ∉ (eltyB, ComplexF32, Int)
                     continue
                 end
 
-                B = convert(Matrix{eltyB}, (elty1 <: Complex ? real(A1) : A1) * fill(1.0, n, n))
+                B = convert(Matrix{eltyB}, (eltype(A1) <: Complex ? real(A1) : A1) * fill(1.0, n, n))
 
-                Tri = Tridiagonal(rand(eltyB, n - 1), rand(eltyB, n), rand(eltyB, n - 1))
-                C = Matrix{promote_type(elty1, eltyB)}(undef, n, n)
+                Tri = Tridiagonal(rand(eltype(B), n - 1), rand(eltype(B), n), rand(eltype(B), n - 1))
+                C = Matrix{promote_type(eltype(A1), eltype(B))}(undef, n, n)
                 mul!(C, Tri, A1)
                 @test C ≈ Tri * M1
-                Tri = Tridiagonal(rand(eltyB, n - 1), rand(eltyB, n), rand(eltyB, n - 1))
+                Tri = Tridiagonal(rand(eltype(B), n - 1), rand(eltype(B), n), rand(eltype(B), n - 1))
                 mul!(C, A1, Tri)
                 @test C ≈ M1 * Tri
 
@@ -496,7 +496,7 @@ function test_triangular(elty1_types)
                     @test mul!(bcol1sim, transpose(A1), bcol1) ≈ transpose(M1) * bcol1
                 end
                 #error handling
-                Ann, Bmm, bm = A1, Matrix{eltyB}(undef, n + 1, n + 1), Vector{eltyB}(undef, n + 1)
+                Ann, Bmm, bm = A1, Matrix{eltype(B)}(undef, n + 1, n + 1), Vector{eltype(B)}(undef, n + 1)
                 @test_throws DimensionMismatch lmul!(Ann, bm)
                 @test_throws DimensionMismatch rmul!(Bmm, Ann)
                 @test_throws DimensionMismatch lmul!(transpose(Ann), bm)
@@ -515,12 +515,12 @@ function test_triangular(elty1_types)
                 @test A1 \ B' ≈ M1 \ B'
                 @test transpose(A1) \ transpose(B) ≈ transpose(M1) \ transpose(B)
                 @test A1' \ B' ≈ M1' \ B'
-                Ann, bm = A1, Vector{elty1}(undef, n + 1)
+                Ann, bm = A1, Vector{eltype(A1)}(undef, n + 1)
                 @test_throws DimensionMismatch Ann \ bm
                 @test_throws DimensionMismatch Ann' \ bm
                 @test_throws DimensionMismatch transpose(Ann) \ bm
                 if A1 isa UpperTriangular || A1 isa LowerTriangular
-                    @test_throws SingularException ldiv!(t1(zeros(elty1, n, n)), fill(eltyB(1), n))
+                    @test_throws SingularException ldiv!(t1(zeros(eltype(A1), n, n)), fill(eltype(B)(1), n))
                 end
                 @test B / A1 ≈ B / M1
                 @test B / transpose(A1) ≈ B / transpose(M1)
@@ -531,7 +531,7 @@ function test_triangular(elty1_types)
                 @test B' / A1' ≈ B' / M1'
 
                 # Error bounds
-                !(elty1 in (BigFloat, Complex{BigFloat})) && !(eltyB in (BigFloat, Complex{BigFloat})) && errorbounds(A1, A1 \ B, B)
+                !(eltype(A1) in (BigFloat, Complex{BigFloat})) && !(eltype(B) in (BigFloat, Complex{BigFloat})) && errorbounds(A1, A1 \ B, B)
             end
         end
     end

--- a/test/triangular2.jl
+++ b/test/triangular2.jl
@@ -2,8 +2,7 @@
 
 module TestTriangularReal
 
-using Test, LinearAlgebra, Random
-using LinearAlgebra: BlasFloat, errorbounds, full!, transpose!
+using Random
 
 Random.seed!(123)
 

--- a/test/triangular3.jl
+++ b/test/triangular3.jl
@@ -2,8 +2,7 @@
 
 module TestTriangularComplex
 
-using Test, LinearAlgebra, Random
-using LinearAlgebra: BlasFloat, errorbounds, full!, transpose!
+using Random
 
 Random.seed!(123)
 


### PR DESCRIPTION
This makes it easier to run the tests without referring to global variables. The main change is, instead of checking types as `t1 == UpperTriangular`, we use `A1 isa UpperTriangular`. This often makes a section of code easier to reason about, as it uses `A1` in the following function calls.