### PR TITLE
Public function to access the `uplo` for `Symmetric`/`Hermitian`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -604,6 +604,7 @@ LinearAlgebra.hermitianpart
 LinearAlgebra.hermitianpart!
 LinearAlgebra.copy_adjoint!
 LinearAlgebra.copy_transpose!
+LinearAlgebra.uplo
 ```
 
 ## Low-level matrix operations

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -181,7 +181,8 @@ public AbstractTriangular,
         zeroslike,
         matprod_dest,
         fillstored!,
-        fillband!
+        fillband!,
+        uplo
 
 const BlasFloat = Union{Float64,Float32,ComplexF64,ComplexF32}
 const BlasReal = Union{Float64,Float32}

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -118,7 +118,7 @@ Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 """
     LinearAlgebra.uplo(S::Bidiagonal)::Symbol
 
-Return a `Symbol` corresponding to whether the upper or lower off-diagonal band is stored.
+Return a `Symbol` corresponding to whether the upper (`:U`) or lower (`:L`) off-diagonal band is stored.
 """
 uplo(::Bidiagonal) = sym_uplo(B.uplo)
 

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -120,7 +120,7 @@ Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 
 Return a `Symbol` corresponding to whether the upper (`:U`) or lower (`:L`) off-diagonal band is stored.
 """
-uplo(::Bidiagonal) = sym_uplo(B.uplo)
+uplo(B::Bidiagonal) = sym_uplo(B.uplo)
 
 _offdiagind(uplo) = uplo == 'U' ? 1 : -1
 

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -115,6 +115,13 @@ Bidiagonal(A::Bidiagonal) = A
 Bidiagonal{T}(A::Bidiagonal{T}) where {T} = A
 Bidiagonal{T}(A::Bidiagonal) where {T} = Bidiagonal{T}(A.dv, A.ev, A.uplo)
 
+"""
+    LinearAlgebra.uplo(S::Bidiagonal)::Symbol
+
+Return a `Symbol` corresponding to whether the upper or lower off-diagonal band is stored.
+"""
+uplo(::Bidiagonal) = sym_uplo(B.uplo)
+
 _offdiagind(uplo) = uplo == 'U' ? 1 : -1
 
 @inline function Base.isassigned(A::Bidiagonal, i::Int, j::Int)

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -237,6 +237,33 @@ nonhermitianwrappertype(::SymSymTri{<:Real}) = Symmetric
 nonhermitianwrappertype(::Hermitian{<:Real}) = Symmetric
 nonhermitianwrappertype(::Hermitian) = identity
 
+"""
+    LinearAlgebra.uplo(S::Union{Symmetric, Hermitian})::Char
+
+Return a `Char` corresponding to the stored triangular half in the matrix `S`,
+that is, the elements are common between `S` and `parent(S)` for that triangular half.
+
+# Example
+```jldoctest
+julia> S = Symmetric([1 2; 3 4])
+2×2 Symmetric{Int64, Matrix{Int64}}:
+ 1  2
+ 2  4
+
+julia> LinearAlgebra.uplo(S)
+'U': ASCII/Unicode U+0055 (category Lu: Letter, uppercase)
+
+julia> H = Hermitian([1 2; 3 4], :L)
+2×2 Hermitian{Int64, Matrix{Int64}}:
+ 1  3
+ 3  4
+
+julia> LinearAlgebra.uplo(H)
+'L': ASCII/Unicode U+004C (category Lu: Letter, uppercase)
+```
+"""
+uplo(S::HermOrSym) = S.uplo
+
 size(A::HermOrSym) = size(A.data)
 axes(A::HermOrSym) = axes(A.data)
 @inline function Base.isassigned(A::HermOrSym, i::Int, j::Int)

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -242,7 +242,6 @@ nonhermitianwrappertype(::Hermitian) = identity
 
 Return a `Symbol` corresponding to the stored triangular half (`:U` or `:L`) in the matrix `S`,
 that is, the elements are common between `S` and `parent(S)` for that triangular half.
-The possible values that may be returned are `:U` and `:L`.
 
 # Example
 ```jldoctest

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -28,7 +28,7 @@ To compute the symmetric part of a real matrix, or more generally the Hermitian 
 a real or complex matrix `A`, use [`hermitianpart`](@ref).
 
 The `uplo` symbol corresponding to the triangular half of `A` that is shared by the symmetric view may be
-fetched by using the function [`uplo`](@ref). The underlying matrix `A` may be fetched from the symmetric
+fetched by using the function [`LinearAlgebra.uplo`](@ref). The underlying matrix `A` may be fetched from the symmetric
 view by using `parent`.
 
 # Examples
@@ -117,7 +117,7 @@ triangle of the matrix `A`.
 To compute the Hermitian part of `A`, use [`hermitianpart`](@ref).
 
 The `uplo` symbol corresponding to the triangular half of `A` that is shared by the hermitian view may be
-fetched by using the function [`uplo`](@ref). The underlying matrix `A` may be fetched from the hermitian
+fetched by using the function [`LinearAlgebra.uplo`](@ref). The underlying matrix `A` may be fetched from the hermitian
 view by using `parent`.
 
 # Examples

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -27,6 +27,10 @@ if any specialized algorithms.)
 To compute the symmetric part of a real matrix, or more generally the Hermitian part `(A + A') / 2` of
 a real or complex matrix `A`, use [`hermitianpart`](@ref).
 
+The `uplo` symbol corresponding to the triangular half of `A` that is shared by the symmetric view may be
+fetched by using the function [`uplo`](@ref). The underlying matrix `A` may be fetched from the symmetric
+view by using `parent`.
+
 # Examples
 ```jldoctest
 julia> A = [1 2 3; 4 5 6; 7 8 9]
@@ -111,6 +115,10 @@ Construct a `Hermitian` view of the upper (if `uplo = :U`) or lower (if `uplo = 
 triangle of the matrix `A`.
 
 To compute the Hermitian part of `A`, use [`hermitianpart`](@ref).
+
+The `uplo` symbol corresponding to the triangular half of `A` that is shared by the hermitian view may be
+fetched by using the function [`uplo`](@ref). The underlying matrix `A` may be fetched from the hermitian
+view by using `parent`.
 
 # Examples
 ```jldoctest

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -242,6 +242,7 @@ nonhermitianwrappertype(::Hermitian) = identity
 
 Return a `Symbol` corresponding to the stored triangular half in the matrix `S`,
 that is, the elements are common between `S` and `parent(S)` for that triangular half.
+The possible values that may be returned are `:U` and `:L`.
 
 # Example
 ```jldoctest

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -240,7 +240,7 @@ nonhermitianwrappertype(::Hermitian) = identity
 """
     LinearAlgebra.uplo(S::Union{Symmetric, Hermitian})::Symbol
 
-Return a `Symbol` corresponding to the stored triangular half in the matrix `S`,
+Return a `Symbol` corresponding to the stored triangular half (`:U` or `:L`) in the matrix `S`,
 that is, the elements are common between `S` and `parent(S)` for that triangular half.
 The possible values that may be returned are `:U` and `:L`.
 

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -238,20 +238,20 @@ nonhermitianwrappertype(::Hermitian{<:Real}) = Symmetric
 nonhermitianwrappertype(::Hermitian) = identity
 
 """
-    LinearAlgebra.uplo(S::Union{Symmetric, Hermitian})::Char
+    LinearAlgebra.uplo(S::Union{Symmetric, Hermitian})::Symbol
 
-Return a `Char` corresponding to the stored triangular half in the matrix `S`,
+Return a `Symbol` corresponding to the stored triangular half in the matrix `S`,
 that is, the elements are common between `S` and `parent(S)` for that triangular half.
 
 # Example
 ```jldoctest
-julia> S = Symmetric([1 2; 3 4])
+julia> S = Symmetric([1 2; 3 4], :U)
 2×2 Symmetric{Int64, Matrix{Int64}}:
  1  2
  2  4
 
 julia> LinearAlgebra.uplo(S)
-'U': ASCII/Unicode U+0055 (category Lu: Letter, uppercase)
+:U
 
 julia> H = Hermitian([1 2; 3 4], :L)
 2×2 Hermitian{Int64, Matrix{Int64}}:
@@ -259,10 +259,10 @@ julia> H = Hermitian([1 2; 3 4], :L)
  3  4
 
 julia> LinearAlgebra.uplo(H)
-'L': ASCII/Unicode U+004C (category Lu: Letter, uppercase)
+:L
 ```
 """
-uplo(S::HermOrSym) = S.uplo
+uplo(S::HermOrSym) = sym_uplo(S.uplo)
 
 size(A::HermOrSym) = size(A.data)
 axes(A::HermOrSym) = axes(A.data)

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -47,6 +47,8 @@ Random.seed!(1)
             # from vectors
             ubd = Bidiagonal(x, y, :U)
             lbd = Bidiagonal(x, y, :L)
+            @test LinearAlgebra.uplo(ubd) == :U
+            @test LinearAlgebra.uplo(lbd) == :L
             @test ubd != lbd || x === dv0
             @test ubd.dv === x
             @test lbd.ev === y

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1343,4 +1343,11 @@ end
     @test_throws msg LinearAlgebra.fillband!(Symmetric(A), 2, 0, 1)
 end
 
+@testset "uplo" begin
+    S = Symmetric([1 2; 3 4], :U)
+    @test LinearAlgebra.uplo(S) == :U
+    H = Hermitian([1 2; 3 4], :L)
+    @test LinearAlgebra.uplo(H) == :L
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
This lets one access the `uplo` field of a `Symmetric`/`Hermitian` matrix without accessing the internal fields of the struct.