### PR TITLE
Add 'eigmin'/'eigmax' methods for 'Eigen'

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -276,6 +276,8 @@ eigvecs(A::Union{Number, AbstractMatrix}; kws...) =
 eigvecs(F::Union{Eigen, GeneralizedEigen}) = F.vectors
 
 eigvals(F::Union{Eigen, GeneralizedEigen}) = F.values
+eigmin(F::Union{Eigen, GeneralizedEigen}) = minimum(F.values)
+eigmax(F::Union{Eigen, GeneralizedEigen}) = maximum(F.values)
 
 """
     eigvals!(A; permute::Bool=true, scale::Bool=true, sortby) -> values

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -276,8 +276,8 @@ eigvecs(A::Union{Number, AbstractMatrix}; kws...) =
 eigvecs(F::Union{Eigen, GeneralizedEigen}) = F.vectors
 
 eigvals(F::Union{Eigen, GeneralizedEigen}) = F.values
-eigmin(F::Union{Eigen, GeneralizedEigen}) = minimum(F.values)
-eigmax(F::Union{Eigen, GeneralizedEigen}) = maximum(F.values)
+eigmin(F::Union{Eigen, GeneralizedEigen}) = minimum(eigvals(F))
+eigmax(F::Union{Eigen, GeneralizedEigen}) = maximum(eigvals(F))
 
 """
     eigvals!(A; permute::Bool=true, scale::Bool=true, sortby) -> values

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -44,6 +44,15 @@ aimg  = randn(n,n)/2
             @test inv(a) ≈ inv(f)
             @test isposdef(a) == isposdef(f)
             @test eigvals(f) === f.values
+
+            if all(isreal, f.values)
+                @test eigmin(f) == minimum(f.values)
+                @test eigmax(f) == maximum(f.values)
+            else
+                @test_throws MethodError eigmin(f)
+                @test_throws MethodError eigmax(f)
+            end
+
             @test eigvecs(f) === f.vectors
             @test Array(f) ≈ a
 
@@ -81,6 +90,15 @@ aimg  = randn(n,n)/2
             @test prod(f.values) ≈ prod(eigvals(asym_sg/(ASG2))) atol=200ε
             @test eigvecs(asym_sg, ASG2) == f.vectors
             @test eigvals(f) === f.values
+
+            if all(isreal, f.values)
+                @test eigmin(f) == minimum(f.values)
+                @test eigmax(f) == maximum(f.values)
+            else
+                @test_throws MethodError eigmin(f)
+                @test_throws MethodError eigmax(f)
+            end
+
             @test eigvecs(f) === f.vectors
             @test_throws FieldError f.Z
 

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -45,9 +45,9 @@ aimg  = randn(n,n)/2
             @test isposdef(a) == isposdef(f)
             @test eigvals(f) === f.values
 
-            if all(isreal, f.values)
-                @test eigmin(f) == minimum(f.values)
-                @test eigmax(f) == maximum(f.values)
+            if all(isreal, eigvals(f))
+                @test eigmin(f) == minimum(eigvals(f))
+                @test eigmax(f) == maximum(eigvals(f))
             else
                 @test_throws MethodError eigmin(f)
                 @test_throws MethodError eigmax(f)
@@ -91,9 +91,9 @@ aimg  = randn(n,n)/2
             @test eigvecs(asym_sg, ASG2) == f.vectors
             @test eigvals(f) === f.values
 
-            if all(isreal, f.values)
-                @test eigmin(f) == minimum(f.values)
-                @test eigmax(f) == maximum(f.values)
+            if all(isreal, eigvals(f))
+                @test eigmin(f) == minimum(eigvals(f))
+                @test eigmax(f) == maximum(eigvals(f))
             else
                 @test_throws MethodError eigmin(f)
                 @test_throws MethodError eigmax(f)


### PR DESCRIPTION
We add the methods 'eigmin' and 'eigmax' on the type 'F::Union{Eigen, GeneralizedEigen}' similarly to how 'eigvals' is defined on 'F'. Note that the corresponding unit tests in 'test/eigen.jl' that call 'eigvals' on such a struct are updated to include 'eigmin' and 'eigmax' calls as well; if all eigenvalues are real, the actual functionality of the methods is tested, and if any happen to be complex, then we test that they throw 'MethodError's.

(Resolves #1464 by @longemen3000.)