### PR TITLE
Specialize norm-related functions for Diagonal

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1114,7 +1114,7 @@ end
 # norm
 function generic_normMinusInf(D::Diagonal)
     norm_diag = norm(D.diag, -Inf)
-    min(norm_diag, zero(norm_diag))
+    return size(D,1) > 1 ? min(norm_diag, zero(norm_diag)) : norm_diag
 end
 generic_normInf(D::Diagonal) = norm(D.diag, Inf)
 generic_norm1(D::Diagonal) = norm(D.diag, 1)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1111,6 +1111,23 @@ end
 /(u::AdjointAbsVec, D::Diagonal) = (D' \ u')'
 /(u::TransposeAbsVec, D::Diagonal) = transpose(transpose(D) \ transpose(u))
 
+# norm
+function generic_normMinusInf(D::Diagonal)
+    norm_diag = norm(D.diag, -Inf)
+    min(norm_diag, zero(norm_diag))
+end
+generic_normInf(D::Diagonal) = norm(D.diag, Inf)
+generic_norm1(D::Diagonal) = norm(D.diag, 1)
+generic_norm2(D::Diagonal) = norm(D.diag)
+function generic_normp(D::Diagonal, p)
+    v = norm(D.diag, p)
+    if size(D,1) > 1 && p < 0
+        v = norm(zero(v), p)
+    end
+    return v
+end
+norm_x_minus_y(D1::Diagonal, D2::Diagonal) = norm_x_minus_y(D1.diag, D2.diag)
+
 _opnorm1(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnormInf(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnorm12Inf(A::Diagonal, p) = maximum(opnorm(x, p) for x in A.diag)
@@ -1246,20 +1263,3 @@ function fillband!(D::Diagonal, x, l, u)
     end
     return D
 end
-
-# norm
-function generic_normMinusInf(D::Diagonal)
-    norm_diag = norm(D.diag, -Inf)
-    min(norm_diag, zero(norm_diag))
-end
-generic_normInf(D::Diagonal) = norm(D.diag, Inf)
-generic_norm1(D::Diagonal) = norm(D.diag, 1)
-generic_norm2(D::Diagonal) = norm(D.diag)
-function generic_normp(D::Diagonal, p)
-    v = norm(D.diag, p)
-    if size(D,1) > 1 && p < 0
-        v = norm(zero(v), p)
-    end
-    return v
-end
-norm_x_minus_y(D1::Diagonal, D2::Diagonal) = norm_x_minus_y(D1.diag, D2.diag)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1254,7 +1254,7 @@ function generic_normMinusInf(D::Diagonal)
 end
 generic_normInf(D::Diagonal) = norm(D.diag, Inf)
 generic_norm1(D::Diagonal) = norm(D.diag, 1)
-generic_norm2(D::Diagonal) = norm(D.diag, 2)
+generic_norm2(D::Diagonal) = norm(D.diag)
 function generic_normp(D::Diagonal, p)
     v = norm(D.diag, p)
     if size(D,1) > 1 && p < 0

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1249,11 +1249,17 @@ end
 
 # norm
 function generic_normMinusInf(D::Diagonal)
-    norm_diag = generic_normMinusInf(D.diag)
+    norm_diag = norm(D.diag, -Inf)
     min(norm_diag, zero(norm_diag))
 end
-generic_normInf(D::Diagonal) = generic_normInf(D.diag)
-generic_norm1(D::Diagonal) = generic_norm1(D.diag)
-_generic_norm2(D::Diagonal, maxabs) = _generic_norm2(D.diag, maxabs)
-_generic_normp(D::Diagonal, p, maxabs) = _generic_normp(D.diag, p, maxabs)
+generic_normInf(D::Diagonal) = norm(D.diag, Inf)
+generic_norm1(D::Diagonal) = norm(D.diag, 1)
+generic_norm2(D::Diagonal) = norm(D.diag, 2)
+function generic_normp(D::Diagonal, p)
+    v = norm(D.diag, p)
+    if size(D,1) > 1 && p < 0
+        v = norm(zero(v), p)
+    end
+    return v
+end
 norm_x_minus_y(D1::Diagonal, D2::Diagonal) = norm_x_minus_y(D1.diag, D2.diag)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1246,3 +1246,14 @@ function fillband!(D::Diagonal, x, l, u)
     end
     return D
 end
+
+# norm
+function generic_normMinusInf(D::Diagonal)
+    norm_diag = generic_normMinusInf(D.diag)
+    min(norm_diag, zero(norm_diag))
+end
+generic_normInf(D::Diagonal) = generic_normInf(D.diag)
+generic_norm1(D::Diagonal) = generic_norm1(D.diag)
+_generic_norm2(D::Diagonal, maxabs) = _generic_norm2(D.diag, maxabs)
+_generic_normp(D::Diagonal, p, maxabs) = _generic_normp(D.diag, p, maxabs)
+norm_x_minus_y(D1::Diagonal, D2::Diagonal) = norm_x_minus_y(D1.diag, D2.diag)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -597,18 +597,14 @@ end
 # Compute L_p norm ‖x‖ₚ = sum(abs(x).^p)^(1/p)
 # (Not technically a "norm" for p < 1.)
 function generic_normp(x, p)
+    (v, s) = iterate(x)::Tuple
     if p > 1 || p < -1 # might need to rescale to avoid overflow
         maxabs = p > 1 ? normInf(x) : normMinusInf(x)
         (ismissing(maxabs) || iszero(maxabs) || isinf(maxabs)) && return maxabs
-        return _generic_normp(x, p, maxabs)
+        T = typeof(maxabs)
     else
-        return _generic_normp(x, p)
+        T = typeof(float(norm(v)))
     end
-end
-
-function _generic_normp(x, p, maxabs::TM = nothing) where {TM}
-    (v, s) = iterate(x)::Tuple
-    T = isnothing(maxabs) ? typeof(float(norm(v))) : TM
     spp::promote_type(Float64, T) = p
     if -1 <= p <= 1 || (isfinite(length(x)*maxabs^spp) && !iszero(maxabs^spp)) # scaling not necessary
         sum::promote_type(Float64, T) = norm(v)^spp

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -575,8 +575,11 @@ norm_sqr(x::Union{T,Complex{T},Rational{T}}) where {T<:Integer} = abs2(float(x))
 function generic_norm2(x)
     maxabs = normInf(x)
     (ismissing(maxabs) || iszero(maxabs) || isinf(maxabs)) && return maxabs
+    return _generic_norm2(x, maxabs)
+end
+
+function _generic_norm2(x, maxabs::T) where {T}
     (v, s) = iterate(x)::Tuple
-    T = typeof(maxabs)
     if isfinite(length(x)*maxabs*maxabs) && !iszero(maxabs*maxabs) # Scaling not necessary
         sum::promote_type(Float64, T) = norm_sqr(v)
         for v in Iterators.rest(x, s)
@@ -601,10 +604,15 @@ function generic_normp(x, p)
     if p > 1 || p < -1 # might need to rescale to avoid overflow
         maxabs = p > 1 ? normInf(x) : normMinusInf(x)
         (ismissing(maxabs) || iszero(maxabs) || isinf(maxabs)) && return maxabs
-        T = typeof(maxabs)
+        return _generic_normp(x, p, maxabs)
     else
-        T = typeof(float(norm(v)))
+        # in this case, only the type of the last argument is used
+        # there is no scaling involved
+        return _generic_normp(x, p, float(norm(v)))
     end
+end
+
+function _generic_normp(x, p, maxabs::T) where {T}
     spp::promote_type(Float64, T) = p
     if -1 <= p <= 1 || (isfinite(length(x)*maxabs^spp) && !iszero(maxabs^spp)) # scaling not necessary
         sum::promote_type(Float64, T) = norm(v)^spp

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -575,11 +575,8 @@ norm_sqr(x::Union{T,Complex{T},Rational{T}}) where {T<:Integer} = abs2(float(x))
 function generic_norm2(x)
     maxabs = normInf(x)
     (ismissing(maxabs) || iszero(maxabs) || isinf(maxabs)) && return maxabs
-    return _generic_norm2(x, maxabs)
-end
-
-function _generic_norm2(x, maxabs::T) where {T}
     (v, s) = iterate(x)::Tuple
+    T = typeof(maxabs)
     if isfinite(length(x)*maxabs*maxabs) && !iszero(maxabs*maxabs) # Scaling not necessary
         sum::promote_type(Float64, T) = norm_sqr(v)
         for v in Iterators.rest(x, s)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -600,19 +600,18 @@ end
 # Compute L_p norm ‖x‖ₚ = sum(abs(x).^p)^(1/p)
 # (Not technically a "norm" for p < 1.)
 function generic_normp(x, p)
-    (v, s) = iterate(x)::Tuple
     if p > 1 || p < -1 # might need to rescale to avoid overflow
         maxabs = p > 1 ? normInf(x) : normMinusInf(x)
         (ismissing(maxabs) || iszero(maxabs) || isinf(maxabs)) && return maxabs
         return _generic_normp(x, p, maxabs)
     else
-        # in this case, only the type of the last argument is used
-        # there is no scaling involved
-        return _generic_normp(x, p, float(norm(v)))
+        return _generic_normp(x, p)
     end
 end
 
-function _generic_normp(x, p, maxabs::T) where {T}
+function _generic_normp(x, p, maxabs::TM = nothing) where {TM}
+    (v, s) = iterate(x)::Tuple
+    T = isnothing(maxabs) ? typeof(float(norm(v))) : TM
     spp::promote_type(Float64, T) = p
     if -1 <= p <= 1 || (isfinite(length(x)*maxabs^spp) && !iszero(maxabs^spp)) # scaling not necessary
         sum::promote_type(Float64, T) = norm(v)^spp

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1576,4 +1576,17 @@ end
     @test D == D2
 end
 
+@testset "norm" begin
+    D = Diagonal(float.(1:3))
+    A = Array(D)
+    @testset for p in -2:2
+        p == 0 && continue
+        @test norm(D, p) ≈ sum(abs.(D).^p)^(1/p)
+        @test norm(D, p) ≈ norm(A, p)
+    end
+    @test norm(D, Inf) ≈ norm(A, Inf)
+    @test norm(D, -Inf) ≈ norm(A, -Inf)
+    @test norm(D, 0) ≈ norm(A, 0)
+end
+
 end # module TestDiagonal

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1577,16 +1577,22 @@ end
 end
 
 @testset "norm" begin
-    D = Diagonal(float.(1:3))
-    A = Array(D)
-    @testset for p in -2:2
-        p == 0 && continue
-        @test norm(D, p) ≈ sum(abs.(D).^p)^(1/p)
-        @test norm(D, p) ≈ norm(A, p)
+    # test x ≈ y but also ensure that the types are identical
+    function test_isapprox_and_type(x::T, y::T) where {T}
+        @test x ≈ y
     end
-    @test norm(D, Inf) ≈ norm(A, Inf)
-    @test norm(D, -Inf) ≈ norm(A, -Inf)
-    @test norm(D, 0) ≈ norm(A, 0)
+    @testset "size(D,1) = $(size(D,1))" for D in ( Diagonal(1:3), Diagonal(1:1), Diagonal(1:0) )
+        A = Array(D)
+        @testset for p in -2:2
+            p == 0 && continue
+            s = sum(float.(abs.(D)).^p)^(1/p)
+            test_isapprox_and_type(norm(D, p), isempty(D) ? zero(s) : s)
+            test_isapprox_and_type(norm(D, p), norm(A, p))
+        end
+        test_isapprox_and_type(norm(D, Inf), norm(A, Inf))
+        test_isapprox_and_type(norm(D, -Inf), norm(A, -Inf))
+        test_isapprox_and_type(norm(D, 0), norm(A, 0))
+    end
 end
 
 end # module TestDiagonal


### PR DESCRIPTION
For banded matrices such as `Diagonal`, we may skip the non-stored elements in computing the norm, as the contribution of these would be zero.

This improves performance.
On master
```julia
julia> D1 = Diagonal(rand(1000));

julia> D2 = Diagonal(rand(1000));

julia> @btime norm($D1);
  2.668 ms (0 allocations: 0 bytes)

julia> @btime isapprox($D1, $D2);
  8.007 ms (3 allocations: 7.88 KiB)
```
vs this PR
```julia
julia> @btime norm($D1);
  247.196 ns (0 allocations: 0 bytes)

julia> @btime isapprox($D1, $D2);
  1.696 μs (0 allocations: 0 bytes)
```