### PR TITLE
Fix incorrect dispatch for Cholesky equality

### DIFF
--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -680,12 +680,10 @@ end
 Base.propertynames(F::Cholesky, private::Bool=false) =
     (:U, :L, :UL, (private ? fieldnames(typeof(F)) : ())...)
 
-function _equal(C1::Cholesky, C2::Cholesky)
+function Base.:(==)(C1::C, C2::D) where {C<:Cholesky, D<:Cholesky}
     C1.uplo == C2.uplo || return false
     C1.uplo == 'L' ? (C1.L == C2.L) : (C1.U == C2.U)
 end
-Base.:(==)(C1::Cholesky, C2::Cholesky) = _equal(C1, C2)
-Base.:(==)(C1::T, C2::T) where {T<:Cholesky} = _equal(C1, C2)
 
 function getproperty(C::CholeskyPivoted{T}, d::Symbol) where {T}
     Cfactors = getfield(C, :factors)

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -680,10 +680,12 @@ end
 Base.propertynames(F::Cholesky, private::Bool=false) =
     (:U, :L, :UL, (private ? fieldnames(typeof(F)) : ())...)
 
-function Base.:(==)(C1::Cholesky, C2::Cholesky)
+function _equal(C1::Cholesky, C2::Cholesky)
     C1.uplo == C2.uplo || return false
     C1.uplo == 'L' ? (C1.L == C2.L) : (C1.U == C2.U)
 end
+Base.:(==)(C1::Cholesky, C2::Cholesky) = _equal(C1, C2)
+Base.:(==)(C1::T, C2::T) where {T<:Cholesky} = _equal(C1, C2)
 
 function getproperty(C::CholeskyPivoted{T}, d::Symbol) where {T}
     Cfactors = getfield(C, :factors)

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -583,6 +583,22 @@ end
         @test C.L == L
         @test C.U == L'
     end
+    let
+        B = [1.0 5.0; 3.0 4.0]
+        CA = Cholesky(LowerTriangular(A))
+        CB = Cholesky(LowerTriangular(B))
+        @test CA == CB
+        @test CA.L == CB.L
+        @test CA.U == CB.U
+    end
+    let
+        C = [1.0 2.0; 5.0 4.0]
+        CA = Cholesky(UpperTriangular(A))
+        CC = Cholesky(UpperTriangular(C))
+        @test CA == CC
+        @test CA.L == CC.L
+        @test CA.U == CC.U
+    end
 end
 
 @testset "adjoint of Cholesky" begin


### PR DESCRIPTION
`==` on Cholesky is not correctly being dispatched when the two operands have exactly the same type:

```julia
julia> x = LowerTriangular([0.0 1.0; 0.0 0.0])
2×2 LowerTriangular{Float64, Matrix{Float64}}:
 0.0   ⋅
 0.0  0.0

julia> y = LowerTriangular([0.0 0.0; 0.0 0.0])
2×2 LowerTriangular{Float64, Matrix{Float64}}:
 0.0   ⋅
 0.0  0.0

julia> x == y
true

julia> Cholesky(x) == Cholesky(y)
false

julia> @which Cholesky(x) == Cholesky(y)
==(F::T, G::T) where T<:Factorization
     @ LinearAlgebra ~/.julia/juliaup/julia-1.11.5+0.aarch64.apple.darwin14/share/julia/stdlib/v1.11/LinearAlgebra/src/factorization.jl:116
```

That's because that method

https://github.com/JuliaLang/LinearAlgebra.jl/blob/2c3fe9b7e0ca4e2c7bf506bd16ae5900f04a8023/src/factorization.jl#L116

is more specific than the intended method

https://github.com/JuliaLang/LinearAlgebra.jl/blob/2c3fe9b7e0ca4e2c7bf506bd16ae5900f04a8023/src/cholesky.jl#L683-L686

This PR fixes it by adding an extra, more specific method.