### PR TITLE
Out-of-place `triu`/`tril` for `Symmetric` in each branch

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -332,6 +332,10 @@ wrapperop(::Transpose) = transpose
 _wrapperop(x) = wrapperop(x)
 _wrapperop(::Adjoint{<:Real}) = transpose
 
+# equivalent to wrapperop, but returns the type of the wrapper
+wrappertype(::Adjoint) = Adjoint
+wrappertype(::Transpose) = Transpose
+
 # the following fallbacks can be removed if Adjoint/Transpose are restricted to AbstractVecOrMat
 size(A::AdjOrTrans) = reverse(size(A.parent))
 axes(A::AdjOrTrans) = reverse(axes(A.parent))
@@ -391,7 +395,7 @@ similar(A::AdjOrTrans, ::Type{T}) where {T} = similar(A.parent, T, axes(A))
 similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent, T, dims)
 
 # AbstractMatrix{T} constructor for adjtrans vector: preserve wrapped type
-AbstractMatrix{T}(A::AdjOrTransAbsVec) where {T} = wrapperop(A)(AbstractVector{T}(A.parent))
+AbstractMatrix{T}(A::AdjOrTransAbsVec) where {T} = wrappertype(A)(AbstractVector{T}(A.parent))
 
 # sundry basic definitions
 parent(A::AdjOrTrans) = A.parent

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -332,10 +332,6 @@ wrapperop(::Transpose) = transpose
 _wrapperop(x) = wrapperop(x)
 _wrapperop(::Adjoint{<:Real}) = transpose
 
-# equivalent to wrapperop, but returns the type of the wrapper
-wrappertype(::Adjoint) = Adjoint
-wrappertype(::Transpose) = Transpose
-
 # the following fallbacks can be removed if Adjoint/Transpose are restricted to AbstractVecOrMat
 size(A::AdjOrTrans) = reverse(size(A.parent))
 axes(A::AdjOrTrans) = reverse(axes(A.parent))
@@ -395,7 +391,7 @@ similar(A::AdjOrTrans, ::Type{T}) where {T} = similar(A.parent, T, axes(A))
 similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent, T, dims)
 
 # AbstractMatrix{T} constructor for adjtrans vector: preserve wrapped type
-AbstractMatrix{T}(A::AdjOrTransAbsVec) where {T} = wrappertype(A)(AbstractVector{T}(A.parent))
+AbstractMatrix{T}(A::AdjOrTransAbsVec) where {T} = wrapperop(A)(AbstractVector{T}(A.parent))
 
 # sundry basic definitions
 parent(A::AdjOrTrans) = A.parent

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -332,7 +332,7 @@ Base.dataids(A::HermOrSym) = Base.dataids(parent(A))
 Base.unaliascopy(A::Hermitian) = Hermitian(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 Base.unaliascopy(A::Symmetric) = Symmetric(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 
-_conjugation(::Union{Symmetric, Hermitian{<:Real}}) = transpose
+_conjugation(::Symmetric) = transpose
 _conjugation(::Hermitian) = adjoint
 
 diag(A::Symmetric) = symmetric.(diag(parent(A)), sym_uplo(A.uplo))

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -332,7 +332,7 @@ Base.dataids(A::HermOrSym) = Base.dataids(parent(A))
 Base.unaliascopy(A::Hermitian) = Hermitian(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 Base.unaliascopy(A::Symmetric) = Symmetric(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 
-_conjugation(::Symmetric) = transpose
+_conjugation(::Union{Symmetric, Hermitian{<:Real}}) = transpose
 _conjugation(::Hermitian) = adjoint
 
 diag(A::Symmetric) = symmetric.(diag(parent(A)), sym_uplo(A.uplo))

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -520,25 +520,25 @@ Base.conj!(A::HermOrSym) = typeof(A)(parentof_applytri(conj!, A), A.uplo)
 # tril/triu
 function tril(A::Hermitian, k::Integer=0)
     if A.uplo == 'U' && k <= 0
-        return tril!(copy(A.data'),k)
+        return tril_maybe_inplace(copy(A.data'),k)
     elseif A.uplo == 'U' && k > 0
-        return tril!(copy(A.data'),-1) + tril!(triu(A.data),k)
+        return tril_maybe_inplace(copy(A.data'),-1) + tril_maybe_inplace(triu(A.data),k)
     elseif A.uplo == 'L' && k <= 0
         return tril(A.data,k)
     else
-        return tril(A.data,-1) + tril!(triu!(copy(A.data')),k)
+        return tril(A.data,-1) + tril_maybe_inplace(triu_maybe_inplace(copy(A.data')),k)
     end
 end
 
 function tril(A::Symmetric, k::Integer=0)
     if A.uplo == 'U' && k <= 0
-        return tril!(copy(transpose(A.data)),k)
+        return tril_maybe_inplace(copy(transpose(A.data)),k)
     elseif A.uplo == 'U' && k > 0
-        return tril!(copy(transpose(A.data)),-1) + tril!(triu(A.data),k)
+        return tril_maybe_inplace(copy(transpose(A.data)),-1) + tril_maybe_inplace(triu(A.data),k)
     elseif A.uplo == 'L' && k <= 0
         return tril(A.data,k)
     else
-        return tril(A.data,-1) + tril!(triu!(copy(transpose(A.data))),k)
+        return tril(A.data,-1) + tril_maybe_inplace(triu_maybe_inplace(copy(transpose(A.data))),k)
     end
 end
 
@@ -546,11 +546,11 @@ function triu(A::Hermitian, k::Integer=0)
     if A.uplo == 'U' && k >= 0
         return triu(A.data,k)
     elseif A.uplo == 'U' && k < 0
-        return triu(A.data,1) + triu!(tril!(copy(A.data')),k)
+        return triu(A.data,1) + triu_maybe_inplace(tril_maybe_inplace(copy(A.data')),k)
     elseif A.uplo == 'L' && k >= 0
-        return triu!(copy(A.data'),k)
+        return triu_maybe_inplace(copy(A.data'),k)
     else
-        return triu!(copy(A.data'),1) + triu!(tril(A.data),k)
+        return triu_maybe_inplace(copy(A.data'),1) + triu_maybe_inplace(tril(A.data),k)
     end
 end
 
@@ -558,11 +558,11 @@ function triu(A::Symmetric, k::Integer=0)
     if A.uplo == 'U' && k >= 0
         return triu(A.data,k)
     elseif A.uplo == 'U' && k < 0
-        return triu(A.data,1) + triu!(tril!(copy(transpose(A.data))),k)
+        return triu(A.data,1) + triu_maybe_inplace(tril_maybe_inplace(copy(transpose(A.data))),k)
     elseif A.uplo == 'L' && k >= 0
-        return triu!(copy(transpose(A.data)),k)
+        return triu_maybe_inplace(copy(transpose(A.data)),k)
     else
-        return triu!(copy(transpose(A.data)),1) + triu!(tril(A.data),k)
+        return triu_maybe_inplace(copy(transpose(A.data)),1) + triu_maybe_inplace(tril(A.data),k)
     end
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -530,6 +530,11 @@ function tril!(A::UnitLowerTriangular, k::Integer=0)
     return tril!(LowerTriangular(A.data), k)
 end
 
+tril_maybe_inplace(A, k::Integer=0) = tril(A, k)
+triu_maybe_inplace(A, k::Integer=0) = triu(A, k)
+tril_maybe_inplace(A::StridedMatrix, k::Integer=0) = tril!(A, k)
+triu_maybe_inplace(A::StridedMatrix, k::Integer=0) = triu!(A, k)
+
 adjoint(A::LowerTriangular) = UpperTriangular(adjoint(A.data))
 adjoint(A::UpperTriangular) = LowerTriangular(adjoint(A.data))
 adjoint(A::UnitLowerTriangular) = UnitUpperTriangular(adjoint(A.data))

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1351,16 +1351,7 @@ end
 end
 
 @testset "triu/tril with immutable arrays" begin
-    struct ImmutableMatrix{T,A<:AbstractMatrix{T}} <: AbstractMatrix{T}
-        a :: A
-    end
-    Base.size(A::ImmutableMatrix) = size(A.a)
-    Base.getindex(A::ImmutableMatrix, i::Int, j::Int) = getindex(A.a, i, j)
-    Base.copy(A::ImmutableMatrix) = A
-    LinearAlgebra.adjoint(A::ImmutableMatrix) = ImmutableMatrix(adjoint(A.a))
-    LinearAlgebra.transpose(A::ImmutableMatrix) = ImmutableMatrix(transpose(A.a))
-
-    A = ImmutableMatrix([1 2; 3 4])
+    A = ImmutableArray([1 2; 3 4])
     for T in (Symmetric, Hermitian), uplo in (:U, :L)
         H = T(A, uplo)
         MH = Matrix(H)

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1350,4 +1350,27 @@ end
     @test LinearAlgebra.uplo(H) == :L
 end
 
+@testset "triu/tril with immutable arrays" begin
+    struct ImmutableMatrix{T,A<:AbstractMatrix{T}} <: AbstractMatrix{T}
+        a :: A
+    end
+    Base.size(A::ImmutableMatrix) = size(A.a)
+    Base.getindex(A::ImmutableMatrix, i::Int, j::Int) = getindex(A.a, i, j)
+    Base.copy(A::ImmutableMatrix) = A
+    LinearAlgebra.adjoint(A::ImmutableMatrix) = ImmutableMatrix(adjoint(A.a))
+    LinearAlgebra.transpose(A::ImmutableMatrix) = ImmutableMatrix(transpose(A.a))
+
+    A = ImmutableMatrix([1 2; 3 4])
+    for T in (Symmetric, Hermitian), uplo in (:U, :L)
+        H = T(A, uplo)
+        MH = Matrix(H)
+        @test triu(H,-1) == triu(MH,-1)
+        @test triu(H) == triu(MH)
+        @test triu(H,1) == triu(MH,1)
+        @test tril(H,1) == tril(MH,1)
+        @test tril(H) == tril(MH)
+        @test tril(H,-1) == tril(MH,-1)
+    end
+end
+
 end # module TestSymmetric

--- a/test/testhelpers/ImmutableArrays.jl
+++ b/test/testhelpers/ImmutableArrays.jl
@@ -28,4 +28,7 @@ AbstractArray{T,N}(A::ImmutableArray{S,N}) where {S,T,N} = ImmutableArray(Abstra
 Base.copy(A::ImmutableArray) = ImmutableArray(copy(A.data))
 Base.zero(A::ImmutableArray) = ImmutableArray(zero(A.data))
 
+Base.adjoint(A::ImmutableArray) = ImmutableArray(adjoint(A.data))
+Base.transpose(A::ImmutableArray) = ImmutableArray(transpose(A.data))
+
 end


### PR DESCRIPTION
In `tril`/`triu` for `Symmetric`/`Hermitian`, we should use the out-of-place variants in each branch, unless we're sure that the array may be mutated. Currently, this is only for `StridedArray`s, in which case we may perform some of the operations in-place.

Fixes issues like
```julia
julia> S = @SMatrix [1 2; 3 4]
2×2 SMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  2
 3  4

julia> H = Hermitian(S)
2×2 Hermitian{Int64, SMatrix{2, 2, Int64, 4}} with indices SOneTo(2)×SOneTo(2):
 1  2
 2  4

julia> triu(H,-1)
ERROR: setindex!(::SMatrix{2, 2, Int64, 4}, value, ::Int) is not defined.
 Hint: Use `MArray` or `SizedArray` to create a mutable static array
```
After this PR, this operation would work:
```julia
julia> triu(H,-1)
2×2 MMatrix{2, 2, Int64, 4} with indices SOneTo(2)×SOneTo(2):
 1  2
 2  4
```