### PR TITLE
Faster `Adjoint`/`Transpose`-`UniformScaling` arithmetic

### DIFF
--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -217,6 +217,22 @@ function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
     return B
 end
 
+for f in (:+, :-)
+    @eval begin
+        function $f(A::AdjOrTransAbsMat, J::UniformScaling)
+            checksquare(A)
+            op = wrapperop(A)
+            op($f(op(A), op(J)))
+        end
+
+        function $f(J::UniformScaling, A::AdjOrTransAbsMat)
+            checksquare(A)
+            op = wrapperop(A)
+            op($f(op(J), op(A)))
+        end
+    end
+end
+
 function (+)(A::AbstractMatrix, J::UniformScaling)
     checksquare(A)
     B = copymutable_oftype(A, Base.promote_op(+, eltype(A), typeof(J)))

--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -217,20 +217,15 @@ function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
     return B
 end
 
-for f in (:+, :-)
-    @eval begin
-        function $f(A::AdjOrTransAbsMat, J::UniformScaling)
-            checksquare(A)
-            op = wrapperop(A)
-            op($f(op(A), op(J)))
-        end
-
-        function $f(J::UniformScaling, A::AdjOrTransAbsMat)
-            checksquare(A)
-            op = wrapperop(A)
-            op($f(op(J), op(A)))
-        end
-    end
+function (+)(A::AdjOrTransAbsMat, J::UniformScaling)
+    checksquare(A)
+    op = wrapperop(A)
+    op(op(A) + op(J))
+end
+function (-)(J::UniformScaling, A::AdjOrTransAbsMat)
+    checksquare(A)
+    op = wrapperop(A)
+    op(op(J) - op(A))
 end
 
 function (+)(A::AbstractMatrix, J::UniformScaling)

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -335,6 +335,19 @@ let
                 @test @inferred(J - T) == J - Array(T)
             end
 
+            @testset for f in (transpose, adjoint)
+                if isa(A, Array)
+                    T = f(randn(ComplexF64,3,3))
+                else
+                    T = f(view(randn(ComplexF64,3,3), 1:3, 1:3))
+                end
+                TA = Array(T)
+                @test @inferred(T + J) == TA + J
+                @test @inferred(J + T) == J + TA
+                @test @inferred(T - J) == TA - J
+                @test @inferred(J - T) == J - TA
+            end
+
             @test @inferred(I\A) == A
             @test @inferred(A\I) == inv(A)
             @test @inferred(λ\I) === UniformScaling(1/λ)


### PR DESCRIPTION
Avoids hitting slow generic methods.
Discussed in https://discourse.julialang.org/t/very-long-time-for-addition-of-complex-identity-matrix-to-transposed-sparse-matrix/129465.
After this, the following are comparable:
```julia
julia> A = sprandn(90, 90, 0.01);

julia> @btime ($A + complex(0,1.) * I);
  1.313 μs (13 allocations: 8.02 KiB)

julia> @btime (transpose($A) + complex(0,1.) * I);
  1.416 μs (13 allocations: 8.02 KiB)
```