### PR TITLE
faster hessenberg eigvals

### DIFF
--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -433,11 +433,11 @@ end
 # faster eigenvalues, since we can skip the intermediate step of Hessenberg factorization.
 # note: permute==true is ignored, since that could spoil the upper-Hessenberg structure
 function eigvals!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasComplex}
-    ilo, ihi, _ = LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1))
+    LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1))
     return sorteig!(LAPACK.hseqr!('E', 'N', 1, size(H,1), H.data, H.data)[3], sortby)
 end
 function eigvals!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasReal}
-    ilo, ihi, _ = LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1))
+    LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1))
     _, _, vals = LAPACK.hseqr!('E', 'N', 1, size(H,1), H.data, H.data)
     return sorteig!(isreal(vals) ? real(vals) : vals, sortby)
 end

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -320,4 +320,14 @@ end
     @test U == U2
 end
 
+@testset "eigensolvers" begin
+    for T in (Float32, Float64, ComplexF32, ComplexF64)
+        H = UpperHessenberg(randn(T, 5,5))
+        λ = eigvals(H)
+        F = eigen(H)
+        @test λ ≈ eigvals(Matrix(H)) ≈ F.values
+        @test H * F.vectors ≈ F.vectors * Diagonal(λ)
+    end
+end
+
 end # module TestHessenberg

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -324,8 +324,9 @@ end
     for T in (Float32, Float64, ComplexF32, ComplexF64)
         H = UpperHessenberg(randn(T, 5,5))
         λ = eigvals(H)
+        λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
         F = eigen(H)
-        @test λ ≈ eigvals(Matrix(H)) ≈ F.values
+        @test λ ≈ eigvals(Matrix(H)) ≈ F.values ≈ λ2
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
     end
 end

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -321,13 +321,16 @@ end
 end
 
 @testset "eigensolvers" begin
-    for T in (Float32, Float64, ComplexF32, ComplexF64)
+    for T in (Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64)
         H = UpperHessenberg(randn(T, 5,5))
         λ = eigvals(H)
-        λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
         F = eigen(H)
-        @test λ ≈ eigvals(Matrix(H)) ≈ F.values ≈ λ2
+        @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
+        if T <: BlasFloat
+            λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
+            @test λ ≈ λ2
+        end
     end
 end
 

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -327,7 +327,7 @@ end
         F = eigen(H)
         @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
-        if T <: BlasFloat
+        if T <: LinearAlgebra.BlasFloat
             λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
             @test λ ≈ λ2
         end


### PR DESCRIPTION
This is a port of https://github.com/JuliaLang/julia/pull/41420, which implements faster `eigvals` methods for `UpperHessenberg` matrices — about twice as fast for a 1000x1000 matrix on my machine, single-threaded.  (By adding a new `eigvals!` method.)

(The PR is simpler than the original because `LAPACK.hseqr!` was added in https://github.com/JuliaLang/julia/pull/47872, which was merged in Julia 1.10.0.)

One could also accelerate other cases, including `eigen`, as noted in that PR, but I don't have time to work on that and `eigvals` is useful in itself.  For example, to find roots of polynomials, one finds eigenvalues of a [companion matrix](https://en.wikipedia.org/wiki/Companion_matrix), and companion matrices are upper-Hessenberg (or transposes thereof); similarly for "colleague" matrices of orthogonal-polynomial bases.