### PR TITLE
Add bidiagonal cholesky version

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1472,7 +1472,14 @@ function _chol!(A::Bidiagonal{<:BlasFloat,<:StridedVector}, ::Type{UpperTriangul
     d = real(A.dv)
     e = A.ev
     dv, ev = LAPACK.pttrf!(d, e)
-    map!(sqrt, dv)
+    for k in eachindex(dv)
+        Akk = dv[k]
+        Akk, info = _chol!(Akk, UpperTriangular)
+        if info != 0
+            return UpperTriangular(A), convert(BlasInt, k)
+        end
+        dv[k] = Akk
+    end
     @views ev .*= dv[1:end-1]
     U = Bidiagonal(dv, ev, :U)
     return UpperTriangular(U), convert(BlasInt, 0)
@@ -1507,7 +1514,14 @@ function _chol!(A::Bidiagonal{<:BlasFloat,<:StridedVector}, ::Type{LowerTriangul
     d = real(A.dv)
     e = A.ev
     dv, ev = LAPACK.pttrf!(d, e)
-    map!(sqrt, dv)
+    for k in eachindex(dv)
+        Akk = dv[k]
+        Akk, info = _chol!(Akk, LowerTriangular)
+        if info != 0
+            return LowerTriangular(A), convert(BlasInt, k)
+        end
+        dv[k] = Akk
+    end
     @views ev .*= dv[1:end-1]
     L = Bidiagonal(dv, ev, :L)
     return LowerTriangular(L), convert(BlasInt, 0)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1468,6 +1468,15 @@ function inv(B::Bidiagonal{T}) where T
 end
 
 # cholesky-version for (sym)tridiagonal matrices
+function _chol!(A::Bidiagonal{<:BlasFloat,<:StridedVector}, ::Type{UpperTriangular})
+    d = real(A.dv)
+    e = A.ev
+    dv, ev = LAPACK.pttrf!(d, e)
+    map!(sqrt, dv)
+    @views ev .*= dv[1:end-1]
+    U = Bidiagonal(dv, ev, :U)
+    return UpperTriangular(U), convert(BlasInt, 0)
+end
 function _chol!(A::Bidiagonal, ::Type{UpperTriangular})
     require_one_based_indexing(A)
     n = checksquare(A)
@@ -1493,6 +1502,15 @@ function _chol!(A::Bidiagonal, ::Type{UpperTriangular})
         end
     end
     return UpperTriangular(A), convert(BlasInt, 0)
+end
+function _chol!(A::Bidiagonal{<:BlasFloat,<:StridedVector}, ::Type{LowerTriangular})
+    d = real(A.dv)
+    e = A.ev
+    dv, ev = LAPACK.pttrf!(d, e)
+    map!(sqrt, dv)
+    @views ev .*= dv[1:end-1]
+    L = Bidiagonal(dv, ev, :L)
+    return LowerTriangular(L), convert(BlasInt, 0)
 end
 function _chol!(A::Bidiagonal, ::Type{LowerTriangular})
     require_one_based_indexing(A)

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1467,6 +1467,60 @@ function inv(B::Bidiagonal{T}) where T
     return B.uplo == 'U' ? UpperTriangular(dest) : LowerTriangular(dest)
 end
 
+# cholesky-version for (sym)tridiagonal matrices
+function _chol!(A::Bidiagonal, ::Type{UpperTriangular})
+    require_one_based_indexing(A)
+    n = checksquare(A)
+    realdiag = eltype(A) <: Complex
+    dv = A.dv
+    ev = A.ev
+    @inbounds begin
+        for k = 1:n
+            Akk = realdiag ? real(dv[k]) : dv[k]
+            if k > 1
+                Akk -= realdiag ? abs2(ev[k-1]) : ev[k-1]'ev[k-1]
+            end
+            dv[k] = Akk
+            Akk, info = _chol!(Akk, UpperTriangular)
+            if info != 0
+                return UpperTriangular(A), convert(BlasInt, k)
+            end
+            dv[k] = Akk
+            AkkInv = inv(copy(Akk'))
+            if k < n
+                ev[k] = AkkInv*ev[k]
+            end
+        end
+    end
+    return UpperTriangular(A), convert(BlasInt, 0)
+end
+function _chol!(A::Bidiagonal, ::Type{LowerTriangular})
+    require_one_based_indexing(A)
+    n = checksquare(A)
+    realdiag = eltype(A) <: Complex
+    dv = A.dv
+    ev = A.ev
+    @inbounds begin
+        for k = 1:n
+            Akk = realdiag ? real(dv[k]) : dv[k]
+            if k > 1
+                Akk -= realdiag ? abs2(ev[k-1]) : ev[k-1]*ev[k-1]'
+            end
+            dv[k] = Akk
+            Akk, info = _chol!(Akk, LowerTriangular)
+            if info != 0
+                return LowerTriangular(A), convert(BlasInt, k)
+            end
+            dv[k] = Akk
+            AkkInv = inv(copy(Akk'))
+            if k < n
+                ev[k] *= AkkInv
+            end
+        end
+     end
+    return LowerTriangular(A), convert(BlasInt, 0)
+end
+
 # Eigensystems
 eigvals(M::Bidiagonal) = copy(M.dv)
 function eigvecs(M::Bidiagonal{T}) where T

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -220,32 +220,6 @@ function _chol!(A::AbstractMatrix, ::Type{UpperTriangular})
     end
     return UpperTriangular(A), convert(BlasInt, 0)
 end
-function _chol!(A::Bidiagonal, ::Type{UpperTriangular})
-    require_one_based_indexing(A)
-    n = checksquare(A)
-    realdiag = eltype(A) <: Complex
-    dv = A.dv
-    ev = A.ev
-    @inbounds begin
-        for k = 1:n
-            Akk = realdiag ? real(dv[k]) : dv[k]
-            if k > 1
-                Akk -= realdiag ? abs2(ev[k-1]) : ev[k-1]'ev[k-1]
-            end
-            dv[k] = Akk
-            Akk, info = _chol!(Akk, UpperTriangular)
-            if info != 0
-                return UpperTriangular(A), convert(BlasInt, k)
-            end
-            dv[k] = Akk
-            AkkInv = inv(copy(Akk'))
-            if k < n
-                ev[k] = AkkInv*ev[k]
-            end
-        end
-    end
-    return UpperTriangular(A), convert(BlasInt, 0)
-end
 function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
     require_one_based_indexing(A)
     n = checksquare(A)
@@ -271,32 +245,6 @@ function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
             end
             @simd for i = k + 1:n
                 A[i,k] *= AkkInv
-            end
-        end
-     end
-    return LowerTriangular(A), convert(BlasInt, 0)
-end
-function _chol!(A::Bidiagonal, ::Type{LowerTriangular})
-    require_one_based_indexing(A)
-    n = checksquare(A)
-    realdiag = eltype(A) <: Complex
-    dv = A.dv
-    ev = A.ev
-    @inbounds begin
-        for k = 1:n
-            Akk = realdiag ? real(dv[k]) : dv[k]
-            if k > 1
-                Akk -= realdiag ? abs2(ev[k-1]) : ev[k-1]*ev[k-1]'
-            end
-            dv[k] = Akk
-            Akk, info = _chol!(Akk, LowerTriangular)
-            if info != 0
-                return LowerTriangular(A), convert(BlasInt, k)
-            end
-            dv[k] = Akk
-            AkkInv = inv(copy(Akk'))
-            if k < n
-                ev[k] *= AkkInv
             end
         end
      end

--- a/src/special.jl
+++ b/src/special.jl
@@ -605,8 +605,8 @@ function _hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractArray,AbstractQ,Unifo
     end
 end
 
-# factorizations
-function cholesky(S::RealHermSymComplexHerm{<:Real,<:SymTridiagonal}, ::NoPivot = NoPivot(); check::Bool = true)
+# tridiagonal cholesky factorization
+function cholesky(S::RealSymHermitian{<:BiTriSym}, ::NoPivot = NoPivot(); check::Bool = true)
     T = choltype(S)
     B = Bidiagonal{T}(diag(S, 0), diag(S, S.uplo == 'U' ? 1 : -1), sym_uplo(S.uplo))
     cholesky!(Hermitian(B, sym_uplo(S.uplo)), NoPivot(); check = check)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -1039,7 +1039,7 @@ function dot(x::AbstractVector, A::Tridiagonal, y::AbstractVector)
     return r
 end
 
-function cholesky(S::SymTridiagonal, ::NoPivot = NoPivot(); check::Bool = true)
+function cholesky(S::Union{SymTridiagonal,Tridiagonal}, ::NoPivot = NoPivot(); check::Bool = true)
     if !ishermitian(S)
         check && checkpositivedefinite(-1)
         return Cholesky(S, 'U', convert(BlasInt, -1))

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -499,7 +499,7 @@ end
         @test C.L * C.U ≈ M
     end
     # test LowerTriangular version
-    M = Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :L), :L)
+    M = Hermitian(Bidiagonal(fill(2.0, 4), im * ones(3), :L), :L)
     C = cholesky!(copy(M))
     @test C.L * C.U ≈ M
 end

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -492,9 +492,16 @@ end
 end
 
 @testset "Cholesky for AbstractMatrix" begin
-    S = SymTridiagonal(fill(2.0, 4), ones(3))
-    C = cholesky(S)
-    @test C.L * C.U ≈ S
+    for M in (SymTridiagonal(fill(2.0, 4), ones(3)),
+        Tridiagonal(ones(3), fill(2.0, 4), ones(3)),
+        )
+        C = cholesky(M)
+        @test C.L * C.U ≈ M
+    end
+    # test LowerTriangular version
+    M = Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :L), :L)
+    C = cholesky!(copy(M))
+    @test C.L * C.U ≈ M
 end
 
 @testset "constructor with non-BlasInt arguments" begin

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -492,14 +492,14 @@ end
 end
 
 @testset "Cholesky for AbstractMatrix" begin
-    for M in (SymTridiagonal(fill(2.0, 4), ones(3)),
-        Symmetric(SymTridiagonal(fill(2.0, 4), ones(3)), :U),
-        Symmetric(SymTridiagonal(fill(2.0, 4), ones(3)), :L),
-        Tridiagonal(ones(3), fill(2.0, 4), ones(3)),
-        Hermitian(Tridiagonal(ones(3), fill(2.0, 4), ones(3)), :U),
-        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :U), :U),
-        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :U), :L),
-        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :L), :L),
+    for T in (identity, big), M in (SymTridiagonal(fill(T(2.0), 4), ones(3)),
+        Symmetric(SymTridiagonal(fill(T(2.0), 4), ones(3)), :U),
+        Symmetric(SymTridiagonal(fill(T(2.0), 4), ones(3)), :L),
+        Tridiagonal(ones(3), fill(T(2.0), 4), ones(3)),
+        Hermitian(Tridiagonal(ones(3), fill(T(2.0), 4), ones(3)), :U),
+        Hermitian(Bidiagonal(fill(T(2.0), 4), ones(3), :U), :U),
+        Hermitian(Bidiagonal(fill(T(2.0), 4), ones(3), :U), :L),
+        Hermitian(Bidiagonal(fill(T(2.0), 4), ones(3), :L), :L),
         )
         C = cholesky(M)
         @test C.L * C.U ≈ M

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -493,15 +493,27 @@ end
 
 @testset "Cholesky for AbstractMatrix" begin
     for M in (SymTridiagonal(fill(2.0, 4), ones(3)),
+        Symmetric(SymTridiagonal(fill(2.0, 4), ones(3)), :U),
+        Symmetric(SymTridiagonal(fill(2.0, 4), ones(3)), :L),
         Tridiagonal(ones(3), fill(2.0, 4), ones(3)),
+        Hermitian(Tridiagonal(ones(3), fill(2.0, 4), ones(3)), :U),
+        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :U), :U),
+        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :U), :L),
+        Hermitian(Bidiagonal(fill(2.0, 4), ones(3), :L), :L),
         )
         C = cholesky(M)
         @test C.L * C.U ≈ M
+        @test parent(C.U) isa Bidiagonal
     end
     # test LowerTriangular version
     M = Hermitian(Bidiagonal(fill(2.0, 4), im * ones(3), :L), :L)
     C = cholesky!(copy(M))
     @test C.L * C.U ≈ M
+    # non-(RealOrComplex) eltype
+    A = Tridiagonal(randn(Quaternion{Float64}, 4, 4) |> t -> t't)
+    C = cholesky(A)
+    @test C.L * C.U ≈ A
+    @test parent(C.U) isa Bidiagonal
 end
 
 @testset "constructor with non-BlasInt arguments" begin

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -505,6 +505,15 @@ end
         @test C.L * C.U ≈ M
         @test parent(C.U) isa Bidiagonal
     end
+    for T in (identity, big), M in (SymTridiagonal(fill(T(-2.0), 4), ones(3)),
+        Symmetric(SymTridiagonal(fill(T(-2.0), 4), ones(3)), :U),
+        Symmetric(SymTridiagonal(fill(T(-2.0), 4), ones(3)), :L),
+        Tridiagonal(ones(3), fill(T(-2.0), 4), ones(3)),
+        Hermitian(Tridiagonal(ones(3), fill(T(-2.0), 4), ones(3)), :U),
+        Hermitian(Bidiagonal(fill(T(-2.0), 4), ones(3), :U), :U),
+        )
+        @test_throws (T == identity ? LAPACKException : PosDefException) cholesky(M)
+    end
     # test LowerTriangular version
     M = Hermitian(Bidiagonal(fill(2.0, 4), im * ones(3), :L), :L)
     C = cholesky!(copy(M))

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -504,14 +504,12 @@ end
         C = cholesky(M)
         @test C.L * C.U ≈ M
         @test parent(C.U) isa Bidiagonal
-    end
-    for T in (identity, big), M in (SymTridiagonal(fill(T(-2.0), 4), ones(3)),
-        Symmetric(SymTridiagonal(fill(T(-2.0), 4), ones(3)), :U),
-        Symmetric(SymTridiagonal(fill(T(-2.0), 4), ones(3)), :L),
-        Tridiagonal(ones(3), fill(T(-2.0), 4), ones(3)),
-        Hermitian(Tridiagonal(ones(3), fill(T(-2.0), 4), ones(3)), :U),
-        Hermitian(Bidiagonal(fill(T(-2.0), 4), ones(3), :U), :U),
-        )
+        M[1,1] *= -1
+        @test_throws PosDefException cholesky(M)
+        C = cholesky(M, check=false)
+        @test C.info > 0
+        M[1,1] *= -1
+        M[end,end] *= -1
         @test_throws PosDefException cholesky(M)
         C = cholesky(M, check=false)
         @test C.info > 0

--- a/test/cholesky.jl
+++ b/test/cholesky.jl
@@ -512,7 +512,9 @@ end
         Hermitian(Tridiagonal(ones(3), fill(T(-2.0), 4), ones(3)), :U),
         Hermitian(Bidiagonal(fill(T(-2.0), 4), ones(3), :U), :U),
         )
-        @test_throws (T == identity ? LAPACKException : PosDefException) cholesky(M)
+        @test_throws PosDefException cholesky(M)
+        C = cholesky(M, check=false)
+        @test C.info > 0
     end
     # test LowerTriangular version
     M = Hermitian(Bidiagonal(fill(2.0, 4), im * ones(3), :L), :L)
@@ -520,6 +522,10 @@ end
     @test C.L * C.U ≈ M
     # non-(RealOrComplex) eltype
     A = Tridiagonal(randn(Quaternion{Float64}, 4, 4) |> t -> t't)
+    C = cholesky(A)
+    @test C.L * C.U ≈ A
+    @test parent(C.U) isa Bidiagonal
+    A = Hermitian(Tridiagonal(randn(Quaternion{Float64}, 4, 4) |> t -> t't), :L)
     C = cholesky(A)
     @test C.L * C.U ≈ A
     @test parent(C.U) isa Bidiagonal


### PR DESCRIPTION
This adds a generic version of cholesky for tridiagonal matrices. This fixes #1383, and massively boosts performance both for `(Sym)Tridiagonal`s. Previously, we haven't had a kernel for the symtridiagonal case.