### PR TITLE
Run `__init__()` even in sysimage builds

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -841,6 +841,8 @@ function lbt_openblas_onload_callback()
         end
         BLAS.lbt_set_num_threads(nthreads)
     end
+
+    return nothing
 end
 
 function __init__()
@@ -848,5 +850,8 @@ function __init__()
     # clear the datastructures modified by this call and call it again with their own.
     libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, lbt_openblas_onload_callback)
 end
+
+# Register eagerly, so that LinearAlgebra is available for sysimage builds (incl. `--trim`)
+libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, lbt_openblas_onload_callback)
 
 end # module LinearAlgebra


### PR DESCRIPTION
This change makes the LinearAlgebra initialization code run during the sysimage build, similar to how it would run when using LinearAlgebra at top-level in a normal package. In this configuration, we can't rely on the serializer to isolate side-effects for us, so we have to manually ensure that any mutations that we perform here are not accidentally persisted to run-time.

Requires https://github.com/JuliaLang/julia/pull/59232 and https://github.com/JuliaLang/julia/pull/59233

Resolves the segfault in https://github.com/JuliaLang/julia/issues/59215