### PR TITLE
slight optimization of exp, sqrt, ^ for positive semidefinite output

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -854,7 +854,7 @@ function ^(A::SelfAdjoint, p::Real)
     isinteger(p) && return integerpow(A, p)
     F = eigen(A)
     if all(λ -> λ ≥ 0, F.values)
-        rootpower = map(λ -> λ^0.5p, F.values)
+        rootpower = map(λ -> λ^(p / 2), F.values)
         retmat = _psd_spectral_product(rootpower, F.vectors)
         return wrappertype(A)(retmat)
     else
@@ -879,7 +879,7 @@ end
 
 function exp(A::SelfAdjoint)
     F = eigen(A)
-    rootexp = map(λ -> exp(0.5λ), F.values)
+    rootexp = map(λ -> exp(λ / 2), F.values)
     retmat = _psd_spectral_product(rootexp, F.vectors)
     return wrappertype(A)(retmat)
 end

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -835,9 +835,7 @@ end
 
 #computes U * Diagonal(abs2.(v)) * U', destroying U
 function _psd_spectral_product!(v, U)
-    @inbounds for j ∈ axes(U, 2), i ∈ axes(U, 1)
-        U[i, j] *= v[j]
-    end
+    rmul!(U, Diagonal(v))
     return U * U'
 end
 

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -833,6 +833,14 @@ function svdvals!(A::RealHermSymComplexHerm)
     return sort!(vals, rev = true)
 end
 
+#computes U * Diagonal(abs2.(v)) * U', destroying U
+function _psd_spectral_product!(v, U)
+    @inbounds for j ∈ axes(U, 2), i ∈ axes(U, 1)
+        U[i, j] *= v[j]
+    end
+    return U * U'
+end
+
 # Matrix functions
 ^(A::SymSymTri{<:Complex}, p::Integer) = sympow(A, p)
 ^(A::SelfAdjoint, p::Integer) = sympow(A, p)
@@ -848,7 +856,8 @@ function ^(A::SelfAdjoint, p::Real)
     isinteger(p) && return integerpow(A, p)
     F = eigen(A)
     if all(λ -> λ ≥ 0, F.values)
-        retmat = (F.vectors * Diagonal((F.values).^p)) * F.vectors'
+        map!(λ -> λ^0.5p, F.values)
+        retmat = _psd_spectral_product!(F.values, F.vectors)
         return wrappertype(A)(retmat)
     else
         retmat = (F.vectors * Diagonal(complex.(F.values).^p)) * F.vectors'
@@ -860,7 +869,7 @@ function ^(A::SymSymTri{<:Complex}, p::Real)
     return Symmetric(schurpow(A, p))
 end
 
-for func in (:exp, :cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :atanh, :cbrt)
+for func in (:cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :atanh, :cbrt)
     @eval begin
         function ($func)(A::SelfAdjoint)
             F = eigen(A)
@@ -868,6 +877,13 @@ for func in (:exp, :cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :atanh,
             return wrappertype(A)(retmat)
         end
     end
+end
+
+function exp(A::SelfAdjoint)
+    F = eigen(A)
+    map!(λ -> exp(0.5λ), F.values)
+    retmat = _psd_spectral_product!(F.values, F.vectors)
+    return wrappertype(A)(retmat)
 end
 
 function cis(A::SelfAdjoint)
@@ -929,7 +945,8 @@ function sqrt(A::SelfAdjoint; rtol = eps(real(float(eltype(A)))) * size(A, 1))
     F = eigen(A)
     λ₀ = -maximum(abs, F.values) * rtol # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff
     if all(λ -> λ ≥ λ₀, F.values)
-        retmat = (F.vectors * Diagonal(sqrt.(max.(0, F.values)))) * F.vectors'
+        map!(λ -> λ < 0 ? zero(λ) : fourthroot(λ), F.values)
+        retmat = _psd_spectral_product!(F.values, F.vectors)
         return wrappertype(A)(retmat)
     else
         retmat = (F.vectors * Diagonal(sqrt.(complex.(F.values)))) * F.vectors'

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -836,7 +836,7 @@ end
 #computes U * Diagonal(abs2.(v)) * U'
 function _psd_spectral_product(v, U)
     Uv = U * Diagonal(v)
-    return Uv * Uv'
+    return Uv * Uv' # often faster than generic matmul by calling BLAS.herk
 end
 
 # Matrix functions

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -833,10 +833,10 @@ function svdvals!(A::RealHermSymComplexHerm)
     return sort!(vals, rev = true)
 end
 
-#computes U * Diagonal(abs2.(v)) * U', destroying U
-function _psd_spectral_product!(v, U)
-    rmul!(U, Diagonal(v))
-    return U * U'
+#computes U * Diagonal(abs2.(v)) * U'
+function _psd_spectral_product(v, U)
+    Uv = U * Diagonal(v)
+    return Uv * Uv'
 end
 
 # Matrix functions
@@ -854,8 +854,8 @@ function ^(A::SelfAdjoint, p::Real)
     isinteger(p) && return integerpow(A, p)
     F = eigen(A)
     if all(λ -> λ ≥ 0, F.values)
-        map!(λ -> λ^0.5p, F.values)
-        retmat = _psd_spectral_product!(F.values, F.vectors)
+        rootpower = map(λ -> λ^0.5p, F.values)
+        retmat = _psd_spectral_product(rootpower, F.vectors)
         return wrappertype(A)(retmat)
     else
         retmat = (F.vectors * Diagonal(complex.(F.values).^p)) * F.vectors'
@@ -879,8 +879,8 @@ end
 
 function exp(A::SelfAdjoint)
     F = eigen(A)
-    map!(λ -> exp(0.5λ), F.values)
-    retmat = _psd_spectral_product!(F.values, F.vectors)
+    rootexp = map(λ -> exp(0.5λ), F.values)
+    retmat = _psd_spectral_product(rootexp, F.vectors)
     return wrappertype(A)(retmat)
 end
 
@@ -943,8 +943,8 @@ function sqrt(A::SelfAdjoint; rtol = eps(real(float(eltype(A)))) * size(A, 1))
     F = eigen(A)
     λ₀ = -maximum(abs, F.values) * rtol # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff
     if all(λ -> λ ≥ λ₀, F.values)
-        map!(λ -> λ < 0 ? zero(λ) : fourthroot(λ), F.values)
-        retmat = _psd_spectral_product!(F.values, F.vectors)
+        rootroot = map(λ -> λ < 0 ? zero(λ) : fourthroot(λ), F.values)
+        retmat = _psd_spectral_product(rootroot, F.vectors)
         return wrappertype(A)(retmat)
     else
         retmat = (F.vectors * Diagonal(sqrt.(complex.(F.values)))) * F.vectors'


### PR DESCRIPTION
The speedup is small, my benchmarks show 2-5%, but since these functions are so often used I think it's worth it. Conversely, the same optimization applies to `cosh`, `acosh`, `acos`, and the positive part of other functions but I didn't do it because I don't think the speedup is worth the complexity.