### PR TITLE
`Char` uplo in `Bidiagonal` constructor

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -65,16 +65,13 @@ julia> Bl = Bidiagonal(dv, ev, :L) # ev is on the first subdiagonal
  ⋅  ⋅  9  4
 ```
 """
-function Bidiagonal(dv::V, ev::V, uplo::Symbol) where {T,V<:AbstractVector{T}}
-    Bidiagonal{T,V}(dv, ev, uplo)
-end
-function Bidiagonal(dv::V, ev::V, uplo::AbstractChar) where {T,V<:AbstractVector{T}}
+function Bidiagonal(dv::V, ev::V, uplo::Union{Symbol, AbstractChar}) where {T,V<:AbstractVector{T}}
     Bidiagonal{T,V}(dv, ev, uplo)
 end
 
 #To allow Bidiagonal's where the "dv" is Vector{T} and "ev" Vector{S},
 #where T and S can be promoted
-function Bidiagonal(dv::Vector{T}, ev::Vector{S}, uplo::Symbol) where {T,S}
+function Bidiagonal(dv::Vector{T}, ev::Vector{S}, uplo::Union{Symbol, AbstractChar}) where {T,S}
     TS = promote_type(T,S)
     return Bidiagonal{TS,Vector{TS}}(dv, ev, uplo)
 end

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -512,6 +512,10 @@ Random.seed!(1)
     @test Matrix{ComplexF64}(BD) == BD
 end
 
+@testset "Constructors with Char uplo"
+    @test Bidiagonal(Int8[1,2], [1], 'U') == Bidiagonal(Int8[1,2], [1], :U)
+end
+
 # Issue 10742 and similar
 let A = Bidiagonal([1,2,3], [0,0], :U)
     @test istril(A)

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -512,7 +512,7 @@ Random.seed!(1)
     @test Matrix{ComplexF64}(BD) == BD
 end
 
-@testset "Constructors with Char uplo"
+@testset "Constructors with Char uplo" begin
     @test Bidiagonal(Int8[1,2], [1], 'U') == Bidiagonal(Int8[1,2], [1], :U)
 end
 


### PR DESCRIPTION
This is an internal constructor, but many methods involving `Bidiagonal` matrices currently use the `Char` `uplo` directly to construct a new `Bidiagonal` matrix. We therefore may require the constructors to accept a `Char` as well, wherever they accept a `Symbol`. This already works for some of the `Bidiagonal` constructors, and this PR plugs a missing case.

Fixes issues like
```julia
julia> B = Bidiagonal(fill(SMatrix{2,3}(1:6), 4), fill(SMatrix{1,3}(1:3), 3), :L)
4×4 Bidiagonal{StaticArraysCore.SArray{S, Int64, 2} where S<:Tuple, Vector{StaticArraysCore.SArray{S, Int64, 2} where S<:Tuple}}:
 [1 3 5; 2 4 6]        ⋅               ⋅               ⋅       
 [1 2 3]         [1 3 5; 2 4 6]        ⋅               ⋅       
       ⋅         [1 2 3]         [1 3 5; 2 4 6]        ⋅       
       ⋅               ⋅         [1 2 3]         [1 3 5; 2 4 6]

julia> 2B
ERROR: MethodError: no method matching Bidiagonal(::Vector{SMatrix{2, 3, Int64, 6}}, ::Vector{SMatrix{1, 3, Int64, 3}}, ::Char)
The type `Bidiagonal` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  Bidiagonal(::Vector{T}, ::Vector{S}, ::Symbol) where {T, S}
   @ LinearAlgebra ~/Dropbox/JuliaPackages/LinearAlgebra_2.jl/src/bidiag.jl:77
  Bidiagonal(::V, ::V, ::AbstractChar) where {T, V<:AbstractVector{T}}
   @ LinearAlgebra ~/Dropbox/JuliaPackages/LinearAlgebra_2.jl/src/bidiag.jl:71
  Bidiagonal(::V, ::V, ::Symbol) where {T, V<:AbstractVector{T}}
   @ LinearAlgebra ~/Dropbox/JuliaPackages/LinearAlgebra_2.jl/src/bidiag.jl:68
  ...
```
After this,
```julia
julia> 2B
4×4 Bidiagonal{StaticArraysCore.SArray{S, Int64, 2} where S<:Tuple, Vector{StaticArraysCore.SArray{S, Int64, 2} where S<:Tuple}}:
 [2 6 10; 4 8 12]        ⋅                 ⋅                 ⋅       
 [2 4 6]           [2 6 10; 4 8 12]        ⋅                 ⋅       
       ⋅           [2 4 6]           [2 6 10; 4 8 12]        ⋅       
       ⋅                 ⋅           [2 4 6]           [2 6 10; 4 8 12]
```

We may require that each method passes a `Symbol` as `uplo`, but this would be a much larger change, and the current approach seems to be less disruptive.