### PR TITLE
Add banded paths to generic solve

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1236,27 +1236,23 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
     require_one_based_indexing(A, B)
     m, n = size(A)
     if m == n
-        if istril(A)
-            if istriu(A)
-                return Diagonal(A) \ B
-            elseif istriu(A, -1)
+        istrium1 = istriu(A, -1)
+        istril1 = istril(A, 1)
+        if istril1 && iszero(diagview(A,1)) # istril(A)
+            if istrium1
+                if iszero(diagview(A, -1))
+                    return Diagonal(A) \ B
+                end
                 return Bidiagonal(A, :L) \ B
             else
                 return LowerTriangular(A) \ B
             end
         end
-        if istriu(A)
-            if istril(A, 1)
+        if istrium1 && iszero(diagview(A, -1)) # istriu(A)
+            if istril1
                 return Bidiagonal(A, :U) \ B
             end
             return UpperTriangular(A) \ B
-        end
-        if isbanded(A, -1, 1)
-            T = Tridiagonal(A)
-            if issymmetric(T)
-                return SymTridiagonal(T) \ B
-            end
-            return lu(T) \ B
         end
         return lu(A) \ B
     end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1251,12 +1251,11 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
             end
             return UpperTriangular(A) \ B
         end
-        if istriu(A, -1) && istril(A, 1)
-            T = Tridiagonal(A)
+        if isbanded(A, -1, 1)
+            T = Tridiagonal(diagview(A,-1), diagview(A, 0), diagview(A, 1))
             if issymmetric(T)
                 return SymTridiagonal(T) \ B
             end
-            return T \ B
         end
         return lu(A) \ B
     end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1239,12 +1239,24 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
         if istril(A)
             if istriu(A)
                 return Diagonal(A) \ B
+            elseif istriu(A, -1)
+                return Bidiagonal(A, :L) \ B
             else
                 return LowerTriangular(A) \ B
             end
         end
         if istriu(A)
+            if istril(A, 1)
+                return Bidiagonal(A, :U) \ B
+            end
             return UpperTriangular(A) \ B
+        end
+        if istriu(A, -1) && istril(A, 1)
+            T = Tridiagonal(A)
+            if issymmetric(T)
+                return SymTridiagonal(T) \ B
+            end
+            return T \ B
         end
         return lu(A) \ B
     end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1256,6 +1256,7 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
             if issymmetric(T)
                 return SymTridiagonal(T) \ B
             end
+            return lu(T) \ B
         end
         return lu(A) \ B
     end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1252,7 +1252,7 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
             return UpperTriangular(A) \ B
         end
         if isbanded(A, -1, 1)
-            T = Tridiagonal(diagview(A,-1), diagview(A, 0), diagview(A, 1))
+            T = Tridiagonal(A)
             if issymmetric(T)
                 return SymTridiagonal(T) \ B
             end

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -1119,11 +1119,6 @@ function ldiv!(A::Tridiagonal, B::AbstractVecOrMat)
     return B
 end
 
-function Base.:(\)(A::Tridiagonal, B::AbstractVecOrMat)
-    T = Base.promote_op(\, eltype(A), eltype(B))
-    ldiv!(T.(A), copy(B))
-end
-
 # combinations of Tridiagonal and Symtridiagonal
 # copyto! for matching axes
 function _copyto_banded!(A::Tridiagonal, B::SymTridiagonal)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -1119,6 +1119,11 @@ function ldiv!(A::Tridiagonal, B::AbstractVecOrMat)
     return B
 end
 
+function Base.:(\)(A::Tridiagonal, B::AbstractVecOrMat)
+    T = Base.promote_op(\, eltype(A), eltype(B))
+    ldiv!(T.(A), copy(B))
+end
+
 # combinations of Tridiagonal and Symtridiagonal
 # copyto! for matching axes
 function _copyto_banded!(A::Tridiagonal, B::SymTridiagonal)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -937,4 +937,16 @@ end
     @test B == A2
 end
 
+@testset "linear solve for dense banded matrices" begin
+    b = randn(5)
+    for A in (diagm(0=>1:5, -1=>1:4, 1=>1:4), # SymTridiagonal
+              diagm(0=>1:5, -1=>1:4, 1=>5:8), # Tridiagonal
+              diagm(0=>1:5, 1=>1:4), # Upper Bidiagonal
+              diagm(0=>1:5, -1=>1:4), # Lower Bidiagonal
+            )
+        x = A \ b
+        @test A * x ≈ b
+    end
+end
+
 end # module TestGeneric


### PR DESCRIPTION
Currently, the generic solve only checks for diagonal and triangular matrices when dispatching to the faster methods. We also have solve methods for `Bidiagonal` and `SymTridiagonal` matrices, so we may add these branches as well.

With these,
```julia
julia> n = 5000; dv, ev = rand(n), rand(n-1);

julia> A = diagm(0=>dv, 1=>ev, -1=>ev); # symmetric tridiagonal by construction

julia> @btime $A \ $dv;
  656.843 ms (9 allocations: 190.81 MiB) # master
  11.549 ms (22 allocations: 235.09 KiB) # PR
```
After this change, almost all the time is spent on checking if the matrix is tridiagonal.