### PR TITLE
Remove some re-exports from Base

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -81,7 +81,6 @@ export
     condskeel,
     copy_adjoint!,
     copy_transpose!,
-    copyto!,
     copytrito!,
     cross,
     det,
@@ -158,11 +157,6 @@ export
     tril,
     triu!,
     triu,
-
-
-# Operators
-    \,
-    /,
 
 # Constants
     I

--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -52,7 +52,7 @@ AbstractArray{T}(Q::AbstractQ) where {T} = AbstractMatrix{T}(Q)
 convert(::Type{T}, Q::AbstractQ) where {T<:AbstractArray} = T(Q)
 # legacy
 @deprecate(convert(::Type{AbstractMatrix{T}}, Q::AbstractQ) where {T},
-    convert(LinearAlgebra.AbstractQ{T}, Q))
+    convert(LinearAlgebra.AbstractQ{T}, Q), false)
 
 function size(Q::AbstractQ, dim::Integer)
     if dim < 1


### PR DESCRIPTION
Base exports `copyto!`, `/`, `\`, and `convert`. LinearAlgebra currently re-exports all of these. I don't think it should really, it's non-standard to re-export what Base is already exporting. This causes slightly weird behavior in ExplicitImports: https://github.com/JuliaTesting/ExplicitImports.jl/issues/137.

xref https://github.com/JuliaLang/julia/issues/60318