### PR TITLE
Prune `LinearAlgebra` module in ambiguity test

### DIFF
--- a/test/ambiguous_exec.jl
+++ b/test/ambiguous_exec.jl
@@ -1,5 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module TestAmbiguity
+
+isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
+
 using Test, LinearAlgebra
 let ambig = detect_ambiguities(LinearAlgebra; recursive=true)
     @test isempty(ambig)
@@ -19,3 +23,5 @@ let ambig = detect_ambiguities(LinearAlgebra; recursive=true)
     @test isempty(expect)
     @test good
 end
+
+end # module


### PR DESCRIPTION
The ambiguity check was being run in a separate process, but it was not pruning the `LinearAlgebra` module. This was therefore not testing for ambiguities in the latest code, but the one in the sysimg.

The PR would be able to replicate the test failure seen in https://buildkite.com/julialang/julia-master/builds/47424#0196c03a-2230-4d64-b404-e04dbfc76c3f