### PR TITLE
Appropriate zero in `_lu_tridiag!`

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -652,7 +652,7 @@ end
 
     # Initialize variables
     info = 0
-    fill!(du2, 0)
+    fill!(du2, zero(eltype(du2)))
 
     @inbounds begin
         for i = 1:n


### PR DESCRIPTION
Working on  #1372, I came across some unusual tests with non-Number `eltype`s, for which this `fill!` fails unless the appropriate zero is used. Probably missing convert methods, but we might as well use the zero of the eltype here.