### PR TITLE
Require square matrices in UpperHessenberg

### DIFF
--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -46,6 +46,7 @@ struct UpperHessenberg{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
 
     function UpperHessenberg{T,S}(data) where {T,S<:AbstractMatrix{T}}
         require_one_based_indexing(data)
+        checksquare(data)
         new{T,S}(data)
     end
 end


### PR DESCRIPTION
Since an `UpperHessenberg` matrix is square, we may require this condition in the constructor. Currently, this accepts a rectangular parent as well.