### PR TITLE
WIP: Allow diagonal offset arrays

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -6,7 +6,6 @@ struct Diagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     diag::V
 
     function Diagonal{T,V}(diag) where {T,V<:AbstractVector{T}}
-        require_one_based_indexing(diag)
         new{T,V}(diag)
     end
 end

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -496,9 +496,11 @@ LinearAlgebra.istril(N::NotDiagonal) = istril(N.a)
 end
 
 @testset "axes" begin
-    v = OffsetArray(1:3)
-    D = Diagonal(v)
-    @test axes(D) isa NTuple{2,typeof(axes(v,1))}
+    for v in (OffsetArray(1:3), OffsetArray(-4:3))
+        D = Diagonal(v)
+        @test D[1,1] == 1
+        @test axes(D) isa NTuple{2,typeof(axes(v,1))}
+    end
 end
 
 @testset "rdiv! (#40887)" begin


### PR DESCRIPTION
The restriction to one-based indexing seems artificial for `Diagonal`. This PR removes the restriction.