### PR TITLE
restrict inv(::Factorization) to square matrices

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -110,7 +110,7 @@ Factorization{T}(A::AdjointFactorization) where {T} =
     adjoint(Factorization{T}(parent(A)))
 Factorization{T}(A::TransposeFactorization) where {T} =
     transpose(Factorization{T}(parent(A)))
-inv(F::Factorization{T}) where {T} = (n = size(F, 1); ldiv!(F, Matrix{T}(I, n, n)))
+inv(F::Factorization{T}) where {T} = (n = checksquare(F); ldiv!(F, Matrix{T}(I, n, n)))
 
 Base.hash(F::Factorization, h::UInt) = mapreduce(f -> hash(getfield(F, f)), hash, 1:nfields(F); init=h)
 Base.:(==)(  F::T, G::T) where {T<:Factorization} = all(f -> getfield(F, f) == getfield(G, f), 1:nfields(F))

--- a/src/svd.jl
+++ b/src/svd.jl
@@ -312,7 +312,7 @@ function pinv(F::SVD{T}; atol::Real=0, rtol::Real = (eps(real(float(oneunit(T)))
 end
 
 function inv(F::SVD)
-    # TODO: checksquare(F)
+    checksquare(F)
     @inbounds for i in eachindex(F.S)
         iszero(F.S[i]) && throw(SingularException(i))
     end

--- a/test/svd.jl
+++ b/test/svd.jl
@@ -53,10 +53,10 @@ using LinearAlgebra: BlasComplex, BlasFloat, BlasReal, QRPivoted
     @test sf2.U*Diagonal(sf2.S)*sf2.Vt' ≊ m2
 
     @test ldiv!([0., 0.], svd(Matrix(I, 2, 2)), [1., 1.]) ≊ [1., 1.]
-    # @test_throws DimensionMismatch inv(svd(Matrix(I, 3, 2)))
+    @test_throws DimensionMismatch inv(svd(Matrix(I, 3, 2)))
     @test inv(svd(Matrix(I, 2, 2))) ≈ I
     @test inv(svd([1 2; 3 4])) ≈ [-2.0 1.0; 1.5 -0.5]
-    @test inv(svd([1 0 1; 0 1 0])) ≈ [0.5 0.0; 0.0 1.0; 0.5 0.0]
+    @test pinv(svd([1 0 1; 0 1 0])) ≈ [0.5 0.0; 0.0 1.0; 0.5 0.0]
     @test_throws SingularException inv(svd([0 0; 0 0]))
     @test inv(svd([1+2im 3+4im; 5+6im 7+8im])) ≈ [-0.5 + 0.4375im 0.25 - 0.1875im; 0.375 - 0.3125im -0.125 + 0.0625im]
 end


### PR DESCRIPTION
This adds a missing `checksquare` to `inv(::SVD)`, which I would argue is a bug from https://github.com/JuliaLang/julia/pull/32126. If you want the pseudo-inverse, you should call `pinv(::SVD)` explicitly (via the method introduced in #1387) , not rely on magic undocumented behavior of `inv`.

Similarly for `inv(::Factorization)` (see below), which previously computed a left inverse for non-square ("tall") QR factorizations (see below).

(Hoisted from #1387.)