### PR TITLE
throw error when sqrt function is inaccurate due to < n-1 nonzero eigenvalues

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -996,7 +996,7 @@ log(A::AdjointAbsMat) = adjoint(log(parent(A)))
 log(A::TransposeAbsMat) = transpose(log(parent(A)))
 
 """
-    sqrt(A::AbstractMatrix)
+    sqrt(A::AbstractMatrix; check=true)
 
 If `A` has no negative real eigenvalues, compute the principal matrix square root of `A`,
 that is the unique matrix ``X`` with eigenvalues having positive real part such that
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist, so a warning is printed. Eigenvalues of magnitude less than `eps(max|λ|)` are treated as zero.
+When an n \times n matrix has fewer than n-1 nonzero eigenvalues, the square root may not exist. When the `check` flag is true, the algorithm will verify `X^2≈A` and throw and error if not.
 
 [^BH83]:
 
@@ -1045,7 +1045,7 @@ julia> sqrt(A)
 """
 sqrt(::AbstractMatrix)
 
-function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
+function sqrt(A::AbstractMatrix{T}; check=true) where {T<:Union{Real,Complex}}
     if checksquare(A) == 0
         return copy(float(A))
     elseif isdiag(A)
@@ -1055,33 +1055,33 @@ function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
             return applydiagonal(sqrt, A)
         end
     elseif ishermitian(A)
-        return _safe_parent(sqrt(Hermitian(A)))
+        return _safe_parent(sqrt(Hermitian(A))) # dont need to check for hermitian matrices
     elseif istriu(A)
-        return triu!(parent(sqrt(UpperTriangular(A))))
+        return triu!(parent(sqrt(UpperTriangular(A), check=check)))
     elseif isreal(A)
         SchurF = schur(real(A))
         if istriu(SchurF.T)
-            sqrtA = SchurF.Z * sqrt(UpperTriangular(SchurF.T)) * SchurF.Z'
+            sqrtA = SchurF.Z * sqrt(UpperTriangular(SchurF.T), check=check) * SchurF.Z'
         else
             # real sqrt exists whenever no eigenvalues are negative
             is_sqrt_real = !any(x -> isreal(x) && real(x) < 0, SchurF.values)
             # sqrt_quasitriu uses LAPACK functions for non-triu inputs
             if typeof(sqrt(zero(T))) <: BlasFloat && is_sqrt_real
-                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values) * SchurF.Z'
+                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values, check=check) * SchurF.Z'
             else
                 SchurS = Schur{Complex}(SchurF)
-                sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T)) * SchurS.Z'
+                sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T), check=check) * SchurS.Z'
             end
         end
         return eltype(A) <: Complex ? complex(sqrtA) : sqrtA
     else
         SchurF = schur(A)
-        return SchurF.vectors * sqrt(UpperTriangular(SchurF.T)) * SchurF.vectors'
+        return SchurF.vectors * sqrt(UpperTriangular(SchurF.T), check=check) * SchurF.vectors'
     end
 end
 
-sqrt(A::AdjointAbsMat) = adjoint(sqrt(parent(A)))
-sqrt(A::TransposeAbsMat) = transpose(sqrt(parent(A)))
+sqrt(A::AdjointAbsMat; check=true) = adjoint(sqrt(parent(A), check=check))
+sqrt(A::TransposeAbsMat, check=true) = transpose(sqrt(parent(A), check=check))
 
 """
     cbrt(A::AbstractMatrix{<:Real})

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,6 +1016,8 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
+When there are less than n-1 nonzero eigenvalues, the square root may not exist so a warning is printed. Eigenvalues of magnitude less than `eps(max|λ|)` are treated as zero.
+
 [^BH83]:
 
     Åke Björck and Sven Hammarling, "A Schur method for the square root of a matrix",
@@ -1065,7 +1067,7 @@ function sqrt(A::AbstractMatrix{T}) where {T<:Union{Real,Complex}}
             is_sqrt_real = !any(x -> isreal(x) && real(x) < 0, SchurF.values)
             # sqrt_quasitriu uses LAPACK functions for non-triu inputs
             if typeof(sqrt(zero(T))) <: BlasFloat && is_sqrt_real
-                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T) * SchurF.Z'
+                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values) * SchurF.Z'
             else
                 SchurS = Schur{Complex}(SchurF)
                 sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T)) * SchurS.Z'

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When there are less than n-1 nonzero eigenvalues, the square root may not exist so a warning is printed. Eigenvalues of magnitude less than `eps(max|λ|)` are treated as zero.
+When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist, so a warning is printed. Eigenvalues of magnitude less than `eps(max|λ|)` are treated as zero.
 
 [^BH83]:
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw and error if not. 
+When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
 
 [^BH83]:
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an n \times n matrix has fewer than n-1 nonzero eigenvalues, the square root may not exist. When the `check` flag is true, the algorithm will verify `X^2≈A` and throw and error if not.
+When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw and error if not. 
 
 [^BH83]:
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1057,7 +1057,7 @@ function sqrt(A::AbstractMatrix{T}; check=true) where {T<:Union{Real,Complex}}
     elseif ishermitian(A)
         return _safe_parent(sqrt(Hermitian(A))) # dont need to check for hermitian matrices
     elseif istriu(A)
-        return triu!(parent(sqrt(UpperTriangular(A), check=check)))
+        return triu!(parent(sqrt(UpperTriangular(A); check)))
     elseif isreal(A)
         SchurF = schur(real(A))
         if istriu(SchurF.T)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1045,7 +1045,7 @@ julia> sqrt(A)
 """
 sqrt(::AbstractMatrix)
 
-function sqrt(A::AbstractMatrix{T}; check=true) where {T<:Union{Real,Complex}}
+function sqrt(A::AbstractMatrix{T}; check::Bool=true) where {T<:Union{Real,Complex}}
     if checksquare(A) == 0
         return copy(float(A))
     elseif isdiag(A)
@@ -1061,7 +1061,7 @@ function sqrt(A::AbstractMatrix{T}; check=true) where {T<:Union{Real,Complex}}
     elseif isreal(A)
         SchurF = schur(real(A))
         if istriu(SchurF.T)
-            sqrtA = SchurF.Z * sqrt(UpperTriangular(SchurF.T), check=check) * SchurF.Z'
+            sqrtA = SchurF.Z * sqrt(UpperTriangular(SchurF.T); check) * SchurF.Z'
         else
             # real sqrt exists whenever no eigenvalues are negative
             is_sqrt_real = !any(x -> isreal(x) && real(x) < 0, SchurF.values)
@@ -1070,18 +1070,18 @@ function sqrt(A::AbstractMatrix{T}; check=true) where {T<:Union{Real,Complex}}
                 sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values, check=check) * SchurF.Z'
             else
                 SchurS = Schur{Complex}(SchurF)
-                sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T), check=check) * SchurS.Z'
+                sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T); check) * SchurS.Z'
             end
         end
         return eltype(A) <: Complex ? complex(sqrtA) : sqrtA
     else
         SchurF = schur(A)
-        return SchurF.vectors * sqrt(UpperTriangular(SchurF.T), check=check) * SchurF.vectors'
+        return SchurF.vectors * sqrt(UpperTriangular(SchurF.T); check) * SchurF.vectors'
     end
 end
 
-sqrt(A::AdjointAbsMat; check=true) = adjoint(sqrt(parent(A), check=check))
-sqrt(A::TransposeAbsMat, check=true) = transpose(sqrt(parent(A), check=check))
+sqrt(A::AdjointAbsMat; check::Bool=true) = adjoint(sqrt(parent(A); check))
+sqrt(A::TransposeAbsMat, check::Bool=true) = transpose(sqrt(parent(A); check))
 
 """
     cbrt(A::AbstractMatrix{<:Real})

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an ``n × n`` non-Hermitian matrix has fewer than ``n - 1`` nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
+When a non-Hermitian matrix has two or more null eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
 
 [^BH83]:
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1081,7 +1081,7 @@ function sqrt(A::AbstractMatrix{T}; check::Bool=true) where {T<:Union{Real,Compl
 end
 
 sqrt(A::AdjointAbsMat; check::Bool=true) = adjoint(sqrt(parent(A); check))
-sqrt(A::TransposeAbsMat, check::Bool=true) = transpose(sqrt(parent(A); check))
+sqrt(A::TransposeAbsMat; check::Bool=true) = transpose(sqrt(parent(A); check))
 
 """
     cbrt(A::AbstractMatrix{<:Real})

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an $n \times n$ matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
+When an $n \times n$ non-Hermitian matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
 
 [^BH83]:
 

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1067,7 +1067,7 @@ function sqrt(A::AbstractMatrix{T}; check::Bool=true) where {T<:Union{Real,Compl
             is_sqrt_real = !any(x -> isreal(x) && real(x) < 0, SchurF.values)
             # sqrt_quasitriu uses LAPACK functions for non-triu inputs
             if typeof(sqrt(zero(T))) <: BlasFloat && is_sqrt_real
-                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values, check=check) * SchurF.Z'
+                sqrtA = SchurF.Z * sqrt_quasitriu(SchurF.T, SchurF.values; check) * SchurF.Z'
             else
                 SchurS = Schur{Complex}(SchurF)
                 sqrtA = SchurS.Z * sqrt(UpperTriangular(SchurS.T); check) * SchurS.Z'

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1055,7 +1055,7 @@ function sqrt(A::AbstractMatrix{T}; check::Bool=true) where {T<:Union{Real,Compl
             return applydiagonal(sqrt, A)
         end
     elseif ishermitian(A)
-        return _safe_parent(sqrt(Hermitian(A))) # dont need to check for hermitian matrices
+        return _safe_parent(sqrt(Hermitian(A); check))
     elseif istriu(A)
         return triu!(parent(sqrt(UpperTriangular(A); check)))
     elseif isreal(A)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When an $n \times n$ non-Hermitian matrix has fewer than $n-1$ nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
+When an ``n × n`` non-Hermitian matrix has fewer than ``n - 1`` nonzero eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
 
 [^BH83]:
 

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -989,7 +989,8 @@ function log(A::SelfAdjoint)
 end
 
 # sqrt has rtol kwarg to handle matrices that are semidefinite up to roundoff errors
-# note that `check` is passed to the function for consistancy with the dense sqrt function, but it is not used as the matrix should always at least have a complex square root (just from eigendecomposition)
+# note a `check` keyword argument is accepted for consistency with the generic `sqrt` function,
+# but it is not used here, as a self-adjoint matrix is diagonalizable and hence always has a sqrt.
 function sqrt(A::SelfAdjoint; check=true, rtol = eps(real(float(eltype(A)))) * size(A, 1))
     F = eigen(A)
     λ₀ = -maximum(abs, F.values) * rtol # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -991,7 +991,7 @@ end
 # sqrt has rtol kwarg to handle matrices that are semidefinite up to roundoff errors
 # note a `check` keyword argument is accepted for consistency with the generic `sqrt` function,
 # but it is not used here, as a self-adjoint matrix is diagonalizable and hence always has a sqrt.
-function sqrt(A::SelfAdjoint; check=true, rtol = eps(real(float(eltype(A)))) * size(A, 1))
+function sqrt(A::SelfAdjoint; check::Bool=true, rtol = eps(real(float(eltype(A)))) * size(A, 1))
     F = eigen(A)
     λ₀ = -maximum(abs, F.values) * rtol # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff
     if all(λ -> λ ≥ λ₀, F.values)

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -989,7 +989,8 @@ function log(A::SelfAdjoint)
 end
 
 # sqrt has rtol kwarg to handle matrices that are semidefinite up to roundoff errors
-function sqrt(A::SelfAdjoint; rtol = eps(real(float(eltype(A)))) * size(A, 1))
+# note that `check` is passed to the function for consistancy with the dense sqrt function, but it is not used as the matrix should always at least have a complex square root (just from eigendecomposition)
+function sqrt(A::SelfAdjoint; check=true, rtol = eps(real(float(eltype(A)))) * size(A, 1))
     F = eigen(A)
     λ₀ = -maximum(abs, F.values) * rtol # treat λ ≥ λ₀ as "zero" eigenvalues up to roundoff
     if all(λ -> λ ≥ λ₀, F.values)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2650,7 +2650,7 @@ end
 
 # End of auxiliary functions for matrix logarithm and matrix power
 
-sqrt(A::UpperTriangular) = sqrt_quasitriu(A)
+sqrt(A::UpperTriangular) = sqrt_quasitriu(A, diagview(A)) # matrix is upper triangular, so eigenvalues are just the diagonals
 function sqrt(A::UnitUpperTriangular{T}) where T
     B = A.data
     t = typeof(sqrt(zero(T)))
@@ -2674,13 +2674,11 @@ sqrt(A::UnitLowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
 # Auxiliary functions for matrix square root
 
 # square root of upper triangular or real upper quasitriangular matrix
-function sqrt_quasitriu(A0; blockwidth = eltype(A0) <: Complex ? 512 : 256)
+# A0 is triangular or quasitriangular matrix, evals is the eigenvalues
+function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256)
     n = checksquare(A0)
-    if isa(eltype(A0), AbstractFloat)
-        nonzero_eig = count(x->abs(x)>=eps(eltype(A0))*norm(A0), diag(A0)) # if its a float, check if the eigenvalue is greater than eps*(2-norm of matrix)
-    else
-        nonzero_eig = count(!iszero, diag(A0)) # check if there are less than n-1 nonzero eigenvalues
-    end
+    atol = eps(generic_normInf(evals)) # should work for any numeric data type
+    nonzero_eig = count(x->abs(x)>=atol, evals) # count number of eigenvalues that are \approx 0
     if (nonzero_eig < n - 1)
         @warn "Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2676,6 +2676,15 @@ sqrt(A::UnitLowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
 # square root of upper triangular or real upper quasitriangular matrix
 function sqrt_quasitriu(A0; blockwidth = eltype(A0) <: Complex ? 512 : 256)
     n = checksquare(A0)
+    if isa(eltype(A0), AbstractFloat)
+        nonzero_eig = sum([abs(e)>floatmin(eltype(A0)) for e in diag(A0)]) # if its a float type, check if the float is greater than the smallest representable float
+    else
+        nonzero_eig = sum([!iszero(e) for e in diag(A0)]) # check if there are less than n-1 nonzero eigenvalues
+    end
+    if (nonzero_eig < n - 1)
+        @warn "Matrix has less than $(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
+    end
+    
     T = eltype(A0)
     Tr = typeof(sqrt(real(zero(T))))
     Tc = typeof(sqrt(complex(zero(T))))

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2678,7 +2678,7 @@ sqrt(A::UnitLowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
 function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256)
     n = checksquare(A0)
     atol = eps(generic_normInf(evals)) # should work for any numeric data type
-    nonzero_eig = count(x->abs(x)>=atol, evals) # count number of eigenvalues that are \approx 0
+    nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
     if (nonzero_eig < n - 1)
         @warn "Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2713,7 +2713,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         if (zero_eig > 1) # in the regime where the algorithm could fail
             test = generic_normInf(R*R .-= A0) <= eps(typeof(atol))^(1//4) * generic_normInf(A0)
             if !test
-                throw(ArgumentError("Failed to produce matrix with X^2≈A. Set `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
+                throw(ArgumentError("Failed to produce matrix with X^2≈A. Pass `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end
         end
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2677,7 +2677,7 @@ sqrt(A::UnitLowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
 function sqrt_quasitriu(A0; blockwidth = eltype(A0) <: Complex ? 512 : 256)
     n = checksquare(A0)
     if isa(eltype(A0), AbstractFloat)
-        nonzero_eig = sum([abs(e)>floatmin(eltype(A0)) for e in diag(A0)]) # if its a float type, check if the float is greater than the smallest representable float
+        nonzero_eig = count(x->abs(x)>=eps(eltype(A0))*norm(A0), diag(A0)) # if its a float, check if the eigenvalue is greater than eps*(2-norm of matrix)
     else
         nonzero_eig = count(!iszero, diag(A0)) # check if there are less than n-1 nonzero eigenvalues
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2682,7 +2682,7 @@ function sqrt_quasitriu(A0; blockwidth = eltype(A0) <: Complex ? 512 : 256)
         nonzero_eig = count(!iszero, diag(A0)) # check if there are less than n-1 nonzero eigenvalues
     end
     if (nonzero_eig < n - 1)
-        @warn "Matrix has less than $(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
+        @warn "Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
     end
     
     T = eltype(A0)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2650,8 +2650,9 @@ end
 
 # End of auxiliary functions for matrix logarithm and matrix power
 
-sqrt(A::UpperTriangular) = sqrt_quasitriu(A, diagview(A)) # matrix is upper triangular, so eigenvalues are just the diagonals
-function sqrt(A::UnitUpperTriangular{T}) where T
+sqrt(A::UpperTriangular; check=true) = sqrt_quasitriu(A, diagview(A), check=check) # matrix is upper triangular, so eigenvalues are just the diagonals
+# shouldn't need to do a check for UnitUpperTriangular because the eigenvalues are all 1, flag included so the function call lines up
+function sqrt(A::UnitUpperTriangular{T}; check=true) where T 
     B = A.data
     t = typeof(sqrt(zero(T)))
     R = Matrix{t}(I, size(A))
@@ -2668,20 +2669,15 @@ function sqrt(A::UnitUpperTriangular{T}) where T
     end
     return UnitUpperTriangular(R)
 end
-sqrt(A::LowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
-sqrt(A::UnitLowerTriangular) = copy(transpose(sqrt(copy(transpose(A)))))
+sqrt(A::LowerTriangular; check=true) = copy(transpose(sqrt(copy(transpose(A)), check=check)))
+sqrt(A::UnitLowerTriangular; check=true) = copy(transpose(sqrt(copy(transpose(A)), check=check)))
 
 # Auxiliary functions for matrix square root
 
 # square root of upper triangular or real upper quasitriangular matrix
 # A0 is triangular or quasitriangular matrix, evals is the eigenvalues
-function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256)
+function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256, check=true)
     n = checksquare(A0)
-    atol = eps(generic_normInf(evals)) # should work for any numeric data type
-    nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
-    if (nonzero_eig < n - 1)
-        @warn "Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."
-    end
     
     T = eltype(A0)
     Tr = typeof(sqrt(real(zero(T))))
@@ -2709,6 +2705,17 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         R = zeros(Tc, size(A0))
     end
     _sqrt_quasitriu!(R, A; blockwidth=blockwidth, n=n)
+    if check
+        if eltype(A0) <: Real || eltype(A0) <: Complex
+            test = R^2≈A0
+        else
+            test = generic_normInf(R*R - A0) <= eps(generic_normInf(A0)) # when eltype is not real or complex, use the norm
+        end
+        if !test
+            throw_sqrterror(evals, n)
+        end
+    end
+
     Rc = eltype(A0) <: Real ? R : complex(R)
     if A0 isa UpperTriangular
         return UpperTriangular(Rc)
@@ -2716,6 +2723,18 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         return UnitUpperTriangular(Rc)
     else
         return Rc
+    end
+end
+
+# throw an error when the sqrt function does not work
+function throw_sqrterror(evals::AbstractVector, n::Int)
+    atol = eps(generic_normInf(evals)) # should work for any numeric data type
+    nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
+    if (nonzero_eig < n - 1)
+        # algorithm failed because matrix has fewer than n-1 nonzero eigenvalues
+        throw(ArgumentError("Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."))
+    else
+        throw("Square root algorithm failed to produce square root to numerical precision")
     end
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2679,7 +2679,7 @@ function sqrt_quasitriu(A0; blockwidth = eltype(A0) <: Complex ? 512 : 256)
     if isa(eltype(A0), AbstractFloat)
         nonzero_eig = sum([abs(e)>floatmin(eltype(A0)) for e in diag(A0)]) # if its a float type, check if the float is greater than the smallest representable float
     else
-        nonzero_eig = sum([!iszero(e) for e in diag(A0)]) # check if there are less than n-1 nonzero eigenvalues
+        nonzero_eig = count(!iszero, diag(A0)) # check if there are less than n-1 nonzero eigenvalues
     end
     if (nonzero_eig < n - 1)
         @warn "Matrix has less than $(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2709,7 +2709,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
     # check that the algorithm worked
     if check
         atol = eps(generic_normInf(evals)) # should work for any numeric data type
-        zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues = 0
+        zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues ≈ 0
         if (zero_eig > 1) # in the regime where the algorithm could fail
             test = generic_normInf(R*R .-= A0) <= eps(generic_normInf(A0))^(1//4) # when eltype is not real or complex, use the norm
             if !test

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2709,16 +2709,11 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
     # check that the algorithm worked
     if check
         atol = eps(generic_normInf(evals)) # should work for any numeric data type
-        nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
-        if (nonzero_eig < n - 1) # in the regime where the algorithm could fail
-            if eltype(A0) <: Real || eltype(A0) <: Complex
-                rtol_test = eps(float(one(eltype(A0))))^(1/4) # check that 1/4 of the digits match
-                test = isapprox(R^2,A0,rtol=rtol_test)
-            else
-                test = generic_normInf(R*R - A0) <= (eps(generic_normInf(A0)))^(1/4) # when eltype is not real or complex, use the norm
-            end
+        zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues = 0
+        if (zero_eig > 1) # in the regime where the algorithm could fail
+            test = generic_normInf(R*R .-= A0) <= eps(generic_normInf(A0))^(1//4) # when eltype is not real or complex, use the norm
             if !test
-                throw(ArgumentError("Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."))
+                throw(ArgumentError("Failed to produce matrix with X^2≈A. Set `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end
         end
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2711,7 +2711,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         atol = eps(generic_normInf(evals)) # should work for any numeric data type
         zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues ≈ 0
         if (zero_eig > 1) # in the regime where the algorithm could fail
-            test = generic_normInf(R*R .-= A0) <= eps(generic_normInf(A0))^(1//4) # when eltype is not real or complex, use the norm
+            test = generic_normInf(R*R .-= A0) <= eps(generic_normInf(A0))^(1//4)
             if !test
                 throw(ArgumentError("Failed to produce matrix with X^2≈A. Set `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2705,14 +2705,21 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         R = zeros(Tc, size(A0))
     end
     _sqrt_quasitriu!(R, A; blockwidth=blockwidth, n=n)
+
+    # check that the algorithm worked
     if check
-        if eltype(A0) <: Real || eltype(A0) <: Complex
-            test = R^2≈A0
-        else
-            test = generic_normInf(R*R - A0) <= eps(generic_normInf(A0)) # when eltype is not real or complex, use the norm
-        end
-        if !test
-            throw_sqrterror(evals, n)
+        atol = eps(generic_normInf(evals)) # should work for any numeric data type
+        nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
+        if (nonzero_eig < n - 1) # in the regime where the algorithm could fail
+            if eltype(A0) <: Real || eltype(A0) <: Complex
+                rtol_test = eps(float(one(eltype(A0))))^(1/4) # check that 1/4 of the digits match
+                test = isapprox(R^2,A0,rtol=rtol_test)
+            else
+                test = generic_normInf(R*R - A0) <= (eps(generic_normInf(A0)))^(1/4) # when eltype is not real or complex, use the norm
+            end
+            if !test
+                throw(ArgumentError("Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."))
+            end
         end
     end
 
@@ -2723,18 +2730,6 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         return UnitUpperTriangular(Rc)
     else
         return Rc
-    end
-end
-
-# throw an error when the sqrt function does not work
-function throw_sqrterror(evals::AbstractVector, n::Int)
-    atol = eps(generic_normInf(evals)) # should work for any numeric data type
-    nonzero_eig = count(x -> abs(x) > atol, evals) # count eigenvalues ≉ 0
-    if (nonzero_eig < n - 1)
-        # algorithm failed because matrix has fewer than n-1 nonzero eigenvalues
-        throw(ArgumentError("Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root."))
-    else
-        throw("Square root algorithm failed to produce square root to numerical precision")
     end
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2650,7 +2650,7 @@ end
 
 # End of auxiliary functions for matrix logarithm and matrix power
 
-sqrt(A::UpperTriangular; check=true) = sqrt_quasitriu(A, diagview(A), check=check) # matrix is upper triangular, so eigenvalues are just the diagonals
+sqrt(A::UpperTriangular; check::Bool=true) = sqrt_quasitriu(A, diagview(A); check=check) # matrix is upper triangular, so eigenvalues are just the diagonals
 # shouldn't need to do a check for UnitUpperTriangular because the eigenvalues are all 1, flag included so the function call lines up
 function sqrt(A::UnitUpperTriangular{T}; check=true) where T 
     B = A.data
@@ -2669,14 +2669,14 @@ function sqrt(A::UnitUpperTriangular{T}; check=true) where T
     end
     return UnitUpperTriangular(R)
 end
-sqrt(A::LowerTriangular; check=true) = copy(transpose(sqrt(copy(transpose(A)), check=check)))
-sqrt(A::UnitLowerTriangular; check=true) = copy(transpose(sqrt(copy(transpose(A)), check=check)))
+sqrt(A::LowerTriangular; check::Bool=true) = copy(transpose(sqrt(copy(transpose(A)); check)))
+sqrt(A::UnitLowerTriangular; check::Bool=true) = copy(transpose(sqrt(copy(transpose(A)); check)))
 
 # Auxiliary functions for matrix square root
 
 # square root of upper triangular or real upper quasitriangular matrix
 # A0 is triangular or quasitriangular matrix, evals is the eigenvalues
-function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256, check=true)
+function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256, check::Bool=true)
     n = checksquare(A0)
     
     T = eltype(A0)
@@ -2708,7 +2708,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
 
     # check that the algorithm worked
     if check
-        atol = eps(generic_normInf(evals)) # should work for any numeric data type
+        atol = eps(generic_normInf(evals)) * size(A, 1) # should work for any numeric data type
         zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues ≈ 0
         if (zero_eig > 1) # in the regime where the algorithm could fail
             test = generic_normInf(R*R .-= A0) <= eps(typeof(atol))^(1//4) * generic_normInf(A0)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2711,7 +2711,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         atol = eps(generic_normInf(evals)) # should work for any numeric data type
         zero_eig = count(x -> abs(x) <= atol, evals) # count eigenvalues ≈ 0
         if (zero_eig > 1) # in the regime where the algorithm could fail
-            test = generic_normInf(R*R .-= A0) <= eps(generic_normInf(A0))^(1//4)
+            test = generic_normInf(R*R .-= A0) <= eps(typeof(atol))^(1//4) * generic_normInf(A0)
             if !test
                 throw(ArgumentError("Failed to produce matrix with X^2≈A. Set `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2650,7 +2650,7 @@ end
 
 # End of auxiliary functions for matrix logarithm and matrix power
 
-sqrt(A::UpperTriangular; check::Bool=true) = sqrt_quasitriu(A, diagview(A); check=check) # matrix is upper triangular, so eigenvalues are just the diagonals
+sqrt(A::UpperTriangular; check::Bool=true) = sqrt_quasitriu(A, diagview(A); check) # matrix is upper triangular, so eigenvalues are just the diagonals
 # shouldn't need to do a check for UnitUpperTriangular because the eigenvalues are all 1, flag included so the function call lines up
 function sqrt(A::UnitUpperTriangular{T}; check=true) where T 
     B = A.data

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2713,7 +2713,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         if (zero_eig > 1) # in the regime where the algorithm could fail
             test = generic_normInf(R*R .-= A0) <= eps(typeof(atol))^(1//4) * generic_normInf(A0)
             if !test
-                throw(ArgumentError("Failed to produce matrix with X^2≈A. Pass `check=false` to ignore. Matrix has two or more null eigenvalues so square root may be inaccurate or matrix may not have a square root."))
+                throw(DomainError("Failed to produce matrix with X^2≈A. Pass `check=false` to ignore. Matrix has two or more null eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end
         end
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2713,7 +2713,7 @@ function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Co
         if (zero_eig > 1) # in the regime where the algorithm could fail
             test = generic_normInf(R*R .-= A0) <= eps(typeof(atol))^(1//4) * generic_normInf(A0)
             if !test
-                throw(ArgumentError("Failed to produce matrix with X^2≈A. Pass `check=false` to ignore. Matrix has fewer than n-1=$(n - 1) nonzero eigenvalues so square root may be inaccurate or matrix may not have a square root."))
+                throw(ArgumentError("Failed to produce matrix with X^2≈A. Pass `check=false` to ignore. Matrix has two or more null eigenvalues so square root may be inaccurate or matrix may not have a square root."))
             end
         end
     end

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1014,8 +1014,18 @@ end
 end
 
 @testset "issue #1548" begin
+    # check that error is thrown when matrix has no square root
     A = [0 1; 0 0]
     @test_throws ArgumentError sqrt(A)
+
+    # check that error is not thrown when algorithm works (even if there are many zero eigenvalues
+    X = randn(5,5)
+    A = X * Diagonal([0,0,0,1,2]) / X # should work fine b/c matrix is non-defective
+    @test sqrt(A)^2 ≈ A
+    X = randn(5,5)
+    A = X * Diagonal([0,0,0,0,3]) / X # should work fine b/c matrix is non-defective
+    @test sqrt(A)^2 ≈ A
+    @test iszero(sqrt(zeros(6,6)))
 end
 
 @testset "matrix logarithm block diagonal underflow/overflow" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1000,7 +1000,7 @@ end
     @test sqrt(x2)^2 ≈ x2
 
     x3 = [-1 -eps() 0 0; eps() -1 0 0; 0 0 -1 -eps(); 0 0 eps() Inf]
-    @test all(isnan, sqrt(x3, check=false))
+    @test all(isnan, sqrt(x3))
 
     # test overflow/underflow handled
     x4 = [0 -1e200; 1e200 0]

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1000,7 +1000,7 @@ end
     @test sqrt(x2)^2 ≈ x2
 
     x3 = [-1 -eps() 0 0; eps() -1 0 0; 0 0 -1 -eps(); 0 0 eps() Inf]
-    @test all(isnan, sqrt(x3))
+    @test all(isnan, sqrt(x3, check=false))
 
     # test overflow/underflow handled
     x4 = [0 -1e200; 1e200 0]
@@ -1011,6 +1011,11 @@ end
 
     x6 = [1.0 1e200; -1e-200 1.0]
     @test sqrt(x6)^2 ≈ x6
+end
+
+@testset "issue #1548" begin
+    A = [0 1; 0 0]
+    @test_throws ArgumentError sqrt(A)
 end
 
 @testset "matrix logarithm block diagonal underflow/overflow" begin

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1016,7 +1016,7 @@ end
 @testset "issue #1548" begin
     # check that error is thrown when matrix has no square root
     A = [0 1; 0 0]
-    @test_throws ArgumentError sqrt(A)
+    @test_throws DomainError sqrt(A)
 
     # check that error is not thrown when algorithm works (even if there are many zero eigenvalues
     X = randn(5,5)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -66,14 +66,16 @@ end
 
 @testset "matrix square root quasi-triangular blockwise" begin
     @testset for T in (Float32, Float64, ComplexF32, ComplexF64)
-        A = schur(rand(T, 100, 100)^2).T
-        @test LinearAlgebra.sqrt_quasitriu(A; blockwidth=16)^2 ≈ A
+        schurA = schur(rand(T, 100, 100)^2)
+        A = schurA.T
+        @test LinearAlgebra.sqrt_quasitriu(A, schurA.values; blockwidth=16)^2 ≈ A
     end
     n = 256
     A = rand(ComplexF64, n, n)
-    U = schur(A).T
+    schurA = schur(A)
+    U = schurA.T
     Ubig = Complex{BigFloat}.(U)
-    @test LinearAlgebra.sqrt_quasitriu(U; blockwidth=64) ≈ LinearAlgebra.sqrt_quasitriu(Ubig; blockwidth=64)
+    @test LinearAlgebra.sqrt_quasitriu(U, schurA.values; blockwidth=64) ≈ LinearAlgebra.sqrt_quasitriu(Ubig, schurA.values; blockwidth=64)
 end
 
 @testset "sylvester quasi-triangular blockwise" begin


### PR DESCRIPTION
Fixes #1548

Now 
```julia
sqrt([0 1; 0 0])
```
prints
```julia
┌ Warning: Matrix has less than 1 nonzero eigenvalues. Square root may be inaccurate or matrix may not have a square root.
└ @ LinearAlgebra ~/Documents/julia_dev/LinearAlgebra.jl/src/triangular.jl:2685
```