### PR TITLE
Update the docstring of ldiv!

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -396,7 +396,7 @@ julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> B = [1, 2.5, 3];
 
-julia> Y = copy(B);
+julia> Y = similar(B); # use similar since there is no need to read from it
 
 julia> ldiv!(Y, qr(A), B); # you may also try qr!(A) to further reduce allocation
 
@@ -428,7 +428,7 @@ julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
 
 julia> B = [1, 2.5, 3];
 
-julia> B0 = copy(B);
+julia> B0 = copy(B); # a backup copy to facilitate testing
 
 julia> ldiv!(lu(A), B); # you may also try lu!(A) to further reduce allocation
 

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -392,11 +392,13 @@ control over the factorization of `A`.
 
 # Examples
 ```jldoctest
-julia> A, B = [1 2.2 4; 3.1 0.2 3; 4 1 2], [1, 2.5, 3];
+julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
+
+julia> B = [1, 2.5, 3];
 
 julia> Y = copy(B);
 
-julia> ldiv!(Y, qr(A), B); # also try qr!(A) for the 2nd arg
+julia> ldiv!(Y, qr(A), B); # you may also try qr!(A) to further reduce allocation
 
 julia> Y ≈ A \\ B
 true
@@ -422,11 +424,13 @@ control over the factorization of `A`.
 
 # Examples
 ```jldoctest
-julia> A, B = [1 2.2 4; 3.1 0.2 3; 4 1 2], [1, 2.5, 3];
+julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
+
+julia> B = [1, 2.5, 3];
 
 julia> B0 = copy(B);
 
-julia> ldiv!(lu(A), B); # also try lu!(A) for the 1st arg
+julia> ldiv!(lu(A), B); # you may also try lu!(A) to further reduce allocation
 
 julia> B ≈ A \\ B0
 true

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -398,7 +398,7 @@ julia> Y = copy(B);
 
 julia> ldiv!(Y, qr(A), B); # also try qr!(A) for the 2nd arg
 
-julia> Y ≈ A \ B
+julia> Y ≈ A \\ B
 true
 ```
 """
@@ -428,7 +428,7 @@ julia> B0 = copy(B);
 
 julia> ldiv!(lu(A), B); # also try lu!(A) for the 1st arg
 
-julia> B ≈ A \ B0
+julia> B ≈ A \\ B0
 true
 ```
 """

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -392,15 +392,13 @@ control over the factorization of `A`.
 
 # Examples
 ```jldoctest
-julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
+julia> A, B = [1 2.2 4; 3.1 0.2 3; 4 1 2], [1, 2.5, 3];
 
-julia> X = [1; 2.5; 3];
+julia> Y = copy(B);
 
-julia> Y = zero(X);
+julia> ldiv!(Y, qr(A), B); # also try qr!(A) for the 2nd arg
 
-julia> ldiv!(Y, qr(A), X);
-
-julia> Y ≈ A\\X
+julia> Y ≈ A \ B
 true
 ```
 """
@@ -424,15 +422,13 @@ control over the factorization of `A`.
 
 # Examples
 ```jldoctest
-julia> A = [1 2.2 4; 3.1 0.2 3; 4 1 2];
+julia> A, B = [1 2.2 4; 3.1 0.2 3; 4 1 2], [1, 2.5, 3];
 
-julia> X = [1; 2.5; 3];
+julia> B0 = copy(B);
 
-julia> Y = copy(X);
+julia> ldiv!(lu(A), B); # also try lu!(A) for the 1st arg
 
-julia> ldiv!(qr(A), X);
-
-julia> X ≈ A\\Y
+julia> B ≈ A \ B0
 true
 ```
 """


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/724d0ca3-fc05-46a7-b22a-cc0ab929bfe0)
A comment about the existing docstring is: 
The lower example reads counter-intuitive, _given_ the experience from reading the upper example.
And `X` and `Y` are not like `A` and `B`.

Hope the revised version reads clearer and intelligible.