### PR TITLE
Comment-out re-exports from Base

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -81,6 +81,7 @@ export
     condskeel,
     copy_adjoint!,
     copy_transpose!,
+    copyto!,
     copytrito!,
     cross,
     det,
@@ -157,6 +158,11 @@ export
     tril,
     triu!,
     triu,
+
+
+# Operators
+    \,
+    /,
 
 # Constants
     I

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -70,7 +70,7 @@ export
 
 # Functions
     adjoint!,
-    adjoint,
+    # adjoint, # exported by Base
     axpby!,
     axpy!,
     bunchkaufman!,
@@ -81,7 +81,7 @@ export
     condskeel,
     copy_adjoint!,
     copy_transpose!,
-    copyto!,
+    # copyto!, # exported by Base
     copytrito!,
     cross,
     det,
@@ -111,8 +111,8 @@ export
     issymmetric,
     istril,
     istriu,
-    kron!,
-    kron,
+    # kron!, # exported by Base
+    # kron, # exported by Base
     ldiv!,
     ldlt!,
     ldlt,
@@ -153,7 +153,7 @@ export
     sylvester,
     tr,
     transpose!,
-    transpose,
+    # transpose, # exported by Base
     tril!,
     tril,
     triu!,
@@ -161,8 +161,8 @@ export
 
 
 # Operators
-    \,
-    /,
+    # \, # exported by Base
+    # /, # exported by Base
 
 # Constants
     I

--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -52,7 +52,7 @@ AbstractArray{T}(Q::AbstractQ) where {T} = AbstractMatrix{T}(Q)
 convert(::Type{T}, Q::AbstractQ) where {T<:AbstractArray} = T(Q)
 # legacy
 @deprecate(convert(::Type{AbstractMatrix{T}}, Q::AbstractQ) where {T},
-    convert(LinearAlgebra.AbstractQ{T}, Q), false)
+    convert(LinearAlgebra.AbstractQ{T}, Q))
 
 function size(Q::AbstractQ, dim::Integer)
     if dim < 1

--- a/src/abstractq.jl
+++ b/src/abstractq.jl
@@ -52,7 +52,7 @@ AbstractArray{T}(Q::AbstractQ) where {T} = AbstractMatrix{T}(Q)
 convert(::Type{T}, Q::AbstractQ) where {T<:AbstractArray} = T(Q)
 # legacy
 @deprecate(convert(::Type{AbstractMatrix{T}}, Q::AbstractQ) where {T},
-    convert(LinearAlgebra.AbstractQ{T}, Q))
+    convert(LinearAlgebra.AbstractQ{T}, Q), false)
 
 function size(Q::AbstractQ, dim::Integer)
     if dim < 1


### PR DESCRIPTION
This re-does #1537 addressing @ViralBShah's review comment that they should be commented out instead. I was also a bit more thoroughly, using this list:
```julia
julia> names(LinearAlgebra) ∩ names(Base)
8-element Vector{Symbol}:
 :/
 :\
 :adjoint
 :convert
 :copyto!
 :kron
 :kron!
 :transpose
```

(on 3-day old nightly).