### PR TITLE
Document SingularException throw for inv(::AbstractMatrix)

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1152,6 +1152,8 @@ Matrix inverse. Computes matrix `N` such that
 Computed by solving the left-division
 `N = M \\ I`.
 
+A [`SingularException`](@ref) is thrown if `M` fails to be numerically inverted.
+
 # Examples
 ```jldoctest
 julia> M = [2 5; 1 3]

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1152,7 +1152,7 @@ Matrix inverse. Computes matrix `N` such that
 Computed by solving the left-division
 `N = M \\ I`.
 
-A [`SingularException`](@ref) is thrown if `M` fails to be numerically inverted.
+A [`SingularException`](@ref) is thrown if `M` fails numerical inversion.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I suggest documenting that `inv(::AbstractMatrix)` throws on (numerically) singular matrices, this is different from `inv(::Number)` that returns `Inf`.

```julia 
inv( 0. )    # Inf, no exception
inv( [0;;] ) # SingularException 
```

I guess documenting this would mean that `inv` guarantees to return a matrix with only finite (`isfinite`) entries if the argument has only finite entries, but I don't know if the implementation guarantees it / if this should be tested ?
