### PR TITLE
Remove zeroing in `similar` for `Hermitian`

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -330,14 +330,8 @@ isdiag(A::HermOrSym) = applytri(isdiag, A)
 
 # For A<:Union{Symmetric,Hermitian}, similar(A[, neweltype]) should yield a matrix with the same
 # symmetry type, uplo flag, and underlying storage type as A. The following methods cover these cases.
-similar(A::Symmetric, ::Type{T}) where {T} = Symmetric(similar(parent(A), T), ifelse(A.uplo == 'U', :U, :L))
-# If the Hermitian constructor's check ascertaining that the wrapped matrix's
-# diagonal is strictly real is removed, the following method can be simplified.
-function similar(A::Hermitian, ::Type{T}) where T
-    B = similar(parent(A), T)
-    for i in 1:size(B, 1) B[i, i] = 0 end
-    return Hermitian(B, ifelse(A.uplo == 'U', :U, :L))
-end
+similar(A::Symmetric, ::Type{T}) where {T} = Symmetric(similar(parent(A), T), sym_uplo(A.uplo))
+similar(A::Hermitian, ::Type{T}) where {T} = Hermitian(similar(parent(A), T), sym_uplo(A.uplo))
 # On the other hand, similar(A, [neweltype,] shape...) should yield a matrix of the underlying
 # storage type of A (not wrapped in a symmetry type). The following method covers these cases.
 similar(A::Union{Symmetric,Hermitian}, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(A), T, dims)


### PR DESCRIPTION
The comment suggests that the `Hermitian` constructor used to ensure that the parent had a real diagonal. It doesn't anymore, so the explicit fill may be removed.