### PR TITLE
Reduce method definitions for cat of `AbstractQ`s

### DIFF
--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -145,7 +145,6 @@ function copyto!(dest::PermutedDimsArray{T,2,perm}, src::AbstractQ) where {T,per
     end
     return dest
 end
-
 # used in concatenations: Base.__cat_offset1!
 Base._copy_or_fill!(A, inds, Q::AbstractQ) = copyto!(view(A, inds...), Q)
 # overloads of helper functions

--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -145,16 +145,14 @@ function copyto!(dest::PermutedDimsArray{T,2,perm}, src::AbstractQ) where {T,per
     end
     return dest
 end
-# used in concatenations: Base.__cat_offset1!
-Base._copy_or_fill!(A, inds, Q::AbstractQ) = (A[inds...] = collect(Q))
+Base.fill!(A, Q::AbstractQ) = copyto!(A, Q)
+
 # overloads of helper functions
 Base.cat_size(A::AbstractQ) = size(A)
 Base.cat_size(A::AbstractQ, d) = size(A, d)
 Base.cat_length(a::AbstractQ) = prod(size(a))
 Base.cat_ndims(a::AbstractQ) = ndims(a)
 Base.cat_indices(A::AbstractQ, d) = axes(A, d)
-Base.cat_similar(A::AbstractQ, T::Type, shape::Tuple) = Array{T}(undef, shape)
-Base.cat_similar(A::AbstractQ, T::Type, shape::Vector) = Array{T}(undef, shape...)
 
 function show(io::IO, ::MIME{Symbol("text/plain")}, Q::AbstractQ)
     print(io, Base.dims2string(size(Q)), ' ', summary(Q))

--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -145,8 +145,9 @@ function copyto!(dest::PermutedDimsArray{T,2,perm}, src::AbstractQ) where {T,per
     end
     return dest
 end
-Base.fill!(A, Q::AbstractQ) = copyto!(A, Q)
 
+# used in concatenations: Base.__cat_offset1!
+Base._copy_or_fill!(A, inds, Q::AbstractQ) = copyto!(view(A, inds...), Q)
 # overloads of helper functions
 Base.cat_size(A::AbstractQ) = size(A)
 Base.cat_size(A::AbstractQ, d) = size(A, d)


### PR DESCRIPTION
This is related to #1233. The remaining function definitions are necessary because the generic counterparts treat everything not-an-array as a scalar, so we absolutely have to teach it to treat `AbstractQ`s as arrays in concatenation. In the assignment of a subarray this even allows to avoid a temporary array.