### PR TITLE
add missing methods for division of Hessenberg matrices

### DIFF
--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -66,6 +66,12 @@ let n = 10
         H = UpperHessenberg(Areal)
         @test Array(Hc + H) == Array(Hc) + Array(H)
         @test Array(Hc - H) == Array(Hc) - Array(H)
+        @testset "ldiv and rdiv" begin
+            for b in (b_, B_), H in (H, Hc, H', Hc', transpose(Hc))
+                @test H * (H \ b) ≈ b
+                @test (b' / H) * H ≈ (Matrix(b') / H) * H ≈ b'
+            end
+        end
         @testset "Preserve UpperHessenberg shape (issue #39388)" begin
             H = UpperHessenberg(Areal)
             A = rand(n,n)

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -70,6 +70,7 @@ let n = 10
             for b in (b_, B_), H in (H, Hc, H', Hc', transpose(Hc))
                 @test H * (H \ b) ≈ b
                 @test (b' / H) * H ≈ (Matrix(b') / H) * H ≈ b'
+                @test (transpose(b) / H) * H ≈ (Matrix(transpose(b)) / H) * H ≈ transpose(b)
             end
         end
         @testset "Preserve UpperHessenberg shape (issue #39388)" begin


### PR DESCRIPTION
As noted [on discourse](https://discourse.julialang.org/t/add-a-upperhessenberg-row-in-linearalgebra-factorize/128530/4?u=stevengj), we were missing `/` and `\` methods for `UpperHessenberg` matrices, despite the existence of optimized `ldiv!` and `rdiv!` methods, so it was falling back to slow $O(n^3)$ methods.

While I was at it, I also added methods for transpose/adjoint Hessenberg matrices.