### PR TITLE
make `dot` docstring match the implementation

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -938,7 +938,7 @@ vector is conjugated.
 `dot` also works on arbitrary iterable objects, including arrays of any dimension,
 as long as `dot` is defined on the elements.
 
-`dot` is semantically equivalent to `sum(dot(vx,vy) for (vx,vy) in zip(x, y))`,
+`dot` is semantically equivalent to `reduce(+, dot(vx,vy) for (vx,vy) in zip(x, y))`,
 with the added restriction that the arguments must have equal lengths.
 
 `x ⋅ y` (where `⋅` can be typed by tab-completing `\\cdot` in the REPL) is a synonym for


### PR DESCRIPTION
as written it's incorrect since `sum` will promote the types but `+` (and `dot`) overflow

```
julia> x = collect(0xf0:0xff); y = copy(x);

julia> sum(dot(i, j) for (i, j) in zip(x, y))
0x00000000000004d8

julia> dot(x, y)
0xd8
```

closes https://github.com/JuliaLang/LinearAlgebra.jl/issues/1453