### PR TITLE
fix dispatch for schur(::UpperHessenberg)

### DIFF
--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -453,6 +453,10 @@ eigvals!(H::UpperHessenberg; permute::Bool=false, scale::Bool=true, sortby::Unio
 eigen!(H::UpperHessenberg; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) =
     eigen!(triu!(H.data,-1); permute, scale, sortby)
 
+
+schur!(A::UpperHessenberg{T}) where {T<:BlasFloat} = Schur(LinearAlgebra.LAPACK.hseqr!(parent(A))...)
+schur!(A::UpperHessenberg) = schur!(triu!(H.data, -1)) # fallback to dense algorithm
+
 ######################################################################################
 # Hessenberg factorizations Q(H+μI)Q' of A+μI:
 

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -454,8 +454,8 @@ eigen!(H::UpperHessenberg; permute::Bool=false, scale::Bool=true, sortby::Union{
     eigen!(triu!(H.data,-1); permute, scale, sortby)
 
 
-schur!(A::UpperHessenberg{T}) where {T<:BlasFloat} = Schur(LinearAlgebra.LAPACK.hseqr!(parent(A))...)
-schur!(A::UpperHessenberg) = schur!(triu!(H.data, -1)) # fallback to dense algorithm
+schur!(H::UpperHessenberg{T}) where {T<:BlasFloat} = Schur(LinearAlgebra.LAPACK.hseqr!(H.data)...)
+schur!(H::UpperHessenberg) = schur!(triu!(H.data, -1)) # fallback to dense algorithm
 
 ######################################################################################
 # Hessenberg factorizations Q(H+μI)Q' of A+μI:

--- a/src/schur.jl
+++ b/src/schur.jl
@@ -102,8 +102,6 @@ julia> A
 """
 schur!(A::StridedMatrix{<:BlasFloat}) = Schur(LinearAlgebra.LAPACK.gees!('V', A)...)
 
-schur!(A::UpperHessenberg{T}) where {T<:BlasFloat} = Schur(LinearAlgebra.LAPACK.hseqr!(parent(A))...)
-
 """
     schur(A) -> F::Schur
 
@@ -154,8 +152,7 @@ julia> t == F.T && z == F.Z && vals == F.values
 true
 ```
 """
-schur(A::AbstractMatrix{T}) where {T} = schur!(copy_similar(A, eigtype(T)))
-schur(A::UpperHessenberg{T}) where {T} = schur!(copy_similar(A, eigtype(T)))
+schur(A::AbstractMatrix{T}) where {T} = schur!(eigencopy_oftype(A, eigtype(T)))
 function schur(A::RealHermSymComplexHerm)
     F = eigen(A; sortby=nothing)
     return Schur(typeof(F.vectors)(Diagonal(F.values)), F.vectors, F.values)

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -212,7 +212,11 @@ end
     fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
     @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)
     @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
-
+    fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
+    fact4 = Schur(LinearAlgebra.LAPACK.hseqr!(copy(A.data))...) # call specialized method
+    @test fact1 == fact4
+    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)
+    @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
 
     A = UpperHessenberg(rand(Int32, 50, 50))
     B = Array(A)

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -210,9 +210,6 @@ end
     fact1 = schur(A)
     fact2 = schur(B)
     fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
-    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)
-    @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
-    fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
     fact4 = Schur(LinearAlgebra.LAPACK.hseqr!(copy(A.data))...) # call specialized method
     @test fact1 == fact4
     @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -209,8 +209,10 @@ end
     B = Array(A)
     fact1 = schur(A)
     fact2 = schur(B)
-    @test fact1.values ≈ fact2.values
-    @test fact1.Z * fact1.T * fact1.Z' ≈ B
+    fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
+    @test fact1.values ≈ fact2.values ≈ fact3.values
+    @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
+
 
     A = UpperHessenberg(rand(Int32, 50, 50))
     B = Array(A)

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -210,7 +210,7 @@ end
     fact1 = schur(A)
     fact2 = schur(B)
     fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
-    @test fact1.values ≈ fact2.values ≈ fact3.values
+    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sorty(fact3.values, by=reim)
     @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
 
 

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -210,7 +210,7 @@ end
     fact1 = schur(A)
     fact2 = schur(B)
     fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
-    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sorty(fact3.values, by=reim)
+    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)
     @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
 
 


### PR DESCRIPTION
Fixes an apparent bug in https://github.com/JuliaLang/julia/pull/47872 — `schur(A::UpperHessenberg{T})` called `copy_similar(A, eigtype(T)))` but the `copy_similar` function strips away the `UpperHessenberg` wrapper.  As a result, the optimized `schur!` function was not being called.

Following #1557, this changes it to call `eigencopy_oftype`, which preserves the `UpperHessenberg` wrapper (and also `Hermitian` wrappers, but `schur` already has a specialized dispatch for Hermitian cases).   It also adds a fallback `schur!` for non-BLAS types, to avoid breaking anything.

cc @albertomercurio, @Jutho, and @dkarrasch, who were involved in the original PR.
