### PR TITLE
Change constructions to assertions in structured broadcast tests

### DIFF
--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -137,13 +137,13 @@ end
         ◥ = UpperTriangular(rand(N,N))
         M = Matrix(rand(N,N))
 
-        @test broadcast!(sin, copy(D), D) == sin.(D)::Diagonal
-        @test broadcast!(sin, copy(Bu), Bu) == sin.(Bu)::Bidiagonal
-        @test broadcast!(sin, copy(Bl), Bl) == sin.(Bl)::Bidiagonal
-        @test broadcast!(sin, copy(T), T) == sin.(T)::Tridiagonal
-        @test broadcast!(sin, copy(◣), ◣) == sin.(◣)::LowerTriangular
-        @test broadcast!(sin, copy(◥), ◥) == sin.(◥)::UpperTriangular
-        @test broadcast!(sin, copy(M), M) == sin.(M)::Matrix
+        @test broadcast!(sin, copy(D), D)::Diagonal == sin.(D)::Diagonal
+        @test broadcast!(sin, copy(Bu), Bu)::Bidiagonal == sin.(Bu)::Bidiagonal
+        @test broadcast!(sin, copy(Bl), Bl)::Bidiagonal == sin.(Bl)::Bidiagonal
+        @test broadcast!(sin, copy(T), T)::Tridiagonal == sin.(T)::Tridiagonal
+        @test broadcast!(sin, copy(◣), ◣)::LowerTriangular == sin.(◣)::LowerTriangular
+        @test broadcast!(sin, copy(◥), ◥)::UpperTriangular == sin.(◥)::UpperTriangular
+        @test broadcast!(sin, copy(M), M)::Matrix == sin.(M)::Matrix
         @test broadcast!(*, copy(D), D, A) == Diagonal(broadcast(*, D, A))
         @test broadcast!(*, copy(Bu), Bu, A) == Bidiagonal(broadcast(*, Bu, A), :U)
         @test broadcast!(*, copy(Bl), Bl, A) == Bidiagonal(broadcast(*, Bl, A), :L)

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -137,13 +137,13 @@ end
         ◥ = UpperTriangular(rand(N,N))
         M = Matrix(rand(N,N))
 
-        @test broadcast!(sin, copy(D), D) == Diagonal(sin.(D))
-        @test broadcast!(sin, copy(Bu), Bu) == Bidiagonal(sin.(Bu), :U)
-        @test broadcast!(sin, copy(Bl), Bl) == Bidiagonal(sin.(Bl), :L)
-        @test broadcast!(sin, copy(T), T) == Tridiagonal(sin.(T))
-        @test broadcast!(sin, copy(◣), ◣) == LowerTriangular(sin.(◣))
-        @test broadcast!(sin, copy(◥), ◥) == UpperTriangular(sin.(◥))
-        @test broadcast!(sin, copy(M), M) == Matrix(sin.(M))
+        @test broadcast!(sin, copy(D), D) == sin.(D)::Diagonal
+        @test broadcast!(sin, copy(Bu), Bu) == sin.(Bu)::Bidiagonal
+        @test broadcast!(sin, copy(Bl), Bl) == sin.(Bl)::Bidiagonal
+        @test broadcast!(sin, copy(T), T) == sin.(T)::Tridiagonal
+        @test broadcast!(sin, copy(◣), ◣) == sin.(◣)::LowerTriangular
+        @test broadcast!(sin, copy(◥), ◥) == sin.(◥)::UpperTriangular
+        @test broadcast!(sin, copy(M), M) == sin.(M)::Matrix
         @test broadcast!(*, copy(D), D, A) == Diagonal(broadcast(*, D, A))
         @test broadcast!(*, copy(Bu), Bu, A) == Bidiagonal(broadcast(*, Bu, A), :U)
         @test broadcast!(*, copy(Bl), Bl, A) == Bidiagonal(broadcast(*, Bl, A), :L)


### PR DESCRIPTION
The broadcast operation should already be returning the correct type, and we may type-assert the result instead of constructing an instance from it.