### PR TITLE
Adjoint/transpose for tridiagonal matrices preserve structure

### DIFF
--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1207,4 +1207,26 @@ end
     @test_throws BoundsError S[LinearAlgebra.BandIndex(0,size(S,1)+1)]
 end
 
+@testset "lazy adjtrans" begin
+    dv = fill([1 2; 3 4], 3)
+    ev = fill([5 6; 7 8], 2)
+    T = Tridiagonal(ev, dv, ev)
+    S = SymTridiagonal(dv, ev)
+    m = [2 4; 4 2]
+    for B in (copy(T), copy(S))
+        for op in (transpose, adjoint)
+            C = op(B)
+            el = op(m)
+            C[1,1] = el
+            @test B[1,1] == m
+            if B isa Tridiagonal
+                C[2,1] = el
+                @test B[1,2] == m
+            end
+            @test (@allocated op(B)) == 0
+            @test (@allocated op(op(B))) == 0
+        end
+    end
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
After this, `adjoint` and `transpose` for `Tridiagonal`/`SymTridiagonal` would preserve the structure. This was already the case for matrices of numbers, and this PR extends this to the general case.

```julia
julia> m = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> T = Tridiagonal(fill(m,3), fill(m,4), fill(m,3))
4×4 Tridiagonal{Matrix{Int64}, Vector{Matrix{Int64}}}:
 [1 2; 3 4]  [1 2; 3 4]      ⋅           ⋅     
 [1 2; 3 4]  [1 2; 3 4]  [1 2; 3 4]      ⋅     
     ⋅       [1 2; 3 4]  [1 2; 3 4]  [1 2; 3 4]
     ⋅           ⋅       [1 2; 3 4]  [1 2; 3 4]

julia> T'
4×4 Tridiagonal{Adjoint{Int64, Matrix{Int64}}, Base.ReshapedArray{Adjoint{Int64, Matrix{Int64}}, 1, Adjoint{Adjoint{Int64, Matrix{Int64}}, Vector{Matrix{Int64}}}, Tuple{}}}:
 [1 3; 2 4]  [1 3; 2 4]      ⋅           ⋅     
 [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]      ⋅     
     ⋅       [1 3; 2 4]  [1 3; 2 4]  [1 3; 2 4]
     ⋅           ⋅       [1 3; 2 4]  [1 3; 2 4]

julia> S = SymTridiagonal(fill(m, 4), fill(m, 3))
4×4 SymTridiagonal{Matrix{Int64}, Vector{Matrix{Int64}}}:
 [1 2; 2 4]  [1 2; 3 4]      ⋅           ⋅     
 [1 3; 2 4]  [1 2; 2 4]  [1 2; 3 4]      ⋅     
     ⋅       [1 3; 2 4]  [1 2; 2 4]  [1 2; 3 4]
     ⋅           ⋅       [1 3; 2 4]  [1 2; 2 4]

julia> S' isa SymTridiagonal
true

julia> S'' === S
true
```