### PR TITLE
test: relax `@test_throws ErrorException` to also allow `BoundsError`

### DIFF
--- a/test/qr.jl
+++ b/test/qr.jl
@@ -174,7 +174,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
                 @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1), adjoint(q))
-                @test_throws ErrorException size(q,-1)
+                @test_throws Union{BoundsError,ErrorException} size(q,-1)
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(q,zeros(eltya,n1+1))
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(adjoint(q), zeros(eltya,n1+1))
 
@@ -196,7 +196,7 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = Matrix(Q)
                 @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test rmul!(squareQ(q), adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
-                @test_throws ErrorException size(q,-1)
+                @test_throws Union{BoundsError,ErrorException} size(q,-1)
                 @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
 
                 @test mul!(c, q, b) ≈ q*b


### PR DESCRIPTION
An issue with `Base` is that some methods of `size` throw `BoundsError` for an out-of-bounds second argument, while others throw `ErrorException` in the same case.

Relax the tests here to allow for fixing that issue in `Base` in the future.

PR that depends on this change:

* JuliaLang/Julia#59442