### PR TITLE
Update pruning instruction in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,33 +17,15 @@ This package performs some type piracy and is also included in the sysimage, whi
 
 To use a development version of this package, you can choose one of the following methods:
 
-1. **Change the UUID in the project file and load the package:**
-
-   Change the UUID line in `Project.toml` as
-   ```diff
-   - uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-   + uuid = "27e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-   ```
+1. **Prune the sysimg version and load the package:**
 
    Start `julia` as
    ```console
-   JULIA_PRUNE_OLD_LA=true julia +nightly --compiled-modules=existing --project
+   JULIA_PRUNE_OLD_LA=true julia +nightly --compiled-modules=existing --project -i -e 'include("test/prune_old_LA.jl")'
    ```
    where it is assumed that one is already within the `LinearAlgebra` directory (otherwise, adjust
    the project path accordingly). The `julia +nightly` command above assumes that `juliaup` is being used
    to launch `julia`, but one may substitute this with the path to the julia executable.
-
-   Within the `julia` session, load the `LinearAlgebra` module after pruning the one in the sysimage. This may be done as
-   ```julia
-   include("test/prune_old_LA.jl") && using LinearAlgebra
-   ```
-
-   Note that loading the test files in the REPL will automatically carry out the pruning to ensure that the development version of the package is used in the tests.
-
-   If you are contributing to the repo using this method, it may be convenient to ignore the local changes to `Project.toml` by running
-   ```console
-   git update-index --skip-worktree Project.toml
-   ```
 
 2. **Build Julia with the custom `LinearAlgebra` commit:**
 


### PR DESCRIPTION
Changing the UUID doesn't appear to be necessary. We may also condense the julia command to make it easier to launch julia with the development version of `LinearAlgebra`.