### PR TITLE
Symmetry check in `setindex!` for `Symmetric`/`Hermitian`

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -229,12 +229,6 @@ const SelfAdjoint = Union{Symmetric{<:Real}, Hermitian{<:Number}}
 wrappertype(::Union{Symmetric, SymTridiagonal}) = Symmetric
 wrappertype(::Hermitian) = Hermitian
 
-_symherm_wrapperop(::Symmetric) = symmetric
-_symherm_wrapperop(::Hermitian) = hermitian
-
-_conjugation(::Symmetric) = transpose
-_conjugation(::Hermitian) = adjoint
-
 size(A::HermOrSym) = size(A.data)
 axes(A::HermOrSym) = axes(A.data)
 @inline function Base.isassigned(A::HermOrSym, i::Int, j::Int)
@@ -294,6 +288,9 @@ end
 Base.dataids(A::HermOrSym) = Base.dataids(parent(A))
 Base.unaliascopy(A::Hermitian) = Hermitian(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 Base.unaliascopy(A::Symmetric) = Symmetric(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
+
+_conjugation(::Symmetric) = transpose
+_conjugation(::Hermitian) = adjoint
 
 diag(A::Symmetric) = symmetric.(diag(parent(A)), sym_uplo(A.uplo))
 diag(A::Hermitian) = hermitian.(diag(parent(A)), sym_uplo(A.uplo))

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1180,4 +1180,15 @@ end
     end
 end
 
+@testset "block-symmetric setindex!" begin
+    A = fill([1 2; 3 4], 2, 2)
+    v = [1 2; 3 4]
+    H = Hermitian(A)
+    h_msg = "cannot set a diagonal element of a hermitian matrix to a non-hermitian value"
+    @test_throws h_msg H[1,1] = v
+    S = Symmetric(A)
+    s_msg = "cannot set a diagonal element of a symmetric matrix to an asymmetric value"
+    @test_throws s_msg S[1,1] = v
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
Currently, the following works unexpectedly:
```julia
julia> A = Symmetric(fill([1 2; 3 4], 3, 3))
3×3 Symmetric{AbstractMatrix, Matrix{Matrix{Int64}}}:
 [1 2; 2 4]  [1 2; 3 4]  [1 2; 3 4]
 [1 3; 2 4]  [1 2; 2 4]  [1 2; 3 4]
 [1 3; 2 4]  [1 3; 2 4]  [1 2; 2 4]

julia> A[1,1] = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> A[1,1]
2×2 Symmetric{Int64, Matrix{Int64}}:
 1  2
 2  4
```
After this PR, the `setindex!` throws an error if the exact value cannot be used:
```julia
julia> A[1,1] = [1 2; 3 4]
ERROR: ArgumentError: cannot set a diagonal element of a symmetric matrix to an asymmetric value
```