### PR TITLE
Limit adj/trans `diagview` to matrices

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -575,8 +575,8 @@ Compute `vec(adjoint(A))`, but avoid an allocating reshape if possible
 _vecadjoint(A::AbstractVector) = vec(adjoint(A))
 _vecadjoint(A::Base.ReshapedArray{<:Any,1,<:AdjointAbsVec}) = adjoint(parent(A))
 
-diagview(A::Transpose, k::Integer = 0) = _vectranspose(diagview(parent(A), -k))
-diagview(A::Adjoint, k::Integer = 0) = _vecadjoint(diagview(parent(A), -k))
+diagview(A::TransposeAbsMat, k::Integer = 0) = _vectranspose(diagview(parent(A), -k))
+diagview(A::AdjointAbsMat, k::Integer = 0) = _vecadjoint(diagview(parent(A), -k))
 
 # triu and tril
 triu!(A::AdjOrTransAbsMat, k::Integer = 0) = wrapperop(A)(tril!(parent(A), -k))

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -790,7 +790,7 @@ end
 
 @testset "diagview" begin
     for A in (rand(4, 4), rand(ComplexF64,4,4),
-                fill([1 2; 3 4], 4, 4))
+                fill([1 2; 3 4], 4, 4), 1:4)
         for k in -3:3
             @test diagview(A', k) == diag(A', k)
             @test diagview(transpose(A), k) == diag(transpose(A), k)


### PR DESCRIPTION
Should fix https://github.com/JuliaLang/LinearAlgebra.jl/pull/1549#issuecomment-3864144919.

After this, the following works:
```julia
julia> a = (1:4)'
1×4 adjoint(::UnitRange{Int64}) with eltype Int64:
 1  2  3  4

julia> diagview(a)
1-element view(::UnitRange{Int64}, 1:2:1) with eltype Int64:
 1
```