### PR TITLE
Forward `diagview` for `adjoint`/`transpose` to parent

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -569,3 +569,6 @@ Compute `vec(adjoint(A))`, but avoid an allocating reshape if possible
 """
 _vecadjoint(A::AbstractVector) = vec(adjoint(A))
 _vecadjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = adjoint(parent(A))
+
+diagview(A::Transpose, k::Integer = 0) = _vectranspose(diagview(parent(A), -k))
+diagview(A::Adjoint, k::Integer = 0) = _vecadjoint(diagview(parent(A), -k))

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -792,8 +792,8 @@ end
     for A in (rand(4, 4), rand(ComplexF64,4,4),
                 fill([1 2; 3 4], 4, 4))
         for k in -3:3
-            @test diagview(A', k) == diagview(copy(A'), k)
-            @test diagview(transpose(A), k) == diagview(copy(transpose(A)), k)
+            @test diagview(A', k) == diag(A', k)
+            @test diagview(transpose(A), k) == diag(transpose(A), k)
         end
         @test IndexStyle(diagview(A')) == IndexLinear()
     end

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -788,4 +788,15 @@ end
     end
 end
 
+@testset "diagview" begin
+    for A in (rand(4, 4), rand(ComplexF64,4,4),
+                fill([1 2; 3 4], 4, 4))
+        for k in -3:3
+            @test diagview(A', k) == diagview(copy(A'), k)
+            @test diagview(transpose(A), k) == diagview(copy(transpose(A)), k)
+        end
+        @test IndexStyle(diagview(A')) == IndexLinear()
+    end
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
After this,
```julia
julia> B = reshape([1:9;], 3, 3)
3×3 Matrix{Int64}:
 1  4  7
 2  5  8
 3  6  9

julia> diagview(B', 1)
2-element view(::Vector{Int64}, 2:4:6) with eltype Int64:
 2
 6
```
The view directly indexes into the parent, and the `adjoint` layer is removed. This also makes the view linearly indexed.