### PR TITLE
Overload array constructors for BunchKaufman (#1461)

### DIFF
--- a/src/bunchkaufman.jl
+++ b/src/bunchkaufman.jl
@@ -219,7 +219,7 @@ Factorization{T}(B::BunchKaufman) where {T} = BunchKaufman{T}(B)
 
 AbstractMatrix(B::BunchKaufman) = B.uplo == 'U' ? B.P'B.U*B.D*B.U'B.P : B.P'B.L*B.D*B.L'B.P
 AbstractArray(B::BunchKaufman) = AbstractMatrix(B)
-Matrix(B::BunchKaufman) = Array(AbstractArray(B))
+Matrix(B::BunchKaufman) = convert(Array, AbstractArray(B))
 Array(B::BunchKaufman) = Matrix(B)
 
 

--- a/src/bunchkaufman.jl
+++ b/src/bunchkaufman.jl
@@ -217,6 +217,12 @@ BunchKaufman{T}(B::BunchKaufman) where {T} =
     BunchKaufman(convert(Matrix{T}, B.LD), B.ipiv, B.uplo, B.symmetric, B.rook, B.info)
 Factorization{T}(B::BunchKaufman) where {T} = BunchKaufman{T}(B)
 
+AbstractMatrix(B::BunchKaufman) = B.uplo == 'U' ? B.P'B.U*B.D*B.U'B.P : B.P'B.L*B.D*B.L'B.P
+AbstractArray(B::BunchKaufman) = AbstractMatrix(B)
+Matrix(B::BunchKaufman) = Array(AbstractArray(B))
+Array(B::BunchKaufman) = Matrix(B)
+
+
 size(B::BunchKaufman) = size(getfield(B, :LD))
 size(B::BunchKaufman, d::Integer) = size(getfield(B, :LD), d)
 issymmetric(B::BunchKaufman) = B.symmetric

--- a/src/cholesky.jl
+++ b/src/cholesky.jl
@@ -646,7 +646,7 @@ Factorization{T}(C::CholeskyPivoted) where {T} = CholeskyPivoted{T}(C)
 
 AbstractMatrix(C::Cholesky) = C.uplo == 'U' ? C.U'C.U : C.L*C.L'
 AbstractArray(C::Cholesky) = AbstractMatrix(C)
-Matrix(C::Cholesky) = Array(AbstractArray(C))
+Matrix(C::Cholesky) = convert(Array, AbstractArray(C))
 Array(C::Cholesky) = Matrix(C)
 
 function AbstractMatrix(F::CholeskyPivoted)
@@ -655,7 +655,7 @@ function AbstractMatrix(F::CholeskyPivoted)
     U'U
 end
 AbstractArray(F::CholeskyPivoted) = AbstractMatrix(F)
-Matrix(F::CholeskyPivoted) = Array(AbstractArray(F))
+Matrix(F::CholeskyPivoted) = convert(Array, AbstractArray(F))
 Array(F::CholeskyPivoted) = Matrix(F)
 
 copy(C::Cholesky) = Cholesky(copy(C.factors), C.uplo, C.info)

--- a/test/bunchkaufman.jl
+++ b/test/bunchkaufman.jl
@@ -263,7 +263,7 @@ end
     a = randn(5,5)
     A = a'a
     for ul in (:U, :L)
-        B = bunchkaufman(A, ul)
+        B = bunchkaufman(Symmetric(A, ul))
         @test A ≈ Array(B) ≈ Matrix(B) ≈ AbstractArray(B) ≈ AbstractMatrix(B)
     end
 end

--- a/test/bunchkaufman.jl
+++ b/test/bunchkaufman.jl
@@ -259,4 +259,13 @@ end
     @test B.U * B.D * B.U' ≈ S
 end
 
+@testset "BunchKaufman array constructors #1461" begin
+    a = randn(5,5)
+    A = a'a
+    for ul in (:U, :L)
+        B = bunchkaufman(A, ul)
+        @test A ≈ Array(B) ≈ Matrix(B) ≈ AbstractArray(B) ≈ AbstractMatrix(B)
+    end
+end
+
 end # module TestBunchKaufman


### PR DESCRIPTION
This adds overloads for array conversion for `BunchKaufman`. This fixes a regression in Julia v1.12-rc3:
```julia
julia> a = randn(5,5); A = a'a; F = factorize(A);

julia> typeof(F) # Was a Cholesky in v1.11
BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}}

julia> Array(F) # Succeeded for Cholesky
ERROR: MethodError: no method matching Array(::BunchKaufman{Float64, Matrix{Float64}, Vector{Int64}})
The type `Array` exists, but no method is defined for this combination of argument types when trying to construct it.

Closest candidates are:
  Array(::QL)
   @ MatrixFactorizations ~/Projects/MatrixFactorizations.jl/src/ql.jl:204
  Array(::Eigen)
   @ LinearAlgebra ~/Projects/julia-1.12/usr/share/julia/stdlib/v1.12/LinearAlgebra/src/eigen.jl:682
  Array(::UniformScaling, ::Tuple{Int64, Int64})
   @ LinearAlgebra ~/Projects/julia-1.12/usr/share/julia/stdlib/v1.12/LinearAlgebra/src/uniformscaling.jl:437
  ...

Stacktrace:
 [1] top-level scope
   @ REPL[52]:1
```
See discussion here: https://github.com/JuliaLang/LinearAlgebra.jl/issues/1461