### PR TITLE
Generalize 3-arg `dot` to `HermOrSym`

### DIFF
--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -618,6 +618,18 @@ end
     end
 end
 
+@testset "3-arg dot with Symmetric/Hermitian matrix of matrices" begin
+    for m in (Symmetric([randn(ComplexF64, 2, 2) for i in 1:2, j in 1:2]),
+                Symmetric([randn(ComplexF64, 2, 2) for i in 1:2, j in 1:2], :L),
+                Hermitian([randn(ComplexF64, 2, 2) for i in 1:2, j in 1:2]),
+                Hermitian([randn(ComplexF64, 2, 2) for i in 1:2, j in 1:2], :L)
+            )
+        x = [randn(ComplexF64, 2) for i in 1:2]
+        y = [randn(ComplexF64, 2) for i in 1:2]
+        @test dot(x, m, y) ≈ dot(x, m*y) ≈ dot(x, Matrix(m), y)
+    end
+end
+
 #Issue #7647: test xsyevr, xheevr, xstevr drivers.
 @testset "Eigenvalues in interval for $(typeof(Mi7647))" for Mi7647 in
         (Symmetric(diagm(0 => 1.0:3.0)),

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -582,13 +582,21 @@ end
 
 # bug identified in PR #52318: dot products of quaternionic Hermitian matrices,
 # or any number type where conj(a)*conj(b) ≠ conj(a*b):
-@testset "dot Hermitian quaternion #52318" begin
-    A, B = [Quaternion.(randn(3,3), randn(3, 3), randn(3, 3), randn(3,3)) |> t -> t + t' for i in 1:2]
+@testset "dot Hermitian quaternion" begin
+    A, B = [(randn(Quaternion{Float64},4,4)) |> t -> t + t' for i in 1:2]
     @test A == Hermitian(A) && B == Hermitian(B)
     @test dot(A, B) ≈ dot(Hermitian(A), Hermitian(B))
-    A, B = [Quaternion.(randn(3,3), randn(3, 3), randn(3, 3), randn(3,3)) |> t -> t + transpose(t) for i in 1:2]
+    A, B = [(randn(Quaternion{Float64},4,4)) |> t -> t + transpose(t) for i in 1:2]
     @test A == Symmetric(A) && B == Symmetric(B)
     @test dot(A, B) ≈ dot(Symmetric(A), Symmetric(B))
+    A = randn(Quaternion{Float64}, 4, 4)
+    x = randn(Quaternion{Float64}, 4)
+    y = randn(Quaternion{Float64}, 4)
+    for t in (Symmetric, Hermitian), uplo in (:U, :L)
+        M = t(A, uplo)
+        N = Matrix(M)
+        @test dot(x, M, y) ≈ dot(x, N, y)
+    end
 end
 
 # let's make sure the analogous bug will not show up with kronecker products

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -595,7 +595,7 @@ end
     for t in (Symmetric, Hermitian), uplo in (:U, :L)
         M = t(A, uplo)
         N = Matrix(M)
-        @test dot(x, M, y) ≈ dot(x, N, y)
+        @test dot(x, M, y) ≈ dot(x, M*y) ≈ dot(x, N, y)
     end
 end
 


### PR DESCRIPTION
This was unnecessarily restrictive, and didn't handle, e.g., complex symmetric and quaternionic hermitian matrices.