### PR TITLE
Fix `Matrix(::HessenbergQ)` and multiplication for empty matrices

### DIFF
--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -6082,7 +6082,7 @@ for (orghr, elty) in
             require_one_based_indexing(A, tau)
             chkstride1(A, tau)
             n = checksquare(A)
-            if n - length(tau) != 1
+            if !iszero(n) && (n - length(tau) != 1)
                 throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             work = Vector{$elty}(undef, 1)
@@ -6339,7 +6339,7 @@ for (orgtr, elty) in
             require_one_based_indexing(A, tau)
             chkstride1(A, tau)
             n = checksquare(A)
-            if n - length(tau) != 1
+            if !iszero(n) && (n - length(tau) != 1)
                 throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             chkuplo(uplo)
@@ -6396,7 +6396,7 @@ for (ormtr, elty) in
             chktrans(trans)
             mC, nC = size(C, 1), size(C, 2)
 
-            if n - length(tau) != 1
+            if !iszero(n) && (n - length(tau) != 1)
                 throw(DimensionMismatch(lazy"tau has length $(length(tau)), needs $(n - 1)"))
             end
             if (side == 'L' && mC != n) || (side == 'R' && nC != n)

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -294,10 +294,14 @@ end
 end
 
 @testset "multiplication with empty HessenbergQ" begin
-    @test ones(2, 0)*hessenberg(zeros(0,0)).Q == zeros(2,0)
-    @test_throws DimensionMismatch ones(2, 1)*hessenberg(zeros(0,0)).Q
-    @test hessenberg(zeros(0,0)).Q * ones(0, 2) == zeros(0,2)
-    @test_throws DimensionMismatch hessenberg(zeros(0,0)).Q * ones(1, 2)
+    for A in (zeros(0,0), Symmetric(zeros(0,0)))
+        Q = hessenberg(A).Q
+        @test Matrix(Q) == zeros(0, 0)
+        @test ones(2, 0) * Q == zeros(2,0)
+        @test_throws DimensionMismatch ones(2, 1) * Q
+        @test Q * ones(0, 2) == zeros(0,2)
+        @test_throws DimensionMismatch Q * ones(1, 2)
+    end
 end
 
 @testset "fillband" begin


### PR DESCRIPTION
Fixes #1545. The modified tests contain four tests that would currently fail.
