### PR TITLE
`Hermitian{<:Real}` and `Symmetric` share conjugation

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -289,7 +289,7 @@ Base.dataids(A::HermOrSym) = Base.dataids(parent(A))
 Base.unaliascopy(A::Hermitian) = Hermitian(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 Base.unaliascopy(A::Symmetric) = Symmetric(Base.unaliascopy(parent(A)), sym_uplo(A.uplo))
 
-_conjugation(::Symmetric) = transpose
+_conjugation(::Union{Symmetric, Hermitian{<:Real}}) = transpose
 _conjugation(::Hermitian) = adjoint
 
 diag(A::Symmetric) = symmetric.(diag(parent(A)), sym_uplo(A.uplo))


### PR DESCRIPTION
Currently, we use a helper function `_conjugation` that produces `transpose` for `Symmetric` and `adjoint` for `Hermitian`. In this PR, we change this to produce `transpose` for real `Hermitian` matrices as well, as these should be equivalent. This improves the TTSX (time to second run) of `applytri`, as the function does not need to be recompiled.
```julia
julia> using LinearAlgebra

julia> A = [1 2; 3 4];

julia> S = Symmetric(A);

julia> @time S + S; # first run
  0.282624 seconds (608.83 k allocations: 31.942 MiB, 99.98% compilation time) # nightly 
  0.285233 seconds (608.83 k allocations: 31.925 MiB, 99.98% compilation time) # this PR

julia> H = Hermitian(A);

julia> @time H + H; # second run
  0.197709 seconds (309.42 k allocations: 16.395 MiB, 6.39% gc time, 99.97% compilation time) # nightly
  0.063034 seconds (48.90 k allocations: 2.900 MiB, 99.91% compilation time) # this PR
```