### PR TITLE
Specialize 5-arg `Hermitian`-`Adjoint` multiplication

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -679,6 +679,12 @@ end
 
 # Special handling for adj/trans vec
 matprod_dest(A::Diagonal, B::AdjOrTransAbsVec, TS) = similar(B, TS)
+# Hermitian and Adjoint multiplication is handled by conjugating the terms
+matprod_dest(H::Hermitian, A::AdjointAbsMat, TS) = adjoint(matprod_dest(adjoint(A), H, TS))
+matprod_dest(A::AdjointAbsMat, H::Hermitian, TS) = adjoint(matprod_dest(H, adjoint(A), TS))
+# Symmetric and Transpose multiplication is handled by transposing the terms
+matprod_dest(S::Symmetric, T::TransposeAbsMat, TS) = transpose(matprod_dest(transpose(T), S, TS))
+matprod_dest(T::TransposeAbsMat, S::Symmetric, TS) = transpose(matprod_dest(S, transpose(T), TS))
 
 # General fallback definition for handling under- and overdetermined system as well as square problems
 # While this definition is pretty general, it does e.g. promote to common element type of lhs and rhs

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -732,11 +732,11 @@ for (AdjTransT, SymHermT) in (
 
     @eval begin
         function mul!(C::$AdjTransT, A::$SymHermT, B::$AdjTransT, α::Union{Real,Complex}, β::Union{Real,Complex})
-            mul!(wrapperop(C)(C), wrapperop(B)(B), A, α, β)
+            mul!(wrapperop(C)(C), wrapperop(B)(B), A, wrapperop(C)(α), wrapperop(C)(β))
             return C
         end
         function mul!(C::$AdjTransT, A::$AdjTransT, B::$SymHermT, α::Union{Real,Complex}, β::Union{Real,Complex})
-            mul!(wrapperop(C)(C), B, wrapperop(A)(A), α, β)
+            mul!(wrapperop(C)(C), B, wrapperop(A)(A), wrapperop(C)(α), wrapperop(C)(β))
             return C
         end
     end

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -876,21 +876,31 @@ end
     end
 end
 
-@testset "Multiplications symmetric/hermitian for $T and $S" for T in
-        (Float16, Float32, Float64, BigFloat), S in (ComplexF16, ComplexF32, ComplexF64)
-    let A = transpose(Symmetric(rand(S, 3, 3))), Bv = Vector(rand(T, 3)), Bm = Matrix(rand(T, 3,3))
+@testset "Multiplications symmetric/hermitian for $T and $S for size $n" for T in
+        (Float16, Float32, Float64, BigFloat, Quaternion{Float64}),
+        S in (T <: Quaternion ? (Quaternion{Float64},) : (ComplexF16, ComplexF32, ComplexF64, Quaternion{Float64})),
+        n in (2, 3, 4)
+    let A = transpose(Symmetric(rand(S, n, n))), Bv = Vector(rand(T, n)), Bm = Matrix(rand(T, n,n))
         @test A * Bv ≈ Matrix(A) * Bv
         @test A * Bm ≈ Matrix(A) * Bm
+        @test A * transpose(Bm) ≈ Matrix(A) * transpose(Bm)
+        @test A * adjoint(Bm) ≈ Matrix(A) * adjoint(Bm)
         @test Bm * A ≈ Bm * Matrix(A)
+        @test transpose(Bm) * A ≈ transpose(Bm) * Matrix(A)
+        @test adjoint(Bm) * A ≈ adjoint(Bm) * Matrix(A)
     end
-    let A = adjoint(Hermitian(rand(S, 3,3))), Bv = Vector(rand(T, 3)), Bm = Matrix(rand(T, 3,3))
+    let A = adjoint(Hermitian(rand(S, n,n))), Bv = Vector(rand(T, n)), Bm = Matrix(rand(T, n,n))
         @test A * Bv ≈ Matrix(A) * Bv
         @test A * Bm ≈ Matrix(A) * Bm
+        @test A * transpose(Bm) ≈ Matrix(A) * transpose(Bm)
+        @test A * adjoint(Bm) ≈ Matrix(A) * adjoint(Bm)
         @test Bm * A ≈ Bm * Matrix(A)
+        @test transpose(Bm) * A ≈ transpose(Bm) * Matrix(A)
+        @test adjoint(Bm) * A ≈ adjoint(Bm) * Matrix(A)
     end
-    let Ahrs = transpose(Hermitian(Symmetric(rand(T, 3, 3)))),
-        Acs = transpose(Symmetric(rand(S, 3, 3))),
-        Ahcs = transpose(Hermitian(Symmetric(rand(S, 3, 3))))
+    let Ahrs = transpose(Hermitian(Symmetric(rand(T, n, n)))),
+        Acs = transpose(Symmetric(rand(S, n, n))),
+        Ahcs = transpose(Hermitian(Symmetric(rand(S, n, n))))
 
         @test Ahrs * Ahrs ≈ Ahrs * Matrix(Ahrs)
         @test Ahrs * Acs ≈ Ahrs * Matrix(Acs)
@@ -899,9 +909,9 @@ end
         @test Ahrs * Ahcs ≈ Matrix(Ahrs) * Ahcs
         @test Ahcs * Ahrs ≈ Ahcs * Matrix(Ahrs)
     end
-    let Ahrs = adjoint(Hermitian(Symmetric(rand(T, 3, 3)))),
-        Acs = adjoint(Symmetric(rand(S, 3, 3))),
-        Ahcs = adjoint(Hermitian(Symmetric(rand(S, 3, 3))))
+    let Ahrs = adjoint(Hermitian(Symmetric(rand(T, n, n)))),
+        Acs = adjoint(Symmetric(rand(S, n, n))),
+        Ahcs = adjoint(Hermitian(Symmetric(rand(S, n, n))))
 
         @test Ahrs * Ahrs ≈ Ahrs * Matrix(Ahrs)
         @test Ahcs * Ahcs ≈ Matrix(Ahcs) * Matrix(Ahcs)

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -900,10 +900,11 @@ end
         @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
         @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
         if eltype(C) <: Complex
-            @test mul!(adjoint(copy(C)), A, adjoint(Bm), 4+2im, 3+im) ≈ A * adjoint(Bm) * (4+2im) + adjoint(C) * (3+im)
-            @test mul!(adjoint(copy(C)), adjoint(Bm), A, 4+2im, 3+im) ≈ adjoint(Bm) * A * (4+2im) + adjoint(C) * (3+im)
-            @test mul!(transpose(copy(C)), A, transpose(Bm), 4+2im, 3+im) ≈ A * transpose(Bm) * (4+2im) + transpose(C) * (3+im)
-            @test mul!(transpose(copy(C)), transpose(Bm), A, 4+2im, 3+im) ≈ transpose(Bm) * A * (4+2im) + transpose(C) * (3+im)
+            alpha, beta  = 4+2im, 3+im
+            @test mul!(adjoint(copy(C)), A, adjoint(Bm), alpha, beta) ≈ A * adjoint(Bm) * alpha + adjoint(C) * beta
+            @test mul!(adjoint(copy(C)), adjoint(Bm), A, alpha, beta) ≈ adjoint(Bm) * A * alpha + adjoint(C) * beta
+            @test mul!(transpose(copy(C)), A, transpose(Bm), alpha, beta) ≈ A * transpose(Bm) * alpha + transpose(C) * beta
+            @test mul!(transpose(copy(C)), transpose(Bm), A, alpha, beta) ≈ transpose(Bm) * A * alpha + transpose(C) * beta
         end
     end
     let A = adjoint(Hermitian(rand(S, n,n))), Bv = Vector(rand(T, n)), Bm = Matrix(rand(T, n,n))
@@ -926,10 +927,11 @@ end
         @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
         @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
         if eltype(C) <: Complex
-            @test mul!(adjoint(copy(C)), A, adjoint(Bm), 4+2im, 3+im) ≈ A * adjoint(Bm) * (4+2im) + adjoint(C) * (3+im)
-            @test mul!(adjoint(copy(C)), adjoint(Bm), A, 4+2im, 3+im) ≈ adjoint(Bm) * A * (4+2im) + adjoint(C) * (3+im)
-            @test mul!(transpose(copy(C)), A, transpose(Bm), 4+2im, 3+im) ≈ A * transpose(Bm) * (4+2im) + transpose(C) * (3+im)
-            @test mul!(transpose(copy(C)), transpose(Bm), A, 4+2im, 3+im) ≈ transpose(Bm) * A * (4+2im) + transpose(C) * (3+im)
+            alpha, beta  = 4+2im, 3+im
+            @test mul!(adjoint(copy(C)), A, adjoint(Bm), alpha, beta) ≈ A * adjoint(Bm) * alpha + adjoint(C) * beta
+            @test mul!(adjoint(copy(C)), adjoint(Bm), A, alpha, beta) ≈ adjoint(Bm) * A * alpha + adjoint(C) * beta
+            @test mul!(transpose(copy(C)), A, transpose(Bm), alpha, beta) ≈ A * transpose(Bm) * alpha + transpose(C) * beta
+            @test mul!(transpose(copy(C)), transpose(Bm), A, alpha, beta) ≈ transpose(Bm) * A * alpha + transpose(C) * beta
         end
     end
     let Ahrs = transpose(Hermitian(Symmetric(rand(T, n, n)))),

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -888,6 +888,17 @@ end
         @test Bm * A ≈ Bm * Matrix(A)
         @test transpose(Bm) * A ≈ transpose(Bm) * Matrix(A)
         @test adjoint(Bm) * A ≈ adjoint(Bm) * Matrix(A)
+        C = similar(Bm, promote_type(T, S))
+        @test mul!(C, A, Bm) ≈ A * Bm
+        @test mul!(adjoint(C), A, adjoint(Bm)) ≈ A * adjoint(Bm)
+        @test mul!(transpose(C), A, transpose(Bm)) ≈ A * transpose(Bm)
+        rand!(C)
+        @test mul!(copy(C), A, Bm, 2, 3) ≈ A * Bm * 2 + C * 3
+        @test mul!(copy(C), Bm, A, 2, 3) ≈ Bm * A * 2 + C * 3
+        @test mul!(adjoint(copy(C)), A, adjoint(Bm), 2, 3) ≈ A * adjoint(Bm) * 2 + adjoint(C) * 3
+        @test mul!(adjoint(copy(C)), adjoint(Bm), A, 2, 3) ≈ adjoint(Bm) * A * 2 + adjoint(C) * 3
+        @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
+        @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
     end
     let A = adjoint(Hermitian(rand(S, n,n))), Bv = Vector(rand(T, n)), Bm = Matrix(rand(T, n,n))
         @test A * Bv ≈ Matrix(A) * Bv
@@ -897,6 +908,17 @@ end
         @test Bm * A ≈ Bm * Matrix(A)
         @test transpose(Bm) * A ≈ transpose(Bm) * Matrix(A)
         @test adjoint(Bm) * A ≈ adjoint(Bm) * Matrix(A)
+        C = similar(Bm, promote_type(T, S))
+        @test mul!(C, A, Bm) ≈ A * Bm
+        @test mul!(adjoint(C), A, adjoint(Bm)) ≈ A * adjoint(Bm)
+        @test mul!(transpose(C), A, transpose(Bm)) ≈ A * transpose(Bm)
+        rand!(C)
+        @test mul!(copy(C), A, Bm, 2, 3) ≈ A * Bm * 2 + C * 3
+        @test mul!(copy(C), Bm, A, 2, 3) ≈ Bm * A * 2 + C * 3
+        @test mul!(adjoint(copy(C)), A, adjoint(Bm), 2, 3) ≈ A * adjoint(Bm) * 2 + adjoint(C) * 3
+        @test mul!(adjoint(copy(C)), adjoint(Bm), A, 2, 3) ≈ adjoint(Bm) * A * 2 + adjoint(C) * 3
+        @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
+        @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
     end
     let Ahrs = transpose(Hermitian(Symmetric(rand(T, n, n)))),
         Acs = transpose(Symmetric(rand(S, n, n))),

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -876,7 +876,7 @@ end
     end
 end
 
-@testset "Multiplications symmetric/hermitian for $T and $S for size $n" for T in
+@testset "Multiplications symmetric/hermitian for T=$T and S=$S for size n=$n" for T in
         (Float16, Float32, Float64, BigFloat, Quaternion{Float64}),
         S in (T <: Quaternion ? (Quaternion{Float64},) : (ComplexF16, ComplexF32, ComplexF64, Quaternion{Float64})),
         n in (2, 3, 4)
@@ -899,6 +899,12 @@ end
         @test mul!(adjoint(copy(C)), adjoint(Bm), A, 2, 3) ≈ adjoint(Bm) * A * 2 + adjoint(C) * 3
         @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
         @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
+        if eltype(C) <: Complex
+            @test mul!(adjoint(copy(C)), A, adjoint(Bm), 4+2im, 3+im) ≈ A * adjoint(Bm) * (4+2im) + adjoint(C) * (3+im)
+            @test mul!(adjoint(copy(C)), adjoint(Bm), A, 4+2im, 3+im) ≈ adjoint(Bm) * A * (4+2im) + adjoint(C) * (3+im)
+            @test mul!(transpose(copy(C)), A, transpose(Bm), 4+2im, 3+im) ≈ A * transpose(Bm) * (4+2im) + transpose(C) * (3+im)
+            @test mul!(transpose(copy(C)), transpose(Bm), A, 4+2im, 3+im) ≈ transpose(Bm) * A * (4+2im) + transpose(C) * (3+im)
+        end
     end
     let A = adjoint(Hermitian(rand(S, n,n))), Bv = Vector(rand(T, n)), Bm = Matrix(rand(T, n,n))
         @test A * Bv ≈ Matrix(A) * Bv
@@ -919,6 +925,12 @@ end
         @test mul!(adjoint(copy(C)), adjoint(Bm), A, 2, 3) ≈ adjoint(Bm) * A * 2 + adjoint(C) * 3
         @test mul!(transpose(copy(C)), A, transpose(Bm), 2, 3) ≈ A * transpose(Bm) * 2 + transpose(C) * 3
         @test mul!(transpose(copy(C)), transpose(Bm), A, 2, 3) ≈ transpose(Bm) * A * 2 + transpose(C) * 3
+        if eltype(C) <: Complex
+            @test mul!(adjoint(copy(C)), A, adjoint(Bm), 4+2im, 3+im) ≈ A * adjoint(Bm) * (4+2im) + adjoint(C) * (3+im)
+            @test mul!(adjoint(copy(C)), adjoint(Bm), A, 4+2im, 3+im) ≈ adjoint(Bm) * A * (4+2im) + adjoint(C) * (3+im)
+            @test mul!(transpose(copy(C)), A, transpose(Bm), 4+2im, 3+im) ≈ A * transpose(Bm) * (4+2im) + transpose(C) * (3+im)
+            @test mul!(transpose(copy(C)), transpose(Bm), A, 4+2im, 3+im) ≈ transpose(Bm) * A * (4+2im) + transpose(C) * (3+im)
+        end
     end
     let Ahrs = transpose(Hermitian(Symmetric(rand(T, n, n)))),
         Acs = transpose(Symmetric(rand(S, n, n))),

--- a/test/testhelpers/Quaternions.jl
+++ b/test/testhelpers/Quaternions.jl
@@ -16,6 +16,7 @@ struct Quaternion{T<:Real} <: Number
 end
 Quaternion{T}(s::Real) where {T<:Real} = Quaternion{T}(T(s), zero(T), zero(T), zero(T))
 Quaternion(s::Real, v1::Real, v2::Real, v3::Real) = Quaternion(promote(s, v1, v2, v3)...)
+Quaternion{T}(q::Quaternion) where {T<:Real} = Quaternion{T}(T(q.s), T(q.v1), T(q.v2), T(q.v3))
 Base.convert(::Type{Quaternion{T}}, s::Real) where {T <: Real} =
     Quaternion{T}(convert(T, s), zero(T), zero(T), zero(T))
 Base.promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T <: Real, S <: Real} =

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -330,9 +330,13 @@ end
         end
         fds = [abs.(d) for d in ds]
         @test abs.(A)::mat_type == mat_type(fds...)
-        @testset "Multiplication with strided matrix/vector" begin
+        @testset "Multiplication with strided matrix/vector, and their adjoint/transpose" begin
             @test (x = fill(1.,n); A*x ≈ Array(A)*x)
             @test (X = fill(1.,n,2); A*X ≈ Array(A)*X)
+            @test (X = fill(1.,2,n); A * X' ≈ Array(A) * X')
+            @test (X = fill(1.,n,2); X' * A ≈ X' * Array(A))
+            @test (X = fill(1.,2,n); A * transpose(X) ≈ Array(A) * transpose(X))
+            @test (X = fill(1.,n,2); transpose(X) * A ≈ transpose(X) * Array(A))
         end
         @testset "Binary operations" begin
             B = mat_type == Tridiagonal ? mat_type(a, b, c) : mat_type(b, a)


### PR DESCRIPTION
This PR computes `H::Hermitian * A::Adjoint` as `(A' * H)'`. This often ensures that we take BLAS paths. The 2-arg multiplication was already specialized for `StridedMatrix{<:BlasFloat }` parents by materializing the `Adjoint`, but this PR removes this and specializes the 5-arg `mul!` instead for generic element types. Even if we don't hit BLAS, the change ensures that we iterate in a cache-friendly manner.

However, this PR changes the return type of the 2-arg product from a `Matrix{T}` to an `Adjoint{T, Matrix{T}}`

On nightly v"1.13.0-DEV.789"
```julia
julia> A = [1 2; 3 4];

julia> Hermitian(A) * A'
2×2 Matrix{Int64}:
  5  11
 10  22
```
This PR:
```julia
julia> Hermitian(A) * A'
2×2 adjoint(::Matrix{Int64}) with eltype Int64:
  5  11
 10  22
```
In principle, we may copy the result and return a materialized `Matrix` here.

Some performance improvements:
```julia
julia> X = randn(100,100); Y = randn(100,100); Z = copy(X);

julia> @btime Hermitian($X) * $Y';
  34.965 μs (6 allocations: 156.42 KiB) # v"1.13.0-DEV.789"
  23.457 μs (3 allocations: 78.21 KiB) # this PR

julia> @btime mul!($Z', Hermitian($X), $Y', 2.0, 1.0);
  1.311 ms (0 allocations: 0 bytes) # v"1.13.0-DEV.789"
  18.966 μs (0 allocations: 0 bytes) # this PR

julia> XInt, YInt, ZInt = rand(Int,size(X)), rand(Int,size(Y)), rand(Int, size(Z)); # non-BLAS

julia> @btime mul!($ZInt', Hermitian($XInt), $YInt', 2, 1);
  1.031 ms (0 allocations: 0 bytes) # v"1.13.0-DEV.789"
  232.422 μs (0 allocations: 0 bytes) # this PR
```