### PR TITLE
Make `adjoint`/`transpose` for `Diagonal`/`Bidiagonal` lazy

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -552,3 +552,16 @@ conj(A::Adjoint) = transpose(A.parent)
 function Base.replace_in_print_matrix(A::AdjOrTrans,i::Integer,j::Integer,s::AbstractString)
     Base.replace_in_print_matrix(parent(A), j, i, s)
 end
+
+# Special adjoint/transpose methods for Adjoint/Transpose that have been reshaped as a vector
+# these are used in transposing banded matrices by forwarding the operation to the bands
+# the permutedims converts a n-element vector to an 1xn matrix
+transpose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = permutedims(transpose(parent(A)))
+adjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = permutedims(adjoint(parent(A)))
+
+# compute vec(transpose(A)), but avoid an allocating reshape if possible
+_vectranspose(A::AbstractVector) = vec(transpose(A))
+_vectranspose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = transpose(parent(A))
+# compute vec(adjoint(A)), but avoid an allocating reshape if possible
+_vecadjoint(A::AbstractVector) = vec(adjoint(A))
+_vecadjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = adjoint(parent(A))

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -555,10 +555,6 @@ end
 
 # Special adjoint/transpose methods for Adjoint/Transpose that have been reshaped as a vector
 # these are used in transposing banded matrices by forwarding the operation to the bands
-# the permutedims converts a n-element vector to an 1xn matrix
-transpose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = permutedims(transpose(parent(A)))
-adjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = permutedims(adjoint(parent(A)))
-
 # compute vec(transpose(A)), but avoid an allocating reshape if possible
 _vectranspose(A::AbstractVector) = vec(transpose(A))
 _vectranspose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = transpose(parent(A))

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -564,6 +564,7 @@ _vectranspose(A::AbstractVector) = vec(transpose(A))
 _vectranspose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = transpose(parent(A))
 """
     _vecadjoint(A::AbstractVector)::AbstractVector
+
 Compute `vec(adjoint(A))`, but avoid an allocating reshape if possible
 """
 _vecadjoint(A::AbstractVector) = vec(adjoint(A))

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -555,9 +555,16 @@ end
 
 # Special adjoint/transpose methods for Adjoint/Transpose that have been reshaped as a vector
 # these are used in transposing banded matrices by forwarding the operation to the bands
-# compute vec(transpose(A)), but avoid an allocating reshape if possible
+"""
+    _vectranspose(A::AbstractVector)::AbstractVector
+
+Compute `vec(transpose(A))`, but avoid an allocating reshape if possible
+"""
 _vectranspose(A::AbstractVector) = vec(transpose(A))
 _vectranspose(A::Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}) = transpose(parent(A))
-# compute vec(adjoint(A)), but avoid an allocating reshape if possible
+"""
+    _vecadjoint(A::AbstractVector)::AbstractVector
+Compute `vec(adjoint(A))`, but avoid an allocating reshape if possible
+"""
 _vecadjoint(A::AbstractVector) = vec(adjoint(A))
 _vecadjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = adjoint(parent(A))

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -308,12 +308,8 @@ for func in (:conj, :copy, :real, :imag)
 end
 isreal(M::Bidiagonal) = isreal(M.dv) && isreal(M.ev)
 
-adjoint(B::Bidiagonal) = Bidiagonal(vec(adjoint(B.dv)), vec(adjoint(B.ev)), B.uplo == 'U' ? :L : :U)
-adjoint(B::Bidiagonal{<:Any, <:Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}}) =
-    Bidiagonal(adjoint(parent(B.dv)), adjoint(parent(B.ev)), B.uplo == 'U' ? :L : :U)
-transpose(B::Bidiagonal) = Bidiagonal(vec(transpose(B.dv)), vec(transpose(B.ev)), B.uplo == 'U' ? :L : :U)
-transpose(B::Bidiagonal{<:Any, <:Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}}) =
-    Bidiagonal(transpose(parent(B.dv)), transpose(parent(B.ev)), B.uplo == 'U' ? :L : :U)
+adjoint(B::Bidiagonal) = Bidiagonal(_vecadjoint(B.dv), _vecadjoint(B.ev), B.uplo == 'U' ? :L : :U)
+transpose(B::Bidiagonal) = Bidiagonal(_vectranspose(B.dv), _vectranspose(B.ev), B.uplo == 'U' ? :L : :U)
 permutedims(B::Bidiagonal) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? 'L' : 'U')
 function permutedims(B::Bidiagonal, perm)
     Base.checkdims_perm(axes(B), axes(B), perm)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -308,12 +308,12 @@ for func in (:conj, :copy, :real, :imag)
 end
 isreal(M::Bidiagonal) = isreal(M.dv) && isreal(M.ev)
 
-adjoint(B::Bidiagonal{<:Number}) = Bidiagonal(vec(adjoint(B.dv)), vec(adjoint(B.ev)), B.uplo == 'U' ? :L : :U)
-adjoint(B::Bidiagonal{<:Number, <:Base.ReshapedArray{<:Number,1,<:Adjoint}}) =
+adjoint(B::Bidiagonal) = Bidiagonal(vec(adjoint(B.dv)), vec(adjoint(B.ev)), B.uplo == 'U' ? :L : :U)
+adjoint(B::Bidiagonal{<:Any, <:Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}}) =
     Bidiagonal(adjoint(parent(B.dv)), adjoint(parent(B.ev)), B.uplo == 'U' ? :L : :U)
-adjoint(B::Bidiagonal) = Bidiagonal(adjoint.(B.dv), adjoint.(B.ev), B.uplo == 'U' ? :L : :U)
-transpose(B::Bidiagonal{<:Number}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
-transpose(B::Bidiagonal) = Bidiagonal(transpose.(B.dv), transpose.(B.ev), B.uplo == 'U' ? :L : :U)
+transpose(B::Bidiagonal) = Bidiagonal(vec(transpose(B.dv)), vec(transpose(B.ev)), B.uplo == 'U' ? :L : :U)
+transpose(B::Bidiagonal{<:Any, <:Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}}) =
+    Bidiagonal(transpose(parent(B.dv)), transpose(parent(B.ev)), B.uplo == 'U' ? :L : :U)
 permutedims(B::Bidiagonal) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? 'L' : 'U')
 function permutedims(B::Bidiagonal, perm)
     Base.checkdims_perm(axes(B), axes(B), perm)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -906,11 +906,10 @@ end
 end
 
 conj(D::Diagonal) = Diagonal(conj(D.diag))
-transpose(D::Diagonal{<:Number}) = D
-transpose(D::Diagonal) = Diagonal(transpose.(D.diag))
-adjoint(D::Diagonal{<:Number}) = Diagonal(vec(adjoint(D.diag)))
-adjoint(D::Diagonal{<:Number,<:Base.ReshapedArray{<:Number,1,<:Adjoint}}) = Diagonal(adjoint(parent(D.diag)))
-adjoint(D::Diagonal) = Diagonal(adjoint.(D.diag))
+transpose(D::Diagonal) = Diagonal(vec(transpose(D.diag)))
+transpose(D::Diagonal{<:Any,<:Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}}) = Diagonal(transpose(parent(D.diag)))
+adjoint(D::Diagonal) = Diagonal(vec(adjoint(D.diag)))
+adjoint(D::Diagonal{<:Any,<:Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}}) = Diagonal(adjoint(parent(D.diag)))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(axes(D), axes(D), perm); D)
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -906,10 +906,8 @@ end
 end
 
 conj(D::Diagonal) = Diagonal(conj(D.diag))
-transpose(D::Diagonal) = Diagonal(vec(transpose(D.diag)))
-transpose(D::Diagonal{<:Any,<:Base.ReshapedArray{<:Any,1,<:TransposeAbsVec}}) = Diagonal(transpose(parent(D.diag)))
-adjoint(D::Diagonal) = Diagonal(vec(adjoint(D.diag)))
-adjoint(D::Diagonal{<:Any,<:Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}}) = Diagonal(adjoint(parent(D.diag)))
+transpose(D::Diagonal) = Diagonal(_vectranspose(D.diag))
+adjoint(D::Diagonal) = Diagonal(_vecadjoint(D.diag))
 permutedims(D::Diagonal) = D
 permutedims(D::Diagonal, perm) = (Base.checkdims_perm(axes(D), axes(D), perm); D)
 

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1240,4 +1240,17 @@ end
     @test_throws BoundsError B[LinearAlgebra.BandIndex(0,size(B,1)+1)]
 end
 
+@testset "lazy adjtrans" begin
+    B = Bidiagonal(fill([1 2; 3 4], 3), fill([5 6; 7 8], 2), :U)
+    m = [2 4; 6 8]
+    for op in (transpose, adjoint)
+        C = op(B)
+        el = op(m)
+        C[1,1] = el
+        @test B[1,1] == m
+        C[2,1] = el
+        @test B[1,2] == m
+    end
+end
+
 end # module TestBidiagonal

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1250,6 +1250,8 @@ end
         @test B[1,1] == m
         C[2,1] = el
         @test B[1,2] == m
+        @test (@allocated op(B)) == 0
+        @test (@allocated op(op(B))) == 0
     end
 end
 

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1523,6 +1523,8 @@ end
         el = op(m)
         C[1,1] = el
         @test D[1,1] == m
+        @test (@allocated op(D)) == 0
+        @test (@allocated op(op(D))) == 0
     end
 end
 

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1515,4 +1515,15 @@ end
     @test_throws BoundsError D[LinearAlgebra.BandIndex(0,size(D,1)+1)]
 end
 
+@testset "lazy adjtrans" begin
+    D = Diagonal(fill([1 2; 3 4], 3))
+    m = [2 4; 6 8]
+    for op in (transpose, adjoint)
+        C = op(D)
+        el = op(m)
+        C[1,1] = el
+        @test D[1,1] == m
+    end
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
Currently, `adjoint` and `transpose` for a block `Diagonal` and a block `Bidiagonal` matrix allocates the diagonals. This was not intentional, and we may use lazy wrappers instead that ensures that the result shares memory with the original array, which is what the documentation states. After this PR, mutating the `adjoint` will automatically mutate the parent array.