### PR TITLE
remove claim that complex numbers cannot be sorted

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -359,13 +359,8 @@ eigvals(x::Number; kwargs...) = imag(x) == 0 ? real(x) : x
 """
     eigmax(A; permute::Bool=true, scale::Bool=true)
 
-Return the largest eigenvalue of `A`.
-The option `permute=true` permutes the matrix to become
-closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
-make rows and columns more equal in norm.
-Note that if the eigenvalues of `A` are complex,
-this method will fail, since complex numbers cannot
-be sorted.
+Return the largest eigenvalue of `A`, assuming they are all real, and throwing an error otherwise.
+The `permute` and `scale` keyword arguments are the same as for [`eigen`](@ref).
 
 # Examples
 ```jldoctest
@@ -390,23 +385,18 @@ Stacktrace:
 ```
 """
 function eigmax(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true)
-    v = eigvals(A, permute = permute, scale = scale)
+    v = eigvals(A; permute, scale)
     if eltype(v)<:Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))
     end
-    maximum(v)
+    return maximum(v)
 end
 
 """
     eigmin(A; permute::Bool=true, scale::Bool=true)
 
-Return the smallest eigenvalue of `A`.
-The option `permute=true` permutes the matrix to become
-closer to upper triangular, and `scale=true` scales the matrix by its diagonal elements to
-make rows and columns more equal in norm.
-Note that if the eigenvalues of `A` are complex,
-this method will fail, since complex numbers cannot
-be sorted.
+Return the smallest eigenvalue of `A`, assuming they are all real, and throwing an error otherwise.
+The `permute` and `scale` keyword arguments are the same as for [`eigen`](@ref).
 
 # Examples
 ```jldoctest
@@ -430,13 +420,12 @@ Stacktrace:
 [...]
 ```
 """
-function eigmin(A::Union{Number, AbstractMatrix};
-                permute::Bool=true, scale::Bool=true)
-    v = eigvals(A, permute = permute, scale = scale)
+function eigmin(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true)
+    v = eigvals(A; permute, scale)
     if eltype(v)<:Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))
     end
-    minimum(v)
+    return minimum(v)
 end
 
 inv(A::Eigen) = A.vectors * inv(Diagonal(A.values)) / A.vectors


### PR DESCRIPTION
Closes #1478.

Instead of talking about ordered fields and talking about why not use lexicographical ordering, I decided to just delete everything.