### PR TITLE
Specialize lmul!/rmul! for adjoint/transpose

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -513,8 +513,9 @@ function _dot_nonrecursive(u, v)
     end
 end
 
-rmul!(X::AdjOrTrans, s::Number) = (lmul!(wrapperop(X)(s), parent(X)); X)
-lmul!(s::Number, X::AdjOrTrans) = (rmul!(parent(X), wrapperop(X)(s)); X)
+# we use (n A^T) = (A n)^T, which holds if the product of n and the elements of A is commutative
+rmul!(X::AdjOrTrans{<:Union{Real,Complex}}, s::Union{Real,Complex}) = (lmul!(wrapperop(X)(s), parent(X)); X)
+lmul!(s::Union{Real,Complex}, X::AdjOrTrans{<:Union{Real,Complex}}) = (rmul!(parent(X), wrapperop(X)(s)); X)
 
 # Adjoint/Transpose-vector * vector
 *(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -513,6 +513,9 @@ function _dot_nonrecursive(u, v)
     end
 end
 
+rmul!(X::AdjOrTrans, s::Number) = (rmul!(parent(X), s); X)
+lmul!(s::Number, X::AdjOrTrans) = (lmul!(s, parent(X)); X)
+
 # Adjoint/Transpose-vector * vector
 *(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)
 *(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -513,8 +513,8 @@ function _dot_nonrecursive(u, v)
     end
 end
 
-rmul!(X::AdjOrTrans, s::Number) = (rmul!(parent(X), s); X)
-lmul!(s::Number, X::AdjOrTrans) = (lmul!(s, parent(X)); X)
+rmul!(X::AdjOrTrans, s::Number) = (lmul!(wrapperop(X)(s), parent(X)); X)
+lmul!(s::Number, X::AdjOrTrans) = (rmul!(parent(X), wrapperop(X)(s)); X)
 
 # Adjoint/Transpose-vector * vector
 *(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -514,8 +514,10 @@ function _dot_nonrecursive(u, v)
 end
 
 # we use (n A^T) = (A n)^T, which holds if the product of n and the elements of A is commutative
-rmul!(X::AdjOrTrans{<:Union{Real,Complex}}, s::Union{Real,Complex}) = (lmul!(wrapperop(X)(s), parent(X)); X)
-lmul!(s::Union{Real,Complex}, X::AdjOrTrans{<:Union{Real,Complex}}) = (rmul!(parent(X), wrapperop(X)(s)); X)
+rmul!(X::Transpose{<:Union{Real,Complex}}, s::Union{Real,Complex}) = (lmul!(s, parent(X)); X)
+rmul!(X::Adjoint, s::Number) = (lmul!(s', parent(X)); X)
+lmul!(s::Union{Real,Complex}, X::Transpose{<:Union{Real,Complex}}) = (rmul!(parent(X), s); X)
+lmul!(s::Number, X::Adjoint) = (rmul!(parent(X), s'); X)
 
 # Adjoint/Transpose-vector * vector
 *(u::AdjointAbsVec{<:Number}, v::AbstractVector{<:Number}) = dot(u.parent, v)

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -513,7 +513,6 @@ function _dot_nonrecursive(u, v)
     end
 end
 
-# we use (n A^T) = (A n)^T, which holds if the product of n and the elements of A is commutative
 rmul!(X::Transpose{<:Union{Real,Complex}}, s::Union{Real,Complex}) = (lmul!(s, parent(X)); X)
 rmul!(X::Adjoint, s::Number) = (lmul!(s', parent(X)); X)
 lmul!(s::Union{Real,Complex}, X::Transpose{<:Union{Real,Complex}}) = (rmul!(parent(X), s); X)

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -809,4 +809,14 @@ end
     end
 end
 
+@testset "lmul!/rmul! by numbers" begin
+    for A in (rand(4, 4), rand(ComplexF64,4,4),
+                fill([1 2; 3 4], 4, 4))
+        B = copy(A)
+        @test lmul!(2, B) == 2 * A
+        B .= A
+        @test rmul!(B, 2) == A * 2
+    end
+end
+
 end # module TestAdjointTranspose

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -12,6 +12,7 @@ isdefined(Main, :LinearAlgebraTestHelpers) || Base.include(Main, TESTHELPERS)
 
 using Main.LinearAlgebraTestHelpers.OffsetArrays
 using Main.LinearAlgebraTestHelpers.ImmutableArrays
+using Main.LinearAlgebraTestHelpers.Quaternions
 
 @testset "Adjoint and Transpose inner constructor basics" begin
     intvec, intmat = [1, 2], [1 2; 3 4]
@@ -811,7 +812,8 @@ end
 
 @testset "lmul!/rmul! by numbers" begin
     @testset "$(eltype(A))" for A in (rand(4, 4), rand(ComplexF64,4,4),
-                fill([1 2; 3 4], 4, 4))
+                fill([1 2; 3 4], 4, 4),
+                fill(Quaternion(1,2,3,4), 4, 4))
         B = copy(A)
         @testset for op in (transpose, adjoint)
             A .= B
@@ -823,6 +825,13 @@ end
                 @test lmul!(-2im, op(A)) == -2im * op(B)
                 A .= B
                 @test rmul!(op(A), -2im) == op(B) * -2im
+            end
+            if eltype(A) <: Quaternion
+                A .= B
+                q = Quaternion(0,1,4,7)
+                @test lmul!(q, op(A)) == q * op(B)
+                A .= B
+                @test rmul!(op(A), q) == op(B) * q
             end
         end
     end

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -810,12 +810,21 @@ end
 end
 
 @testset "lmul!/rmul! by numbers" begin
-    for A in (rand(4, 4), rand(ComplexF64,4,4),
+    @testset "$(eltype(A))" for A in (rand(4, 4), rand(ComplexF64,4,4),
                 fill([1 2; 3 4], 4, 4))
         B = copy(A)
-        @test lmul!(2, B) == 2 * A
-        B .= A
-        @test rmul!(B, 2) == A * 2
+        @testset for op in (transpose, adjoint)
+            A .= B
+            @test lmul!(2, op(A)) == 2 * op(B)
+            A .= B
+            @test rmul!(op(A), 2) == op(B) * 2
+            if eltype(A) <: Complex
+                A .= B
+                @test lmul!(-2im, op(A)) == -2im * op(B)
+                A .= B
+                @test rmul!(op(A), -2im) == op(B) * -2im
+            end
+        end
     end
 end
 


### PR DESCRIPTION
This ensures that the scaling happens in a cache-friendly manner, which improves performance.

```julia
julia> A = adjoint(rand(100,100));
 
julia> @btime rmul!($A, 2.0);
  2.877 μs (0 allocations: 0 bytes) # nightly
  961.385 ns (0 allocations: 0 bytes) # this PR
```