### PR TITLE
Generalize zero in Givens algorithm

### DIFF
--- a/src/givens.jl
+++ b/src/givens.jl
@@ -77,7 +77,7 @@ floatmin2(::Type{T}) where {T} = (twopar = 2one(T); twopar^trunc(Integer,log(flo
 function givensAlgorithm(f::T, g::T) where T<:AbstractFloat
     onepar = one(T)
     T0 = typeof(onepar) # dimensionless
-    zeropar = T0(zero(T)) # must be dimensionless
+    zeropar = zero(onepar) # must be dimensionless
 
     # need both dimensionful and dimensionless versions of these:
     safmn2 = floatmin2(T0)

--- a/src/givens.jl
+++ b/src/givens.jl
@@ -150,7 +150,7 @@ end
 function givensAlgorithm(f::Complex{T}, g::Complex{T}) where T<:AbstractFloat
     onepar = one(T)
     T0 = typeof(onepar) # dimensionless
-    zeropar = T0(zero(T)) # must be dimensionless
+    zeropar = zero(onepar) # must be dimensionless
     czero = complex(zeropar)
 
     abs1(ff) = max(abs(real(ff)), abs(imag(ff)))

--- a/test/givens.jl
+++ b/test/givens.jl
@@ -104,6 +104,33 @@ oneunit(::Type{<:MockUnitful{T}}) where T = MockUnitful(one(T))
     @test r.data ≈ 5.0
 end
 
+struct MockMeasurement{T<:AbstractFloat} <: AbstractFloat
+    data::T
+end
+import Base: promote_rule, floatmin, eps, ==, <, -, +, <=, sqrt
+MockMeasurement(x::Real) = MockMeasurement(float(x))
+one(::Type{<:MockMeasurement{T}}) where {T<:Real} = one(T)
+promote_rule(::Type{MockMeasurement{T}}, ::Type{<:Real}) where {T} = MockMeasurement{T}
+for f in (:floatmin, :eps, :oneunit)
+    @eval $f(::Type{MockMeasurement{T}}) where {T<:AbstractFloat} = $f(T)
+end
+for f in (:-, :sqrt)
+    @eval $f(x::MockMeasurement) = MockMeasurement($f(x.data))
+end
+for f in (:*, :+, :/)
+    @eval $f(x::MockMeasurement, y::MockMeasurement) = MockMeasurement($f(x.data,y.data))
+end
+for f in (:<, :(==), :(<=))
+    @eval $f(x::MockMeasurement, y::MockMeasurement) = $f(x.data,y.data)
+end
+
+@testset "measurement givens rotation unitful $T " for T in (Float64, ComplexF64)
+    g, r = givens(MockMeasurement(T(3)), MockMeasurement(T(4)), 1, 2)
+    @test g.c ≈ 3/5
+    @test g.s ≈ 4/5
+    @test r.data ≈ 5.0
+end
+
 # 51554
 # avoid infinite loop on Inf inputs
 @testset "givensAlgorithm - Inf inputs" for T in (Float64, ComplexF64)


### PR DESCRIPTION
This PR fixes errors for eigen and singular value decompositions with [`Measurmements.jl`](https://github.com/JuliaPhysics/Measurements.jl) numbers.
See https://github.com/JuliaLinearAlgebra/GenericLinearAlgebra.jl/issues/163 and https://github.com/JuliaPhysics/Measurements.jl/issues/189 for a detailed history. 