### PR TITLE
Fix copy for partly initialized unit triangular

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -623,7 +623,8 @@ end
     copytrito!(dest, U, U isa UpperOrUnitUpperTriangular ? 'L' : 'U')
     return dest
 end
-@propagate_inbounds function _copy!(dest::StridedMatrix, U::UpperOrLowerTriangular{<:Any, <:StridedMatrix})
+@propagate_inbounds function _copy!(dest::StridedMatrix,
+        U::Union{UnitUpperOrUnitLowerTriangular, UpperOrLowerTriangularStrided})
     U2 = Base.unalias(dest, U)
     copy_unaliased!(dest, U2)
     return dest
@@ -656,7 +657,7 @@ end
     end
     dest
 end
-@inline function copy_unaliased!(dest::StridedMatrix, U::UpperOrUnitUpperTriangular{<:Any, <:StridedMatrix})
+@inline function copy_unaliased!(dest::StridedMatrix, U::UpperOrUnitUpperTriangular)
     @boundscheck checkbounds(dest, axes(U)...)
     for col in axes(dest,2)
         @inbounds copy_unaliased_stored!(dest, U, col)
@@ -666,7 +667,7 @@ end
     end
     return dest
 end
-@inline function copy_unaliased!(dest::StridedMatrix, L::LowerOrUnitLowerTriangular{<:Any, <:StridedMatrix})
+@inline function copy_unaliased!(dest::StridedMatrix, L::LowerOrUnitLowerTriangular)
     @boundscheck checkbounds(dest, axes(L)...)
     for col in axes(dest,2)
         for row in firstindex(dest,1):col-1

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -650,6 +650,16 @@ end
             @test_throws "cannot set index in the upper triangular part" copyto!(A, B)
         end
     end
+
+    @testset "partly initialized unit triangular" begin
+        for T in (UnitUpperTriangular, UnitLowerTriangular)
+            isupper = T == UnitUpperTriangular
+            M = Matrix{BigFloat}(undef, 2, 2)
+            M[1+isupper,1+!isupper] = 3
+            U = T(M')
+            @test copyto!(similar(M), U) == U
+        end
+    end
 end
 
 @testset "getindex with Integers" begin

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -6,6 +6,7 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
 using LinearAlgebra: errorbounds, transpose!, BandIndex
+using Test: GenericArray
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 
@@ -655,8 +656,8 @@ end
         for T in (UnitUpperTriangular, UnitLowerTriangular)
             isupper = T == UnitUpperTriangular
             M = Matrix{BigFloat}(undef, 2, 2)
-            M[1+isupper,1+!isupper] = 3
-            U = T(M')
+            M[1+!isupper,1+isupper] = 3
+            U = T(GenericArray(M))
             @test copyto!(similar(M), U) == U
         end
     end


### PR DESCRIPTION
Currently, we forward copy for unit triangular matrices to the parents. This also copies the diagonal, which may not be initialized in the parent. This PR fixes this.
After this, the following works again
```julia
julia> M = Matrix{BigFloat}(undef,2,2);

julia> M[2,1] = 3;

julia> M'
2×2 adjoint(::Matrix{BigFloat}) with eltype BigFloat:
 #undef    3.0
 #undef  #undef

julia> U = UnitUpperTriangular(M')
2×2 UnitUpperTriangular{BigFloat, Adjoint{BigFloat, Matrix{BigFloat}}}:
 1.0  3.0
  ⋅   1.0

julia> copyto!(similar(M), U)
2×2 Matrix{BigFloat}:
 1.0  3.0
 0.0  1.0
```