### PR TITLE
Specialize `triu!` and `tril!` for adj/trans

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -572,3 +572,7 @@ _vecadjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = adjoint(parent(A))
 
 diagview(A::Transpose, k::Integer = 0) = _vectranspose(diagview(parent(A), -k))
 diagview(A::Adjoint, k::Integer = 0) = _vecadjoint(diagview(parent(A), -k))
+
+# triu and tril
+triu!(A::AdjOrTransAbsMat, k::Integer = 0) = wrapperop(A)(tril!(parent(A), -k))
+tril!(A::AdjOrTransAbsMat, k::Integer = 0) = wrapperop(A)(triu!(parent(A), -k))

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -798,4 +798,15 @@ end
     end
 end
 
+@testset "triu!/tril!" begin
+    @testset for sz in ((4,4), (3,4), (4,3))
+        A = rand(sz...)
+        B = similar(A)
+        @testset for f in (adjoint, transpose), k in -3:3
+            @test triu!(f(copy!(B, A)), k) == triu(f(A), k)
+            @test tril!(f(copy!(B, A)), k) == tril!(f(A), k)
+        end
+    end
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
We may forward the operation to the parent, which would usually ensure that the loops are cache-friendly. 