### PR TITLE
Generic fallback for `fillstored!`

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -576,3 +576,8 @@ diagview(A::Adjoint, k::Integer = 0) = _vecadjoint(diagview(parent(A), -k))
 # triu and tril
 triu!(A::AdjOrTransAbsMat, k::Integer = 0) = wrapperop(A)(tril!(parent(A), -k))
 tril!(A::AdjOrTransAbsMat, k::Integer = 0) = wrapperop(A)(triu!(parent(A), -k))
+
+function fillstored!(A::AdjOrTransAbsMat, v)
+    fillstored!(parent(A), wrapperop(A)(v))
+    return A
+end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -218,6 +218,8 @@ function fillband!(A::AbstractMatrix{T}, x, l, u) where T
     return A
 end
 
+fillstored!(A::AbstractMatrix, v) = fill!(A, v)
+
 diagind(m::Integer, n::Integer, k::Integer=0) = diagind(IndexLinear(), m, n, k)
 diagind(::IndexLinear, m::Integer, n::Integer, k::Integer=0) =
     k <= 0 ? range(1-k, step=m+1, length=min(m+k, n)) : range(k*m+1, step=m+1, length=min(m, n-k))

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -812,11 +812,11 @@ end
 @testset "fillstored!" begin
     A = rand(ComplexF64, 4, 4)
     U = UpperTriangular(A)
-    @testset for op in (adjoint, transpose)
+    @testset for (op, f) in ((Adjoint, adjoint), (Transpose, transpose))
         @test LinearAlgebra.fillstored!(op(A), 1) == op(fill(1, size(A)))
-        @test LinearAlgebra.fillstored!(op(A), 2im) == op(fill(op(2im), size(A)))
+        @test LinearAlgebra.fillstored!(op(A), 2im) == op(fill(f(2im), size(A)))
         @test LinearAlgebra.fillstored!(op(U), 1) == op(triu(fill(1, size(U))))
-        @test LinearAlgebra.fillstored!(op(U), 2im) == op(triu(fill(op(2im), size(U))))
+        @test LinearAlgebra.fillstored!(op(U), 2im) == op(triu(fill(f(2im), size(U))))
     end
 end
 

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -809,4 +809,15 @@ end
     end
 end
 
+@testset "fillstored!" begin
+    A = rand(ComplexF64, 4, 4)
+    U = UpperTriangular(A)
+    @testset for op in (adjoint, transpose)
+        @test LinearAlgebra.fillstored!(op(A), 1) == op(fill(1, size(A)))
+        @test LinearAlgebra.fillstored!(op(A), 2im) == op(fill(op(2im), size(A)))
+        @test LinearAlgebra.fillstored!(op(U), 1) == op(triu(fill(1, size(U))))
+        @test LinearAlgebra.fillstored!(op(U), 2im) == op(triu(fill(op(2im), size(U))))
+    end
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
Also, specialize for `Adjoint`/`Transpose` to dispatch to the methods for the parent.

The following works after this:
```julia
julia> U = Adjoint(UpperTriangular(zeros(2,2)))
2×2 adjoint(::UpperTriangular{Float64, Matrix{Float64}}) with eltype Float64:
 0.0   ⋅ 
 0.0  0.0

julia> LinearAlgebra.fillstored!(U, 3)
2×2 adjoint(::UpperTriangular{Float64, Matrix{Float64}}) with eltype Float64:
 3.0   ⋅ 
 3.0  3.0
```