### PR TITLE
Check for elementwise equality when comparing with `UniformScaling`

### DIFF
--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -347,15 +347,17 @@ end
 function ==(A::AbstractMatrix, J::UniformScaling)
     require_one_based_indexing(A)
     size(A, 1) == size(A, 2) || return false
-    iszero(J.λ) && return iszero(A)
-    isone(J.λ) && return isone(A)
-    isdiag(A) || return false
-    return all(==(J.λ), diagview(A))
+    isempty(A) && return true
+    # Check that the elements of A are equal to those of J,
+    # this ensures that if A == J, their elements are equal as well
+    iszero(J.λ) && return first(A) == J.λ && iszero(A)
+    isone(J.λ) && return first(A) == J.λ && isone(A)
+    return _isequalto_uniformscaling(A, J)
 end
-function ==(A::StridedMatrix, J::UniformScaling)
-    size(A, 1) == size(A, 2) || return false
-    iszero(J.λ) && return iszero(A)
-    isone(J.λ) && return isone(A)
+function _isequalto_uniformscaling(A::AbstractMatrix, J::UniformScaling)
+    return isdiag(A) && all(==(J.λ), diagview(A))
+end
+function _isequalto_uniformscaling(A::StridedMatrix, J::UniformScaling)
     for j in axes(A, 2), i in axes(A, 1)
         ifelse(i == j, A[i, j] == J.λ, iszero(A[i, j])) || return false
     end

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -589,4 +589,11 @@ end
     @test A\J ≈ cA\J
 end
 
+@testset "block matrix equality" begin
+    A = Diagonal(fill(I(2), 4))
+    @test isone(A)
+    @test A != I
+    @test 0*A != 0*I
+end
+
 end # module TestUniformscaling


### PR DESCRIPTION
This works around issues with block matrices like:
```julia
julia> A = Diagonal(fill(I(2), 4))
4×4 Diagonal{Diagonal{Bool, Vector{Bool}}, Vector{Diagonal{Bool, Vector{Bool}}}}:
 Diagonal(Bool[1, 1])  …        ⋅       
       ⋅                        ⋅       
       ⋅                        ⋅       
       ⋅                  Diagonal(Bool[1, 1])

julia> A == I
true

julia> A[1,1] == I[1,1]
false
```
The checks in this PR ensure that if a matrix is `==` a `UniformScaling`, their elements are equal as well.

This builds on top of https://github.com/JuliaLang/LinearAlgebra.jl/pull/1367, and may be rebased once that is merged.