### PR TITLE
Iterator norm in `isapprox` for `Array`s

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2020,8 +2020,9 @@ function isapprox(x::AbstractArray, y::AbstractArray;
 end
 
 norm_x_minus_y(x, y) = norm(x - y)
-const ArrayOrFastContiguousSubArrayStrided = Union{Array, FastContiguousSubArrayStrided}
-function norm_x_minus_y(x::ArrayOrFastContiguousSubArrayStrided, y::ArrayOrFastContiguousSubArrayStrided)
+FastContiguousArrayView{T,N,P<:Array,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
+const ArrayOrFastContiguousArrayView = Union{Array, FastContiguousArrayView}
+function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView)
     norm(Iterators.map(splat(-), zip(x,y)))
 end
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,12 +2004,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    Base.promote_shape(size(x), size(y)) # ensure compatible size
-    d = if isempty(x) && isempty(y)
-        norm(zero(eltype(x)) - zero(eltype(y)))
-    else
-        norm_x_minus_y(x, y)
-    end
+    d = norm_x_minus_y(x, y)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
@@ -2023,7 +2018,12 @@ norm_x_minus_y(x, y) = norm(x - y)
 FastContiguousArrayView{T,N,P<:Array,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
 const ArrayOrFastContiguousArrayView = Union{Array, FastContiguousArrayView}
 function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView)
-    norm(Iterators.map(splat(-), zip(x,y)))
+    Base.promote_shape(size(x), size(y)) # ensure compatible size
+    if isempty(x) && isempty(y)
+        norm(zero(eltype(x)) - zero(eltype(y)))
+    else
+        norm(Iterators.map(splat(-), zip(x,y)))
+    end
 end
 
 """

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,7 +2004,12 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    d = norm_x_minus_y(x, y)
+    d = if isempty(x) && isempty(y)
+        Base.promote_shape(size(x), size(y)) # ensure same size
+        norm(zero(eltype(x)) - zero(eltype(y)))
+    else
+        norm_x_minus_y(x, y)
+    end
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,7 +2004,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    d = norm(x - y)
+    d = norm_x_minus_y(x, y)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
@@ -2012,6 +2012,12 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         # (mapreduce instead of all for greater generality [#44893])
         return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
+end
+
+norm_x_minus_y(x, y) = norm(x - y)
+function norm_x_minus_y(x::Array, y::Array)
+    Base.promote_shape(size(x), size(y)) # ensure same size
+    norm(Iterators.map(splat(-), zip(x,y)))
 end
 
 """

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,8 +2004,8 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
+    Base.promote_shape(size(x), size(y)) # ensure compatible size
     d = if isempty(x) && isempty(y)
-        Base.promote_shape(size(x), size(y)) # ensure same size
         norm(zero(eltype(x)) - zero(eltype(y)))
     else
         norm_x_minus_y(x, y)
@@ -2020,8 +2020,8 @@ function isapprox(x::AbstractArray, y::AbstractArray;
 end
 
 norm_x_minus_y(x, y) = norm(x - y)
-function norm_x_minus_y(x::Array, y::Array)
-    Base.promote_shape(size(x), size(y)) # ensure same size
+const ArrayOrFastContiguousSubArrayStrided = Union{Array, FastContiguousSubArrayStrided}
+function norm_x_minus_y(x::ArrayOrFastContiguousSubArrayStrided, y::ArrayOrFastContiguousSubArrayStrided)
     norm(Iterators.map(splat(-), zip(x,y)))
 end
 

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -938,11 +938,12 @@ end
     @test B == A2
 end
 
-@testset "isapprox alloc" begin
+@testset "isapprox for Arrays" begin
     A = rand(3,3)
     isapprox(A, A)
     n = @allocated isapprox(A, A)
     @test n == 0
+    @test Int[] ≈ Int[]
 end
 
 end # module TestGeneric

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -940,7 +940,6 @@ end
 
 @testset "isapprox for Arrays" begin
     A = rand(3,3)
-    isapprox(A, A)
     n = @allocated isapprox(A, A)
     @test n == 0
     @test Int[] ≈ Int[]

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -938,4 +938,11 @@ end
     @test B == A2
 end
 
+@testset "isapprox alloc" begin
+    A = rand(3,3)
+    isapprox(A, A)
+    n = @allocated isapprox(A, A)
+    @test n == 0
+end
+
 end # module TestGeneric


### PR DESCRIPTION
This seems to improve performance and reduce allocations:
```julia
julia> A = rand(100,100);

julia> @btime isapprox($A, $A);
  13.305 μs (3 allocations: 78.21 KiB) # master
  8.063 μs (0 allocations: 0 bytes) # this PR

julia> A = rand(5000,5000);

julia> @btime isapprox($A, $A);
  106.003 ms (3 allocations: 190.74 MiB) # master
  43.122 ms (0 allocations: 0 bytes) # this PR
```
Currently, this is only specialized for `Array`s and contiguous views of `Array`s, as these are the cases with a significant performance improvement.