### PR TITLE
Avoid construction in convert

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -249,6 +249,7 @@ AbstractMatrix{T}(A::Bidiagonal{T}) where {T} = copy(A)
 
 function convert(::Type{T}, A::AbstractMatrix) where T<:Bidiagonal
     checksquare(A)
+    A isa T && return A
     isbanded(A, -1, 1) || throw(InexactError(:convert, T, A))
     iszero(diagview(A, 1)) ? T(A, :L) :
         iszero(diagview(A, -1)) ? T(A, :U) : throw(InexactError(:convert, T, A))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -104,6 +104,7 @@ Diagonal{T}(A::AbstractMatrix) where T = Diagonal{T}(diag(A))
 Diagonal{T,V}(A::AbstractMatrix) where {T,V<:AbstractVector{T}} = Diagonal{T,V}(diag(A))
 function convert(::Type{T}, A::AbstractMatrix) where T<:Diagonal
     checksquare(A)
+    A isa T && return A
     isdiag(A) ? T(A) : throw(InexactError(:convert, T, A))
 end
 

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -639,6 +639,7 @@ end
 
 function convert(::Type{T}, A::AbstractMatrix) where T<:Tridiagonal
     checksquare(A)
+    A isa T && return A
     isbanded(A, -1, 1) ? T(A) : throw(InexactError(:convert, T, A))
 end
 

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -131,6 +131,7 @@ SymTridiagonal(S::SymTridiagonal) = S
 
 function convert(::Type{T}, A::AbstractMatrix) where T<:SymTridiagonal
     checksquare(A)
+    A isa T && return A
     _checksymmetric(A) && isbanded(A, -1, 1) ? T(A) : throw(InexactError(:convert, T, A))
 end
 

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -798,6 +798,12 @@ end
     @test convert(AbstractMatrix{Float64}, Bu)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bu
     @test convert(AbstractArray{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
     @test convert(AbstractMatrix{Float64}, Bl)::Bidiagonal{Float64,ImmutableArray{Float64,1,Array{Float64,1}}} == Bl
+
+    @testset "convert to Bidiagonal from same type" begin
+        @test convert(typeof(Bu), Bu) === Bu
+        @test convert(Bidiagonal{eltype(Bu)}, Bu) === Bu
+        @test convert(Bidiagonal, Bu) === Bu
+    end
 end
 
 @testset "block-bidiagonal matrix" begin

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -549,6 +549,7 @@ end
 
 @testset "convert for SymTridiagonal" begin
     STF32 = SymTridiagonal{Float32}(fill(1f0, 5), fill(1f0, 4))
+    @test convert(typeof(STF32), STF32) === STF32
     @test convert(SymTridiagonal{Float64}, STF32)::SymTridiagonal{Float64} == STF32
     @test convert(AbstractMatrix{Float64}, STF32)::SymTridiagonal{Float64} == STF32
 end
@@ -1140,6 +1141,16 @@ end
         end
         @test_throws InexactError convert(SymTridiagonal, fill(5, 4, 4))
         @test_throws InexactError convert(SymTridiagonal, diagm(0=>fill(NaN,4)))
+    end
+    @testset "convert from same type" begin
+        T = Tridiagonal(1:3, 1:4, 1:3)
+        @test convert(Tridiagonal, T) === T
+        @test convert(Tridiagonal{eltype(T)}, T) === T
+        @test convert(typeof(T), T) === T
+        S = SymTridiagonal(1:4, 1:3)
+        @test convert(SymTridiagonal, S) === S
+        @test convert(SymTridiagonal{eltype(S)}, S) === S
+        @test convert(typeof(S), S) === S
     end
 end
 


### PR DESCRIPTION
This follows the `convert` implementation for `AbstractArray`s and short-circuits if the input is already of the correct type. There's no actual construction required in this case.

Should fix the failure on master seen in https://github.com/JuliaLang/LinearAlgebra.jl/pull/1554