### PR TITLE
Change the implementation of `rotate!` to avoid unary minus

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1726,7 +1726,7 @@ end
 """
     rotate!(x, y, c, s)
 
-Overwrite `x` with `c*x + s*y` and `y` with `-conj(s)*x + c*y`.
+Overwrite `x` with `s*y + c*x` and `y` with `c*y - conj(s)*x`.
 Returns `x` and `y`.
 
 !!! compat "Julia 1.5"
@@ -1741,8 +1741,8 @@ function rotate!(x::AbstractVector, y::AbstractVector, c, s)
     for i in eachindex(x,y)
         @inbounds begin
             xi, yi = x[i], y[i]
-            x[i] =       c *xi + s*yi
-            y[i] = -conj(s)*xi + c*yi
+            x[i] = s*yi +      c *xi
+            y[i] = c*yi - conj(s)*xi 
         end
     end
     return x, y


### PR DESCRIPTION
The current implementation of `rotate!(x, y, c, s)` overwrites `x` with `c*x + s*y` and `y` with `-conj(s)*x + c*y`. There exists this edge case of `rotate!([NaN], [NaN], false, false)` 
```julia
julia> rotate!([NaN], [NaN], false, false)
([0.0], [NaN])
```
The new `x` becomes `0.0`, because `false` acts as a ["strong zero" in Julia](https://docs.julialang.org/en/v1/manual/mathematical-operations/#Arithmetic-Operators) (so `false * NaN == 0.0`). When calculating the new `y`, the code executes `-conj(false)*NaN + false*NaN`. However, the unary minus, `-`, turns the `false::Bool` to `0::Int`, which is no longer a strong zero, and thus, we get `NaN`. This is inconsistent with
```julia
julia> reflect!([NaN], [NaN], false, false)
([0.0], [0.0])
```
This PR changes `-conj(s)*x + c*y` to `c*y - conj(s)*x` to avoid unary minus, so that
```julia
julia> rotate!([NaN], [NaN], false, false) # This PR
([0.0], [0.0])
```
I noted this from https://github.com/JuliaGPU/CUDA.jl/issues/2607#issuecomment-2573015555. More discussion in https://discourse.julialang.org/t/negative-false-no-longer-acts-as-a-strong-zero/128506/1