### PR TITLE
Load testhelpers into test modules instead of `Main`

### DIFF
--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -9,10 +9,10 @@ using Test, LinearAlgebra
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
 using .Main.OffsetArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
 using .Main.ImmutableArrays
 
 @testset "Adjoint and Transpose inner constructor basics" begin

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
 using .OffsetArrays

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -10,10 +10,10 @@ const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
 include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+using .OffsetArrays
 
 include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+using .ImmutableArrays
 
 @testset "Adjoint and Transpose inner constructor basics" begin
     intvec, intmat = [1, 2], [1 2; 3 4]

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -7,12 +7,11 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using Main.LinearAlgebraTestHelpers
 using .OffsetArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
 using .ImmutableArrays
 
 @testset "Adjoint and Transpose inner constructor basics" begin

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -10,9 +10,8 @@ const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
 isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-using Main.LinearAlgebraTestHelpers
-using .OffsetArrays
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.OffsetArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 @testset "Adjoint and Transpose inner constructor basics" begin
     intvec, intmat = [1, 2], [1 2; 3 4]

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -10,22 +10,22 @@ using LinearAlgebra: BlasReal, BlasFloat
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
 
-isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($TESTHELPERS, "InfiniteArrays.jl"))
-using .Main.InfiniteArrays
+include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
+using .InfiniteArrays
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-using .Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+using .FillArrays
 
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using .OffsetArrays
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
 using .Main.ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -26,7 +26,7 @@ include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays
 
 include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+using .ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase
 

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -11,13 +11,12 @@ const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
 isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-using Main.LinearAlgebraTestHelpers
-using .Quaternions
-using .InfiniteArrays
-using .FillArrays
-using .OffsetArrays
-using .SizedArrays
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
+using Main.LinearAlgebraTestHelpers.InfiniteArrays
+using Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.OffsetArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase
 

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -8,24 +8,15 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasReal, BlasFloat
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using Main.LinearAlgebraTestHelpers
 using .Quaternions
-
-include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
 using .InfiniteArrays
-
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
 using .FillArrays
-
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
 using .OffsetArrays
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
 using .ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -7,8 +7,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasReal, BlasFloat
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -9,9 +9,10 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted,
     PosDefException, RankDeficientException, chkfullrank
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using Main.LinearAlgebraTestHelpers
 using .Quaternions
 
 function unary_ops_tests(a, ca, tol; n=size(a, 1))

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -11,8 +11,8 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted,
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
 
 function unary_ops_tests(a, ca, tol; n=size(a, 1))
     @test inv(ca)*a ≈ Matrix(I, n, n)

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -12,8 +12,7 @@ const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
 isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-using Main.LinearAlgebraTestHelpers
-using .Quaternions
+using Main.LinearAlgebraTestHelpers.Quaternions
 
 function unary_ops_tests(a, ca, tol; n=size(a, 1))
     @test inv(ca)*a ≈ Matrix(I, n, n)

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -8,8 +8,8 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted,
     PosDefException, RankDeficientException, chkfullrank
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -9,13 +9,11 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal
 using Test: GenericArray
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
-import .FillArrays
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
+import Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
 
 @testset "Check that non-floats are correctly promoted" begin
     @test [1 0 0; 0 1 0]\[1,1] ≈ [1;1;0]

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -11,11 +11,11 @@ using Test: GenericArray
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-import Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+import .FillArrays
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
 @testset "Check that non-floats are correctly promoted" begin
     @test [1 0 0; 0 1 0]\[1,1] ≈ [1;1;0]

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -8,8 +8,8 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasComplex, BlasFloat, BlasReal
 using Test: GenericArray
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "FillArrays.jl"))
 import .FillArrays

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -7,8 +7,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasFloat, BlasComplex
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
 using .OffsetArrays

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -10,20 +10,20 @@ using LinearAlgebra: BlasFloat, BlasComplex
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using .OffsetArrays
 
-isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($TESTHELPERS, "InfiniteArrays.jl"))
-using .Main.InfiniteArrays
+include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
+using .InfiniteArrays
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-using .Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+using .FillArrays
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
+using .ImmutableArrays
 
 const n=12 # Size of matrix problem to test
 Random.seed!(1)

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -8,22 +8,14 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: BlasFloat, BlasComplex
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
-using .OffsetArrays
-
-include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
-using .InfiniteArrays
-
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
-using .FillArrays
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.OffsetArrays
+using Main.LinearAlgebraTestHelpers.InfiniteArrays
+using Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 const n=12 # Size of matrix problem to test
 Random.seed!(1)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -8,8 +8,8 @@ using Test, LinearAlgebra, Random
 using Test: GenericArray
 using LinearAlgebra: isbanded
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -11,20 +11,20 @@ using LinearAlgebra: isbanded
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
 
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using .OffsetArrays
 
-isdefined(Main, :DualNumbers) || @eval Main include(joinpath($TESTHELPERS, "DualNumbers.jl"))
-using .Main.DualNumbers
+include(joinpath(TESTHELPERS, "DualNumbers.jl"))
+using .DualNumbers
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-using .Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+using .FillArrays
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
 Random.seed!(123)
 

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -9,22 +9,14 @@ using Test: GenericArray
 using LinearAlgebra: isbanded
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
-using .Quaternions
-
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
-using .OffsetArrays
-
-include(joinpath(TESTHELPERS, "DualNumbers.jl"))
-using .DualNumbers
-
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
-using .FillArrays
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
+using Main.LinearAlgebraTestHelpers.OffsetArrays
+using Main.LinearAlgebraTestHelpers.DualNumbers
+using Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
 
 Random.seed!(123)
 

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -9,11 +9,11 @@ using Test, LinearAlgebra, Random
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
+using .ImmutableArrays
 
 # for tuple tests below
 ≅(x,y) = all(p -> p[1] ≈ p[2], zip(x,y))

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -7,13 +7,11 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 # for tuple tests below
 ≅(x,y) = all(p -> p[1] ≈ p[2], zip(x,y))

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -8,8 +8,8 @@ using Base: rtoldefault
 using Test, LinearAlgebra, Random
 using LinearAlgebra: mul!, Symmetric, Hermitian
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -11,8 +11,8 @@ using LinearAlgebra: mul!, Symmetric, Hermitian
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
 ## Test Julia fallbacks to BLAS routines
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -9,10 +9,10 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: mul!, Symmetric, Hermitian
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
 
 ## Test Julia fallbacks to BLAS routines
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,10 @@ include("prune_old_LA.jl")
 
 using Test, LinearAlgebra
 
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
+
 for file in readlines(joinpath(@__DIR__, "testgroups"))
     @info "Testing $file"
     include(file * ".jl")

--- a/test/special.jl
+++ b/test/special.jl
@@ -10,8 +10,8 @@ using LinearAlgebra: rmul!, BandIndex
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
 n= 10 #Size of matrix to test
 Random.seed!(1)

--- a/test/special.jl
+++ b/test/special.jl
@@ -8,10 +8,10 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: rmul!, BandIndex
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
 
 n= 10 #Size of matrix to test
 Random.seed!(1)

--- a/test/special.jl
+++ b/test/special.jl
@@ -7,8 +7,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 using LinearAlgebra: rmul!, BandIndex
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -9,8 +9,8 @@ using Test, LinearAlgebra
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
 @testset "broadcast[!] over combinations of scalars, structured matrices, and dense vectors/matrices" begin
     @testset for N in (0,1,2,10) # some edge cases, and a structured case

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -7,10 +7,10 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
 
 @testset "broadcast[!] over combinations of scalars, structured matrices, and dense vectors/matrices" begin
     @testset for N in (0,1,2,10) # some edge cases, and a structured case

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -7,16 +7,12 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
-using .Quaternions
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 Random.seed!(1010)
 

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -9,14 +9,14 @@ using Test, LinearAlgebra, Random
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
+using .ImmutableArrays
 
 Random.seed!(1010)
 

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/testhelpers/testhelpers.jl
+++ b/test/testhelpers/testhelpers.jl
@@ -1,0 +1,16 @@
+module LinearAlgebraTestHelpers
+
+export DualNumbers, FillArrays, Furlongs, ImmutableArrays,
+       InfiniteArrays, OffsetArrays, Quaternions, SizedArrays, StructArrays
+
+include("DualNumbers.jl")
+include("FillArrays.jl")
+include("Furlongs.jl")
+include("ImmutableArrays.jl")
+include("InfiniteArrays.jl")
+include("OffsetArrays.jl")
+include("Quaternions.jl")
+include("SizedArrays.jl")
+include("StructArrays.jl")
+
+end

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -8,8 +8,8 @@ using Test, LinearAlgebra, Random
 using LinearAlgebra: errorbounds, transpose!, BandIndex
 using Test: GenericArray
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "SizedArrays.jl"))
 using .SizedArrays
@@ -246,7 +246,7 @@ end
 end
 
 # dimensional correctness:
-const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
+const TESTDIR = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 
 @testset "AbstractArray constructor should preserve underlying storage type" begin
     # tests corresponding to #34995

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -9,16 +9,12 @@ using LinearAlgebra: errorbounds, transpose!, BandIndex
 using Test: GenericArray
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
-
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
-using .FillArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 n = 9
 Random.seed!(123)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -11,14 +11,14 @@ using Test: GenericArray
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-using .Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+using .FillArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
+using .ImmutableArrays
 
 n = 9
 Random.seed!(123)

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -9,23 +9,23 @@ using Test, LinearAlgebra, Random
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
 
-isdefined(Main, :InfiniteArrays) || @eval Main include(joinpath($TESTHELPERS, "InfiniteArrays.jl"))
-using .Main.InfiniteArrays
+include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
+using .InfiniteArrays
 
-isdefined(Main, :FillArrays) || @eval Main include(joinpath($TESTHELPERS, "FillArrays.jl"))
-using .Main.FillArrays
+include(joinpath(TESTHELPERS, "FillArrays.jl"))
+using .FillArrays
 
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using .OffsetArrays
 
-isdefined(Main, :SizedArrays) || @eval Main include(joinpath($TESTHELPERS, "SizedArrays.jl"))
-using .Main.SizedArrays
+include(joinpath(TESTHELPERS, "SizedArrays.jl"))
+using .SizedArrays
 
-isdefined(Main, :ImmutableArrays) || @eval Main include(joinpath($TESTHELPERS, "ImmutableArrays.jl"))
-using .Main.ImmutableArrays
+include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
+using .ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase
 

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -7,25 +7,15 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
-using .Quaternions
-
-include(joinpath(TESTHELPERS, "InfiniteArrays.jl"))
-using .InfiniteArrays
-
-include(joinpath(TESTHELPERS, "FillArrays.jl"))
-using .FillArrays
-
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
-using .OffsetArrays
-
-include(joinpath(TESTHELPERS, "SizedArrays.jl"))
-using .SizedArrays
-
-include(joinpath(TESTHELPERS, "ImmutableArrays.jl"))
-using .ImmutableArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
+using Main.LinearAlgebraTestHelpers.InfiniteArrays
+using Main.LinearAlgebraTestHelpers.FillArrays
+using Main.LinearAlgebraTestHelpers.OffsetArrays
+using Main.LinearAlgebraTestHelpers.SizedArrays
+using Main.LinearAlgebraTestHelpers.ImmutableArrays
 
 include("testutils.jl") # test_approx_eq_modphase
 

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -7,13 +7,11 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 using Test, LinearAlgebra, Random
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Quaternions.jl"))
-using .Quaternions
-
-include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
-using .OffsetArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
+using Main.LinearAlgebraTestHelpers.OffsetArrays
 
 Random.seed!(1234543)
 

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -9,10 +9,11 @@ using Test, LinearAlgebra, Random
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Quaternions) || @eval Main include(joinpath($TESTHELPERS, "Quaternions.jl"))
-using .Main.Quaternions
-isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($TESTHELPERS, "OffsetArrays.jl"))
-using .Main.OffsetArrays
+include(joinpath(TESTHELPERS, "Quaternions.jl"))
+using .Quaternions
+
+include(joinpath(TESTHELPERS, "OffsetArrays.jl"))
+using .OffsetArrays
 
 Random.seed!(1234543)
 

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -6,8 +6,8 @@ isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Quaternions.jl"))
 using .Quaternions

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -6,8 +6,8 @@ using Test, LinearAlgebra, Random
 
 Random.seed!(1234321)
 
-const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
+const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
 
 include(joinpath(TESTHELPERS, "Furlongs.jl"))
 using .Furlongs

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -9,8 +9,8 @@ Random.seed!(1234321)
 const BASE_TEST_PATH = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(BASE_TEST_PATH, "testhelpers")
 
-isdefined(Main, :Furlongs) || @eval Main include(joinpath($TESTHELPERS, "Furlongs.jl"))
-using .Main.Furlongs
+include(joinpath(TESTHELPERS, "Furlongs.jl"))
+using .Furlongs
 
 LinearAlgebra.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 

--- a/test/unitful.jl
+++ b/test/unitful.jl
@@ -7,10 +7,10 @@ using Test, LinearAlgebra, Random
 Random.seed!(1234321)
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
-const TESTHELPERS = joinpath(TESTDIR, "testhelpers")
+const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")
+isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
-include(joinpath(TESTHELPERS, "Furlongs.jl"))
-using .Furlongs
+using Main.LinearAlgebraTestHelpers.Furlongs
 
 LinearAlgebra.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 


### PR DESCRIPTION
This avoids unnecessary namespace collisions in `Main`.