### PR TITLE
Avoid allocations in checking `==` with `UniformScaling`

### DIFF
--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -338,7 +338,8 @@ function ==(A::AbstractMatrix, J::UniformScaling)
     size(A, 1) == size(A, 2) || return false
     iszero(J.λ) && return iszero(A)
     isone(J.λ) && return isone(A)
-    return A == J.λ*one(A)
+    isdiag(A) || return false
+    return all(==(J.λ), diagview(A))
 end
 function ==(A::StridedMatrix, J::UniformScaling)
     size(A, 1) == size(A, 2) || return false


### PR DESCRIPTION
This improves performance and reduces allocations. E.g.,
```julia
julia> A = sprandn(90,90, 0.01);

julia> @btime $A == 2I # master
  807.674 ns (12 allocations: 4.97 KiB)
false

julia> @btime $A == 2I # this PR
  18.746 ns (0 allocations: 0 bytes)
false
```