### PR TITLE
log for dense diagonal matrix with negative elements

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -915,7 +915,7 @@ julia> log(A)
 function log(A::AbstractMatrix)
     # If possible, use diagonalization
     if isdiag(A) && eltype(A) <: Union{Real,Complex}
-        if eltype(A) <: Real && all(>(0), diagview(A))
+        if eltype(A) <: Real && all(>=(0), diagview(A))
             return applydiagonal(log, A)
         else
             return applydiagonal(log∘complex, A)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -914,8 +914,12 @@ julia> log(A)
 """
 function log(A::AbstractMatrix)
     # If possible, use diagonalization
-    if isdiag(A)
-        return applydiagonal(log, A)
+    if isdiag(A) && eltype(A) <: Union{Real,Complex}
+        if eltype(A) <: Real && all(>(0), diagview(A))
+            return applydiagonal(log, A)
+        else
+            return applydiagonal(log∘complex, A)
+        end
     elseif ishermitian(A)
         logHermA = log(Hermitian(A))
         PH = parent(logHermA)

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1418,4 +1418,13 @@ end
     @test tril(GenericArray(M),-1) == res'
 end
 
+@testset "log for diagonal" begin
+    D = diagm([-2.0, 2.0])
+    @test log(D) ≈ log(UpperTriangular(D))
+    D = diagm([2.0, 2.0])
+    @test log(D) ≈ log(UpperTriangular(D))
+    D = diagm([2.0, 2.0*im])
+    @test log(D) ≈ log(UpperTriangular(D))
+end
+
 end # module TestDense

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1421,6 +1421,8 @@ end
 @testset "log for diagonal" begin
     D = diagm([-2.0, 2.0])
     @test log(D) ≈ log(UpperTriangular(D))
+    D = diagm([-2.0, 0.0])
+    @test log(D) ≈ log(UpperTriangular(D))
     D = diagm([2.0, 2.0])
     @test log(D) ≈ log(UpperTriangular(D))
     D = diagm([2.0, 2.0*im])


### PR DESCRIPTION
Fixes a regression introduced in v1.12, where we have a special branch for diagonal matrices to improve performance. The issue is that log for `Diagonal` matrices acts elementwise, which, for real matrices, requires the diagonal elements to be greater than zero. This PR adds an extra branch to check this.