### PR TITLE
Avoid divide the first element for type check in normalize

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2108,7 +2108,7 @@ NaN
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
     if !isempty(a)
-        aa = copymutable_oftype(a, typeof(first(a)/nrm))
+        aa = copymutable_oftype(a, float(Base.promote_eltype(a, nrm)))
         return __normalize!(aa, nrm)
     else
         T = typeof(zero(eltype(a))/nrm)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2108,7 +2108,7 @@ NaN
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
     if !isempty(a)
-        aa = copymutable_oftype(a, float(Base.promote_eltype(a, nrm)))
+        aa = copymutable_oftype(a, float(Base.promote_op(/, eltype(a), typeof(nrm))))
         return __normalize!(aa, nrm)
     else
         T = typeof(zero(eltype(a))/nrm)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2107,6 +2107,7 @@ NaN
 """
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
+    T = promote_op(/, eltype(a), typeof(nrm))
     if !isempty(a)
         aa = copymutable_oftype(a, promote_op(/, eltype(a), typeof(nrm)))
         return __normalize!(aa, nrm)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2108,7 +2108,7 @@ NaN
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
     if !isempty(a)
-        aa = copymutable_oftype(a, Base.promote_op(/, eltype(a), typeof(nrm)))
+        aa = copymutable_oftype(a, promote_op(/, eltype(a), typeof(nrm)))
         return __normalize!(aa, nrm)
     else
         T = typeof(zero(eltype(a))/nrm)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2111,7 +2111,6 @@ function normalize(a::AbstractArray, p::Real = 2)
         aa = copymutable_oftype(a, promote_op(/, eltype(a), typeof(nrm)))
         return __normalize!(aa, nrm)
     else
-        T = typeof(zero(eltype(a))/nrm)
         return T[]
     end
 end

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2109,7 +2109,7 @@ function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
     T = promote_op(/, eltype(a), typeof(nrm))
     if !isempty(a)
-        aa = copymutable_oftype(a, promote_op(/, eltype(a), typeof(nrm)))
+        aa = copymutable_oftype(a, T)
         return __normalize!(aa, nrm)
     else
         return T[]

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2108,7 +2108,7 @@ NaN
 function normalize(a::AbstractArray, p::Real = 2)
     nrm = norm(a, p)
     if !isempty(a)
-        aa = copymutable_oftype(a, float(Base.promote_op(/, eltype(a), typeof(nrm))))
+        aa = copymutable_oftype(a, Base.promote_op(/, eltype(a), typeof(nrm)))
         return __normalize!(aa, nrm)
     else
         T = typeof(zero(eltype(a))/nrm)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -497,14 +497,10 @@ end
 
 @testset "normalize array of arrays" begin
     a = [[1,2], [3,4]]
-    for Tr in (Int32, Int64, Float32, Float64)
-        for T in (Tr, Complex{Tr})
-            b = convert(Vector{Vector{T}}, a)
-            @test normalize(b) == normalize!(copy(b))
-            @test norm(normalize(b)) == 1.0
-            @inferred normalize(b)
-        end
-    end
+    b = [Int[]]
+    @test @inferred norm(normalize(a)) ≈ 1
+    @test normalize(a) isa Vector{Vector{Float64}}
+    @test normalize(b) isa Vector{Vector{Float64}}
 end
 
 @testset "Issue 14657" begin

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -495,6 +495,18 @@ end
                        [0.0 + 0.0im, 0.0 - 0.0im, NaN + NaN*im]))
 end
 
+@testset "normalize array of arrays" begin
+    a = [[1,2], [3,4]]
+    for Tr in (Int32, Int64, Float32, Float64)
+        for T in (Tr, Complex{Tr})
+            b = convert(Vector{Vector{T}}, a)
+            @test normalize(b) == normalize!(copy(b))
+            @test norm(normalize(b)) == 1.0
+            @inferred normalize(b)
+        end
+    end
+end
+
 @testset "Issue 14657" begin
     @test det([true false; false true]) == det(Matrix(1I, 2, 2))
 end


### PR DESCRIPTION
Closes #1182

The previous implementation of `normalize` was computing the division between the first element of the array and the norm, in order to obtain the output type. This is both inefficient and doesn't work on arrays that don't support scalar indexing.

I have changed the type check with `float(Base.promote_eltype(a, nrm))`.