### PR TITLE
ldiv for vector-of-vectors RHS

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -700,6 +700,12 @@ const LAPACKFactorizations{T,S} = Union{
 (\)(F::AdjointFactorization{<:Any,<:LAPACKFactorizations}, B::AbstractVecOrMat) = ldiv(F, B)
 (\)(F::TransposeFactorization{<:Any,<:LU}, B::AbstractVecOrMat) = ldiv(F, B)
 
+# return the "scalar" type for vector fields, if possible
+_scalartype(::Type{T}) where {T<:Number} = T
+_scalartype(::Type{T}) where T = _scalartype(T, Base.IteratorEltype(T))
+_scalartype(::Type{T}, ::Base.HasEltype) where T = _scalartype(eltype(T))
+_scalartype(::Type{T}, ::Base.EltypeUnknown) where T = T
+
 function ldiv(F::Factorization, B::AbstractVecOrMat)
     require_one_based_indexing(B)
     m, n = size(F)
@@ -707,12 +713,13 @@ function ldiv(F::Factorization, B::AbstractVecOrMat)
         throw(DimensionMismatch("arguments must have the same number of rows"))
     end
 
-    TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
+    TFB = typeof(zero(_scalartype(eltype(B))) / oneunit(eltype(F)))
     FF = Factorization{TFB}(F)
 
     # For wide problem we (often) compute a minimum norm solution. The solution
     # is larger than the right hand side so we use size(F, 2).
-    BB = _zeros(TFB, B, n)
+    TBB = typeof(zero(eltype(B)) / oneunit(eltype(F)))
+    BB = _zeros(TBB, B, n)
 
     if n > size(B, 1)
         # Underdetermined

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -135,7 +135,7 @@ end
 
 function (\)(F::Factorization, B::AbstractVecOrMat)
     require_one_based_indexing(B)
-    TFB = typeof(oneunit(eltype(F)) \ oneunit(eltype(B)))
+    TFB = typeof(oneunit(eltype(F)) \ zero(eltype(B)))
     ldiv!(F, copy_similar(B, TFB))
 end
 (\)(F::TransposeFactorization, B::AbstractVecOrMat) = conj!(adjoint(F.parent) \ conj.(B))
@@ -179,7 +179,7 @@ end
 
 function (/)(B::AbstractMatrix, F::Factorization)
     require_one_based_indexing(B)
-    TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
+    TFB = typeof(zero(eltype(B)) / oneunit(eltype(F)))
     rdiv!(copy_similar(B, TFB), F)
 end
 # reinterpretation trick for complex lhs and real factorization

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -196,7 +196,7 @@ TransUpperHessenberg{T,S<:UpperHessenberg{T}} = Transpose{T, S}
 AdjOrTransUpperHessenberg{T,S<:UpperHessenberg{T}} = AdjOrTrans{T, S}
 
 function (\)(H::Union{UpperHessenberg,AdjOrTransUpperHessenberg}, B::AbstractVecOrMat)
-    TFB = typeof(oneunit(eltype(H)) \ oneunit(eltype(B)))
+    TFB = typeof(oneunit(eltype(H)) \ zero(eltype(B)))
     return ldiv!(H, copy_similar(B, TFB))
 end
 
@@ -204,7 +204,7 @@ end
 (/)(B::AbstractMatrix, H::AdjUpperHessenberg) = _rdiv(B, H)
 (/)(B::AbstractMatrix, H::TransUpperHessenberg) = _rdiv(B, H)
 function _rdiv(B, H)
-    TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(H)))
+    TFB = typeof(zero(eltype(B)) / oneunit(eltype(H)))
     return rdiv!(copy_similar(B, TFB), H)
 end
 

--- a/src/special.jl
+++ b/src/special.jl
@@ -132,13 +132,13 @@ function mul(B::Bidiagonal, H::UpperHessenberg)
 end
 
 function /(H::UpperHessenberg, B::Bidiagonal)
-    T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
+    T = typeof(oneunit(eltype(H))/zero(eltype(B)))
     A = _rdiv!(similar(H, T, size(H)), H, B)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end
 
 function \(B::Bidiagonal, H::UpperHessenberg)
-    T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
+    T = typeof(zero(eltype(B))\oneunit(eltype(H)))
     A = ldiv!(similar(H, T, size(H)), B, H)
     return B.uplo == 'U' ? UpperHessenberg(A) : A
 end

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -127,7 +127,7 @@ dimg  = randn(n)/2
                 end
 
                 # Test whether Ax_ldiv_B!(y, LU, x) indeed overwrites y
-                resultT = typeof(oneunit(eltyb) / oneunit(eltya))
+                resultT = typeof(zero(eltyb) / oneunit(eltya))
 
                 b_dest = similar(b, resultT)
                 c_dest = similar(c, resultT)


### PR DESCRIPTION
Close #904 to allow the right-hand-side for `ldiv` calls to be a vector of vectors: i.e. solving $Ax=b$ where the *elements* of $b$ and $x$ are themselves vectors (e.g. arrays, or elements of some arbitrary vector field).

Mostly, this was a straightforward matter of changing `oneunit` to `zero` (vector fields should support `zero` but need not have `one`), with two caveats:

* This works as long as the eltype itself supports `zero`, e.g. it works for `Vector{<:SVector}` but not `Vector{<:Vector}` because `zero(Vector{T})` fails (it doesn't know the size).  This seems like a reasonable limitation to me.
* In one place, for `ldiv(F::Factorization, B::AbstractVecOrMat)`, for some reason the code first converts the factorization `F` itself to a type `TFB` based on promotion with `B`.  I don't actually understand why this conversion is necessary — it dates back to https://github.com/JuliaLang/julia/pull/40899 by @andreasnoack.  **Andreas, any comments?**  If we keep that conversion, however, then it needs to know the "scalar" type of `eltype(B)`.  We don't currently provide a generic function for this.   In this PR, I make my best guess via a new function `_scalartype` that calls `eltype` recursively until it hits a `Number` type, or until it hits a type with `EltypeUnknown`.  (This should at least be backwards-compatible?) I would rather just remove the `FF = Factorization{TFB}(F)` conversion entirely, if possible, since it makes this code less generic.

(A workaround to the latter issue is to call `ldiv!`, since the in-place routines don't convert the factorization type.)

To do:
- [ ] Decide what to do about `FF = Factorization{TFB}(F)` — remove this conversion, keep the `_scalartype` workaround, or do something else?
- [ ] Tests — I tested this locally using `b = [@SVector rand(2) for _=1:2]; A = rand(2,2); x = A \ b; @test A*x ≈ b`, but to avoid a StaticArrays dependency we may need to add a dummy `SVector`-like type to `test/testhelpers.jl`