### PR TITLE
Avoid a multiplication in ldlt!

### DIFF
--- a/src/ldlt.jl
+++ b/src/ldlt.jl
@@ -120,8 +120,9 @@ function ldlt!(S::SymTridiagonal{T,V}) where {T,V}
     e = S.ev
     @inbounds for i in 1:n-1
         iszero(d[i]) && throw(ZeroPivotException(i))
-        e[i] /= d[i]
-        d[i+1] -= e[i]^2*d[i]
+        new_ei = e[i] / d[i]
+        d[i+1] -= new_ei * e[i]
+        e[i] = new_ei
     end
     return LDLt{T,SymTridiagonal{T,V}}(S)
 end


### PR DESCRIPTION
By storing the new off-diagonal element in a temporary variable.

### Current
```julia
julia> @btime ldlt!(copy(S)) setup=(S=SymTridiagonal(2*ones(1_000_000), -ones(999_999)););
  9.708 ms (6 allocations: 15.28 MiB)
```

### This PR
```julia
julia> @btime ldlt!(copy(S)) setup=(S=SymTridiagonal(2*ones(1_000_000), -ones(999_999)););
  8.448 ms (6 allocations: 15.28 MiB)
```