### PR TITLE
Only loop over nonzero indices in matvecmul

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -551,6 +551,7 @@ include("exceptions.jl")
 include("generic.jl")
 
 include("blas.jl")
+include("sparse_interface.jl")
 include("matmul.jl")
 include("lapack.jl")
 

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -13,6 +13,8 @@ StridedMaybeAdjOrTransVecOrMat{T} = Union{StridedVecOrMat{T}, AdjOrTrans{<:Any, 
 
 matprod(x, y) = x*y + x*y
 
+nonzeroinds(v::AbstractVector) = eachindex(v)
+
 # dot products
 
 dot(x::StridedVecLike{T}, y::StridedVecLike{T}) where {T<:BlasReal} = BLAS.dot(x, y)
@@ -1055,7 +1057,7 @@ function __generic_matvecmul!(f::F, C::AbstractVector, A::AbstractVecOrMat, B::A
                 aoffs = (k-1)*Astride
                 firstterm = f(A[aoffs + 1]) * B[1]
                 s = zero(firstterm + firstterm)
-                for i = eachindex(B)
+                for i in nonzeroinds(B)
                     s += f(A[aoffs+i]) * B[i]
                 end
                 @stable_muladdmul _modify!(MulAddMul(alpha,beta), s, C, k)
@@ -1078,7 +1080,7 @@ function __generic_matvecmul!(::typeof(identity), C::AbstractVector, A::Abstract
             end
         end
         if !iszero(alpha)
-            for k = eachindex(B)
+            for k in nonzeroinds(B)
                 aoffs = (k-1)*Astride
                 b = @stable_muladdmul MulAddMul(alpha,false)(B[k])
                 for i = eachindex(C)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -13,8 +13,6 @@ StridedMaybeAdjOrTransVecOrMat{T} = Union{StridedVecOrMat{T}, AdjOrTrans{<:Any, 
 
 matprod(x, y) = x*y + x*y
 
-nonzeroinds(v::AbstractVector) = eachindex(v)
-
 # dot products
 
 dot(x::StridedVecLike{T}, y::StridedVecLike{T}) where {T<:BlasReal} = BLAS.dot(x, y)

--- a/src/sparse_interface.jl
+++ b/src/sparse_interface.jl
@@ -1,0 +1,1 @@
+nonzeroinds(v::AbstractVector) = eachindex(v)


### PR DESCRIPTION
This speeds up the operation for sparse arrays in general if a specialization is added by `SparseArrays.jl`. I'm choosing `FillArrays` somewhat arbitrarily in the example to ensure that we take the fallback method defined here.

```julia
julia> using LinearAlgebra, FillArrays, SparseArrays

julia> A = Fill(4, 100, 100);

julia> v = sparsevec([1, 100], [1, 100]);

julia> y = similar(A, size(A,1));

julia> @btime mul!($y, $A, $v);
  1.159 μs (0 allocations: 0 bytes)

julia> LinearAlgebra.nonzeroinds(v::SparseVector) = SparseArrays.nonzeroinds(v)

julia> @btime mul!($y, $A, $v);
  243.815 ns (0 allocations: 0 bytes)
```

The idea is that since we compute `A * v` as `sum(@view(A[:,i]) * v[i] for i in eachindex(v))`, we may limit the sum to the indices for which `v` has a non-zero element.