### PR TITLE
lu!(F, ::Matrix) requires Julia 1.13

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -110,8 +110,8 @@ end
 `lu!` is the same as [`lu`](@ref), but saves space by overwriting the
 input `F`, instead of creating a copy.
 
-!!! compat "Julia 1.12"
-    Reusing dense `LU` factorizations in `lu!` require Julia 1.12 or later.
+!!! compat "Julia 1.13"
+    Reusing dense `LU` factorizations in `lu!` require Julia 1.13 or later.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
It looks like #1131 was merged after the feature-freeze for 1.12, so the docstring should list the minimum version as 1.13 instead.

cc @longemen3000