### PR TITLE
Forward `_tri(l/r)div!` to parent of triangular

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1323,15 +1323,6 @@ end
 # Generic routines #
 ####################
 
-function _set_diag!(B::UpperOrLowerTriangular, x)
-    # get a mutable array to modify the diagonal
-    Bm = parent(B) isa StridedArray ? B : copy!(similar(B), B)
-    for i in diagind(Bm.data, IndexStyle(Bm.data))
-        Bm.data[i] = x
-    end
-    Bm
-end
-
 for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
                    (LowerTriangular, UnitLowerTriangular))
     tstrided = t{<:Any, <:StridedMaybeAdjOrTransMat}
@@ -1344,8 +1335,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (*)(A::$unitt, x::Number)
-            B = $t(A.data)*x
-            _set_diag!(B, oneunit(eltype(A)) * x)
+            B = copy!(similar($t(A.data)), A)
+            B * x
         end
 
         (*)(x::Number, A::$t) = $t(x*A.data)
@@ -1356,8 +1347,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (*)(x::Number, A::$unitt)
-            B = x*$t(A.data)
-            _set_diag!(B, x * oneunit(eltype(A)))
+            B = copy!(similar($t(A.data)), A)
+            x * B
         end
 
         (/)(A::$t, x::Number) = $t(A.data/x)
@@ -1368,8 +1359,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (/)(A::$unitt, x::Number)
-            B = $t(A.data)/x
-            _set_diag!(B, oneunit(eltype(A)) / x)
+            B = copy!(similar($t(A.data)), A)
+            B / x
         end
 
         (\)(x::Number, A::$t) = $t(x\A.data)
@@ -1380,8 +1371,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (\)(x::Number, A::$unitt)
-            B = x\$t(A.data)
-            _set_diag!(B, x \ oneunit(eltype(A)))
+            B = copy!(similar($t(A.data)), A)
+            x \ B
         end
     end
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1323,6 +1323,15 @@ end
 # Generic routines #
 ####################
 
+function _set_diag!(B::UpperOrLowerTriangular, x)
+    # get a mutable array to modify the diagonal
+    Bm = parent(B) isa StridedArray ? B : copy!(similar(B), B)
+    for i in diagind(Bm.data, IndexStyle(Bm.data))
+        Bm.data[i] = x
+    end
+    Bm
+end
+
 for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
                    (LowerTriangular, UnitLowerTriangular))
     tstrided = t{<:Any, <:StridedMaybeAdjOrTransMat}
@@ -1335,8 +1344,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (*)(A::$unitt, x::Number)
-            B = copy!(similar($t(A.data)), A)
-            B * x
+            B = $t(A.data)*x
+            _set_diag!(B, oneunit(eltype(A)) * x)
         end
 
         (*)(x::Number, A::$t) = $t(x*A.data)
@@ -1347,8 +1356,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (*)(x::Number, A::$unitt)
-            B = copy!(similar($t(A.data)), A)
-            x * B
+            B = x*$t(A.data)
+            _set_diag!(B, x * oneunit(eltype(A)))
         end
 
         (/)(A::$t, x::Number) = $t(A.data/x)
@@ -1359,8 +1368,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (/)(A::$unitt, x::Number)
-            B = copy!(similar($t(A.data)), A)
-            B / x
+            B = $t(A.data)/x
+            _set_diag!(B, oneunit(eltype(A)) / x)
         end
 
         (\)(x::Number, A::$t) = $t(x\A.data)
@@ -1371,8 +1380,8 @@ for (t, unitt) in ((UpperTriangular, UnitUpperTriangular),
         end
 
         function (\)(x::Number, A::$unitt)
-            B = copy!(similar($t(A.data)), A)
-            x \ B
+            B = x\$t(A.data)
+            _set_diag!(B, x \ oneunit(eltype(A)))
         end
     end
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -801,38 +801,38 @@ function _triscale!(A::LowerOrUnitLowerTriangular, c::Number, B::UnitLowerTriang
     return A
 end
 
-function _trirdiv!(A::UpperTriangular, B::UpperOrUnitUpperTriangular, c::Number)
+function _trirdiv!(A::UpperTriangular, B::UpperTriangular, c::Number)
     checksize1(A, B)
     for j in axes(B,2)
         for i in firstindex(B,1):j
-            @inbounds A[i, j] = B[i, j] / c
+            @inbounds A.data[i, j] = B.data[i, j] / c
         end
     end
     return A
 end
-function _trirdiv!(A::LowerTriangular, B::LowerOrUnitLowerTriangular, c::Number)
+function _trirdiv!(A::LowerTriangular, B::LowerTriangular, c::Number)
     checksize1(A, B)
     for j in axes(B,2)
         for i in j:lastindex(B,1)
-            @inbounds A[i, j] = B[i, j] / c
+            @inbounds A.data[i, j] = B.data[i, j] / c
         end
     end
     return A
 end
-function _trildiv!(A::UpperTriangular, c::Number, B::UpperOrUnitUpperTriangular)
+function _trildiv!(A::UpperTriangular, c::Number, B::UpperTriangular)
     checksize1(A, B)
     for j in axes(B,2)
         for i in firstindex(B,1):j
-            @inbounds A[i, j] = c \ B[i, j]
+            @inbounds A.data[i, j] = c \ B.data[i, j]
         end
     end
     return A
 end
-function _trildiv!(A::LowerTriangular, c::Number, B::LowerOrUnitLowerTriangular)
+function _trildiv!(A::LowerTriangular, c::Number, B::LowerTriangular)
     checksize1(A, B)
     for j in axes(B,2)
         for i in j:lastindex(B,1)
-            @inbounds A[i, j] = c \ B[i, j]
+            @inbounds A.data[i, j] = c \ B.data[i, j]
         end
     end
     return A

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -944,4 +944,18 @@ end
     @test 2*U == 2*M
 end
 
+@testset "scaling partly initialized unit triangular" begin
+    for T in (UnitUpperTriangular, UnitLowerTriangular)
+        isupper = T == UnitUpperTriangular
+        M = Matrix{BigFloat}(undef,2,2)
+        M[1+!isupper, 1+isupper] = 3
+        U = T(M)
+        C = Matrix(U)
+        @test U * 2 == C * 2
+        @test 2 * U == 2 * C
+        @test U / 2 == C / 2
+        @test 2 \ U == 2 \ C
+    end
+end
+
 end # module TestTriangular

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -944,18 +944,4 @@ end
     @test 2*U == 2*M
 end
 
-@testset "scaling partly initialized unit triangular" begin
-    for T in (UnitUpperTriangular, UnitLowerTriangular)
-        isupper = T == UnitUpperTriangular
-        M = Matrix{BigFloat}(undef,2,2)
-        M[1+!isupper, 1+isupper] = 3
-        U = T(M)
-        C = Matrix(U)
-        @test U * 2 == C * 2
-        @test 2 * U == 2 * C
-        @test U / 2 == C / 2
-        @test 2 \ U == 2 \ C
-    end
-end
-
 end # module TestTriangular


### PR DESCRIPTION
These loop over the stored triangular halves, so we may forward the operations to the parents. These are also internal methods that are not applied to unit triangular matrices, so we restrict these to `UpperTriangular` and `LowerTriangular` matrices in this PR. This makes it straightforward to forward the operations to the parent.