### PR TITLE
Add compat notice for `diagview`

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -297,6 +297,9 @@ Return a view into the `k`th diagonal of the matrix `M`.
 
 See also [`diag`](@ref), [`diagind`](@ref).
 
+!!! compat "Julia 1.12"
+    This function requires Julia 1.12 or later.
+
 # Examples
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]


### PR DESCRIPTION
This function didn't exist in Julia 1.11

There is a note in NEWS, here: https://github.com/JuliaLang/julia/blob/master/HISTORY.md#linearalgebra

Added in https://github.com/JuliaLang/julia/pull/56175