### PR TITLE
Force SymTridiagonal to have consistent lengths

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -655,13 +655,6 @@ _unwrap(A::AbstractVecOrMat) = A
 _cut_B(x::AbstractVector, r::UnitRange) = length(x)  > length(r) ? x[r]   : x
 _cut_B(X::AbstractMatrix, r::UnitRange) = size(X, 1) > length(r) ? X[r,:] : X
 
-# In the past, SymTridiagonal ev could be the same length as dv, but the last element was
-# ignored. However, some methods can fail if they read the entire ev
-# rather than just the meaningful elements. This is a helper function
-# for getting only the meaningful elements of ev. See #41089
-# See https://github.com/JuliaLang/LinearAlgebra.jl/issues/629
-_evview(S::SymTridiagonal) = @view S.ev[begin:begin + length(S.dv) - 2]
-
 ## append right hand side with zeros if necessary
 _zeros(::Type{T}, b::AbstractVector, n::Integer) where {T} = zeros(T, max(length(b), n))
 _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B, 1), n), size(B, 2))

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -666,10 +666,6 @@ _evview(S::SymTridiagonal) = @view S.ev[begin:begin + length(S.dv) - 2]
 _zeros(::Type{T}, b::AbstractVector, n::Integer) where {T} = zeros(T, max(length(b), n))
 _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B, 1), n), size(B, 2))
 
-# append a zero element / drop the last element
-_pushzero(A) = (B = similar(A, length(A)+1); @inbounds B[begin:end-1] .= A; @inbounds B[end] = zero(eltype(B)); B)
-_droplast!(A) = deleteat!(A, lastindex(A))
-
 # destination type for matmul
 matprod_dest(A::StructuredMatrix, B::StructuredMatrix, TS) = similar(B, TS, size(B))
 matprod_dest(A, B::StructuredMatrix, TS) = similar(A, TS, size(A))

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -655,10 +655,11 @@ _unwrap(A::AbstractVecOrMat) = A
 _cut_B(x::AbstractVector, r::UnitRange) = length(x)  > length(r) ? x[r]   : x
 _cut_B(X::AbstractMatrix, r::UnitRange) = size(X, 1) > length(r) ? X[r,:] : X
 
-# SymTridiagonal ev can be the same length as dv, but the last element is
+# In the past, SymTridiagonal ev could be the same length as dv, but the last element was
 # ignored. However, some methods can fail if they read the entire ev
 # rather than just the meaningful elements. This is a helper function
 # for getting only the meaningful elements of ev. See #41089
+# See https://github.com/JuliaLang/LinearAlgebra.jl/issues/629
 _evview(S::SymTridiagonal) = @view S.ev[begin:begin + length(S.dv) - 2]
 
 ## append right hand side with zeros if necessary

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -261,9 +261,8 @@ similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = simi
 tr(B::Bidiagonal) = sum(B.dv)
 
 function kron(A::Diagonal, B::Bidiagonal)
-    # `_droplast!` is only guaranteed to work with `Vector`
-    kdv = convert(Vector, kron(diag(A), B.dv))
-    kev = _droplast!(convert(Vector, kron(diag(A), _pushzero(B.ev))))
+    kdv = kron(A.diag, B.dv)
+    kev = _diagonal_kron!(similar(kdv, length(kdv) - 1), A.diag, B.ev)
     Bidiagonal(kdv, kev, B.uplo)
 end
 

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -828,7 +828,12 @@ end
 
 function kron(A::Diagonal, B::SymTridiagonal)
     kdv = kron(A.diag, B.dv)
-    kev = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.ev))))
+    kev_long = kron(A.diag, _pushzero(_evview(B)))
+
+    # We must drop the last element while preserving the type
+    kev = similar(kev_long, length(kev_long)-1);
+    @inbounds kev .= kev_long[begin:end-1]
+
     SymTridiagonal(kdv, kev)
 end
 function kron(A::Diagonal, B::Tridiagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -826,34 +826,37 @@ function kron!(C::Diagonal, A::Diagonal, B::Diagonal)
     return C
 end
 
-function kron(A::Diagonal, B::SymTridiagonal)
-    kdv = kron(A.diag, B.dv)
-    kev = similar(kdv, length(kdv) - 1)
-    z = zero(first(kdv))
+#efficient way of doing kron(a, [b; 0])[1:end-1]
+function _diagonal_kron!(c, a, b)
+    z = zero(first(a) * first(b))
     counter = 0
-    @inbounds for i in firstindex(A.diag):lastindex(A.diag) - 1
-        ai = A.diag[i]
-        for bj in B.ev
+    @inbounds for i in firstindex(a):lastindex(a) - 1
+        ai = a[i]
+        for bj in b
             counter += 1
-            kev[counter] = ai * bj
+            c[counter] = ai * bj
         end
         counter += 1
-        kev[counter] = z
+        c[counter] = z
     end
-    ai = last(A.diag)
-    @inbounds for bj in B.ev
+    ai = last(a)
+    @inbounds for bj in b
         counter += 1
-        kev[counter] = ai * bj
+        c[counter] = ai * bj
     end
+    return c
+end
 
-    SymTridiagonal(kdv, kev)
+function kron(A::Diagonal, B::SymTridiagonal)
+    kdv = kron(A.diag, B.dv)
+    kev = _diagonal_kron!(similar(kdv, length(kdv) - 1), A.diag, B.ev)
+    return SymTridiagonal(kdv, kev)
 end
 function kron(A::Diagonal, B::Tridiagonal)
-    # `_droplast!` is only guaranteed to work with `Vector`
-    kd = convert(Vector, kron(A.diag, B.d))
-    kdl = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.dl))))
-    kdu = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.du))))
-    Tridiagonal(kdl, kd, kdu)
+    kd = kron(A.diag, B.d)
+    kdl = _diagonal_kron!(similar(kd, length(kd) - 1), A.diag, B.dl)
+    kdu = _diagonal_kron!(similar(kd, length(kd) - 1), A.diag, B.du)
+    return Tridiagonal(kdl, kd, kdu)
 end
 
 @inline function kron!(C::AbstractMatrix, A::Diagonal, B::AbstractMatrix)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -828,11 +828,23 @@ end
 
 function kron(A::Diagonal, B::SymTridiagonal)
     kdv = kron(A.diag, B.dv)
-    kev_long = kron(A.diag, _pushzero(_evview(B)))
-
-    # We must drop the last element while preserving the type
-    kev = similar(kev_long, length(kev_long)-1);
-    @inbounds kev .= kev_long[begin:end-1]
+    kev = similar(kdv, length(kdv) - 1)
+    z = zero(first(kdv))
+    counter = 0
+    @inbounds for i in firstindex(A.diag):lastindex(A.diag) - 1
+        ai = A.diag[i]
+        for bj in B.ev
+            counter += 1
+            kev[counter] = ai * bj
+        end
+        counter += 1
+        kev[counter] = z
+    end
+    ai = last(A.diag)
+    @inbounds for bj in B.ev
+        counter += 1
+        kev[counter] = ai * bj
+    end
 
     SymTridiagonal(kdv, kev)
 end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -828,8 +828,7 @@ end
 
 function kron(A::Diagonal, B::SymTridiagonal)
     kdv = kron(A.diag, B.dv)
-    # We don't need to drop the last element
-    kev = kron(A.diag, _pushzero(_evview(B)))
+    kev = _droplast!(convert(Vector, kron(A.diag, _pushzero(B.ev))))
     SymTridiagonal(kdv, kev)
 end
 function kron(A::Diagonal, B::Tridiagonal)

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -3989,8 +3989,8 @@ for (stev, stebz, stegr, stein, elty) in
             @chkvalidparam 1 job ('N', 'V')
             chkstride1(dv, ev)
             n = length(dv)
-            if length(ev) != n - 1 && length(ev) != n
-                throw(DimensionMismatch(lazy"ev has length $(length(ev)) but needs one less than or equal to dv's length, $n)"))
+            if length(ev) != n - 1
+                throw(DimensionMismatch(lazy"ev has length $(length(ev)) but needs one less than dv's length, $n)"))
             end
             Zmat = similar(dv, $elty, (n, job != 'N' ? n : 0))
             work = Vector{$elty}(undef, max(1, 2n-2))
@@ -4050,7 +4050,7 @@ for (stev, stebz, stegr, stein, elty) in
             if ne == n - 1
                 eev = [ev; zero($elty)]
             else
-                throw(DimensionMismatch(lazy"ev has length $ne but needs one less than or equal to dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev has length $ne but needs one less than dv's length, $n)"))
             end
 
             abstol = Vector{$elty}(undef, 1)
@@ -4098,7 +4098,7 @@ for (stev, stebz, stegr, stein, elty) in
             if ne == n - 1
                 ev = [ev_in; zero($elty)]
             else
-                throw(DimensionMismatch(lazy"ev_in has length $ne but needs one less than or equal to dv's length, $n)"))
+                throw(DimensionMismatch(lazy"ev_in has length $ne but needs one less than dv's length, $n)"))
             end
             ldz = n #Leading dimension
             #Number of eigenvalues to find

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -4097,9 +4097,6 @@ for (stev, stebz, stegr, stein, elty) in
             ne = length(ev_in)
             if ne == n - 1
                 ev = [ev_in; zero($elty)]
-            elseif ne == n
-                ev = copy(ev_in)
-                ev[n] = zero($elty)
             else
                 throw(DimensionMismatch(lazy"ev_in has length $ne but needs one less than or equal to dv's length, $n)"))
             end

--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -4049,9 +4049,6 @@ for (stev, stebz, stegr, stein, elty) in
             ne = length(ev)
             if ne == n - 1
                 eev = [ev; zero($elty)]
-            elseif ne == n
-                eev = copy(ev)
-                eev[n] = zero($elty)
             else
                 throw(DimensionMismatch(lazy"ev has length $ne but needs one less than or equal to dv's length, $n)"))
             end

--- a/src/special.jl
+++ b/src/special.jl
@@ -27,8 +27,6 @@ _diagview(S::SymTridiagonal) = diagview(S)
 # conversions from SymTridiagonal to other special matrix types
 Diagonal(A::SymTridiagonal) = Diagonal(_diagview(A))
 
-# These can fail when ev has the same length as dv
-# TODO: Revisit when a good solution for #42477 is found
 Bidiagonal(A::SymTridiagonal{<:Number}) =
     iszero(A.ev) ? Bidiagonal(A.dv, A.ev, :U) :
         throw(ArgumentError("matrix cannot be represented as Bidiagonal"))

--- a/src/special.jl
+++ b/src/special.jl
@@ -51,7 +51,7 @@ Bidiagonal(A::AbstractTriangular) =
 _lucopy(A::Bidiagonal, T) = copymutable_oftype(Tridiagonal(A), T)
 _lucopy(A::Diagonal, T)   = copymutable_oftype(Tridiagonal(A), T)
 function _lucopy(A::SymTridiagonal, T)
-    du = copy_similar(_evview(A), T)
+    du = copy_similar(A.ev, T)
     dl = copy.(transpose.(du))
     d  = copy_similar(A.dv, T)
     return Tridiagonal(dl, d, du)
@@ -182,30 +182,30 @@ end
 
 @commutative function (+)(A::Diagonal, B::SymTridiagonal)
     newdv = A.diag + _diagview(B)
-    _symtri_or_tri(_evview_transposed(B), newdv, _evview(B))
+    _symtri_or_tri(_evview_transposed(B), newdv, B.ev)
 end
 
 function (-)(A::Diagonal, B::SymTridiagonal)
     newdv = A.diag - _diagview(B)
-    _symtri_or_tri(-_evview_transposed(B), newdv, -_evview(B))
+    _symtri_or_tri(-_evview_transposed(B), newdv, -B.ev)
 end
 
 function (-)(A::SymTridiagonal, B::Diagonal)
     newdv = _diagview(A) - B.diag
-    _symtri_or_tri(_evview_transposed(A), newdv, _evview(A))
+    _symtri_or_tri(_evview_transposed(A), newdv, A.ev)
 end
 
 # this set doesn't have the aforementioned problem
-_evview_transposed(S::SymTridiagonal{<:Number}) = _evview(S)
-_evview_transposed(S::SymTridiagonal) = transpose.(_evview(S))
+_evview_transposed(S::SymTridiagonal{<:Number}) = S.ev
+_evview_transposed(S::SymTridiagonal) = transpose.(S.ev)
 @commutative function (+)(A::Tridiagonal, B::SymTridiagonal)
-    Tridiagonal(A.dl+_evview_transposed(B), A.d+_diagview(B), A.du+_evview(B))
+    Tridiagonal(A.dl+_evview_transposed(B), A.d+_diagview(B), A.du+B.ev)
 end
 function -(A::Tridiagonal, B::SymTridiagonal)
-    Tridiagonal(A.dl-_evview_transposed(B), A.d-_diagview(B), A.du-_evview(B))
+    Tridiagonal(A.dl-_evview_transposed(B), A.d-_diagview(B), A.du-B.ev)
 end
 function -(A::SymTridiagonal, B::Tridiagonal)
-    Tridiagonal(_evview_transposed(A)-B.dl, _diagview(A)-B.d, _evview(A)-B.du)
+    Tridiagonal(_evview_transposed(A)-B.dl, _diagview(A)-B.d, A.ev-B.du)
 end
 
 @commutative function (+)(A::Diagonal, B::Tridiagonal)
@@ -240,17 +240,17 @@ end
 
 @commutative function (+)(A::Bidiagonal, B::SymTridiagonal)
     newdv = A.dv + _diagview(B)
-    Tridiagonal((A.uplo == 'U' ? (typeof(newdv)(_evview_transposed(B)), newdv, A.ev+_evview(B)) : (A.ev+_evview_transposed(B), newdv, typeof(newdv)(_evview(B))))...)
+    Tridiagonal((A.uplo == 'U' ? (typeof(newdv)(_evview_transposed(B)), newdv, A.ev+B.ev) : (A.ev+_evview_transposed(B), newdv, typeof(newdv)(B.ev)))...)
 end
 
 function (-)(A::Bidiagonal, B::SymTridiagonal)
     newdv = A.dv - _diagview(B)
-    Tridiagonal((A.uplo == 'U' ? (typeof(newdv)(-_evview_transposed(B)), newdv, A.ev-_evview(B)) : (A.ev-_evview_transposed(B), newdv, typeof(newdv)(-_evview(B))))...)
+    Tridiagonal((A.uplo == 'U' ? (typeof(newdv)(-_evview_transposed(B)), newdv, A.ev-B.ev) : (A.ev-_evview_transposed(B), newdv, typeof(newdv)(-B.ev)))...)
 end
 
 function (-)(A::SymTridiagonal, B::Bidiagonal)
     newdv = _diagview(A) - B.dv
-    Tridiagonal((B.uplo == 'U' ? (typeof(newdv)(_evview_transposed(A)), newdv, _evview(A)-B.ev) : (_evview_transposed(A)-B.ev, newdv, typeof(newdv)(_evview(A))))...)
+    Tridiagonal((B.uplo == 'U' ? (typeof(newdv)(_evview_transposed(A)), newdv, A.ev-B.ev) : (_evview_transposed(A)-B.ev, newdv, typeof(newdv)(A.ev)))...)
 end
 
 @commutative function (+)(A::Tridiagonal, B::UniformScaling)
@@ -280,7 +280,7 @@ function (-)(A::UniformScaling, B::Tridiagonal)
 end
 function (-)(A::UniformScaling, B::SymTridiagonal)
     dv = Ref(A) .- B.dv
-    SymTridiagonal(dv, convert(typeof(dv), -_evview(B)))
+    SymTridiagonal(dv, convert(typeof(dv), -B.ev))
 end
 function (-)(A::UniformScaling, B::Bidiagonal)
     dv = Ref(A) .- B.dv
@@ -400,7 +400,7 @@ end
 function _copyto_banded!(SymT::SymTridiagonal, D::Diagonal)
     issymmetric(D) || throw(ArgumentError("cannot copy a non-symmetric Diagonal matrix to a SymTridiagonal"))
     SymT.dv .= D.diag
-    _ev = _evview(SymT)
+    _ev = SymT.ev
     _ev .= diagview(D,  1)
     return SymT
 end
@@ -444,7 +444,7 @@ end
 function _copyto_banded!(SymT::SymTridiagonal, B::Bidiagonal)
     issymmetric(B) || throw(ArgumentError("cannot copy a non-symmetric Bidiagonal matrix to a SymTridiagonal"))
     SymT.dv .= B.dv
-    _ev = _evview(SymT)
+    _ev = SymT.ev
     _ev .= B.ev
     return SymT
 end
@@ -472,7 +472,7 @@ end
 # SymTridiagonal == Tridiagonal is already defined in tridiag.jl
 
 ==(A::Diagonal, B::Bidiagonal) = iszero(B.ev) && A.diag == B.dv
-==(A::Diagonal, B::SymTridiagonal) = iszero(_evview(B)) && A.diag == _diagview(B)
+==(A::Diagonal, B::SymTridiagonal) = iszero(B.ev) && A.diag == _diagview(B)
 ==(B::Bidiagonal, A::Diagonal) = A == B
 ==(A::Diagonal, B::Tridiagonal) = iszero(B.dl) && iszero(B.du) && A.diag == B.d
 ==(B::Tridiagonal, A::Diagonal) = A == B
@@ -486,7 +486,7 @@ function ==(A::Bidiagonal, B::Tridiagonal)
 end
 ==(B::Tridiagonal, A::Bidiagonal) = A == B
 
-==(A::Bidiagonal, B::SymTridiagonal) = iszero(_evview(B)) && iszero(A.ev) && A.dv == _diagview(B)
+==(A::Bidiagonal, B::SymTridiagonal) = iszero(B.ev) && iszero(A.ev) && A.dv == _diagview(B)
 ==(B::SymTridiagonal, A::Bidiagonal) = A == B
 
 # TODO: remove these deprecations (used by SparseArrays in the past)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -8,8 +8,8 @@ struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
     ev::V                        # superdiagonal
     function SymTridiagonal{T, V}(dv, ev) where {T, V<:AbstractVector{T}}
         require_one_based_indexing(dv, ev)
-        if !(length(dv) - 1 <= length(ev) <= length(dv))
-            throw(DimensionMismatch(lazy"subdiagonal has wrong length. Has length $(length(ev)), but should be either $(length(dv) - 1) or $(length(dv))."))
+        if length(dv) - 1 != length(ev)
+            throw(DimensionMismatch(lazy"subdiagonal has wrong length. Has length $(length(ev)), but should be $(length(dv) - 1)."))
         end
         new{T, V}(dv, ev)
     end

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -8,7 +8,7 @@ struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
     ev::V                        # superdiagonal
     function SymTridiagonal{T, V}(dv, ev) where {T, V<:AbstractVector{T}}
         require_one_based_indexing(dv, ev)
-        if length(dv) - 1 != length(ev)
+        if length(ev) != length(dv)-1 && !(length(dv) == 0 && length(ev) == 0)
             throw(DimensionMismatch(lazy"subdiagonal has wrong length. Has length $(length(ev)), but should be $(length(dv) - 1)."))
         end
         new{T, V}(dv, ev)

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -166,7 +166,7 @@ similar(S::SymTridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = 
 
 # copyto! for matching axes
 _copyto_banded!(dest::SymTridiagonal, src::SymTridiagonal) =
-    (copyto!(dest.dv, src.dv); copyto!(dest.ev, _evview(src)); dest)
+    (copyto!(dest.dv, src.dv); copyto!(dest.ev, src.ev); dest)
 
 #Elementary operations
 for func in (:conj, :copy, :real, :imag)
@@ -186,15 +186,15 @@ function permutedims(S::SymTridiagonal, perm)
 end
 Base.copy(S::Adjoint{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(adjoint.(x)), (S.parent.dv, S.parent.ev))...)
 
-ishermitian(S::SymTridiagonal) = isreal(S.dv) && isreal(_evview(S))
+ishermitian(S::SymTridiagonal) = isreal(S.dv) && isreal(S.ev)
 issymmetric(S::SymTridiagonal) = true
 
 tr(S::SymTridiagonal) = sum(symmetric, S.dv)
 
 _diagiter(M::SymTridiagonal{<:Number}) = M.dv
 _diagiter(M::SymTridiagonal) = (symmetric(x, :U) for x in M.dv)
-_eviter_transposed(M::SymTridiagonal{<:Number}) = _evview(M)
-_eviter_transposed(M::SymTridiagonal) = (transpose(x) for x in _evview(M))
+_eviter_transposed(M::SymTridiagonal{<:Number}) = M.ev
+_eviter_transposed(M::SymTridiagonal) = (transpose(x) for x in M.ev)
 
 function diag(M::SymTridiagonal, n::Integer=0)
     # every branch call similar(..., ::Int) to make sure the
@@ -204,7 +204,7 @@ function diag(M::SymTridiagonal, n::Integer=0)
     if n == 0
         return copyto!(v, _diagiter(M))
     elseif n == 1
-        return copyto!(v, _evview(M))
+        return copyto!(v, M.ev)
     elseif n == -1
         return copyto!(v, _eviter_transposed(M))
     else
@@ -215,8 +215,8 @@ function diag(M::SymTridiagonal, n::Integer=0)
     return v
 end
 
-+(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv+B.dv, _evview(A)+_evview(B))
--(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv-B.dv, _evview(A)-_evview(B))
++(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv+B.dv, A.ev+B.ev)
+-(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv-B.dv, A.ev-B.ev)
 -(A::SymTridiagonal) = SymTridiagonal(-A.dv, -A.ev)
 *(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv*B, A.ev*B)
 *(B::Number, A::SymTridiagonal) = SymTridiagonal(B*A.dv, B*A.ev)
@@ -228,7 +228,7 @@ function rmul!(A::SymTridiagonal, x::Number)
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
     rmul!(A.dv, x)
-    rmul!(_evview(A), x)
+    rmul!(A.ev, x)
     return A
 end
 function lmul!(x::Number, B::SymTridiagonal)
@@ -239,15 +239,15 @@ function lmul!(x::Number, B::SymTridiagonal)
             lazy"the tridiagonal band to a nonzero value ($y)")))
     end
     lmul!(x, B.dv)
-    lmul!(x, _evview(B))
+    lmul!(x, B.ev)
     return B
 end
 /(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv/B, A.ev/B)
 \(B::Number, A::SymTridiagonal) = SymTridiagonal(B\A.dv, B\A.ev)
 ==(A::SymTridiagonal{<:Number}, B::SymTridiagonal{<:Number}) =
-    (A.dv == B.dv) && (_evview(A) == _evview(B))
+    (A.dv == B.dv) && (A.ev == B.ev)
 ==(A::SymTridiagonal, B::SymTridiagonal) =
-    size(A) == size(B) && all(i -> A[i,i] == B[i,i], axes(A, 1)) && (_evview(A) == _evview(B))
+    size(A) == size(B) && all(i -> A[i,i] == B[i,i], axes(A, 1)) && (A.ev == B.ev)
 
 function dot(x::AbstractVector, S::SymTridiagonal, y::AbstractVector)
     require_one_based_indexing(x, y)
@@ -359,15 +359,15 @@ Base.@constprop :aggressive function istriu(M::SymTridiagonal, k::Integer=0)
     if k <= -1
         return true
     elseif k == 0
-        return iszero(_evview(M))
+        return iszero(M.ev)
     else # k >= 1
-        return iszero(_evview(M)) && iszero(M.dv)
+        return iszero(M.ev) && iszero(M.dv)
     end
 end
 Base.@constprop :aggressive istril(M::SymTridiagonal, k::Integer) = istriu(M, -k)
-iszero(M::SymTridiagonal) =  iszero(_evview(M)) && iszero(M.dv)
-isone(M::SymTridiagonal) =  iszero(_evview(M)) && all(isone, M.dv)
-isdiag(M::SymTridiagonal) =  iszero(_evview(M))
+iszero(M::SymTridiagonal) =  iszero(M.ev) && iszero(M.dv)
+isone(M::SymTridiagonal) =  iszero(M.ev) && all(isone, M.dv)
+isdiag(M::SymTridiagonal) =  iszero(M.ev)
 
 
 function tril!(M::SymTridiagonal{T}, k::Integer=0) where T
@@ -927,7 +927,7 @@ end
 ==(A::Tridiagonal, B::Tridiagonal) = (A.dl==B.dl) && (A.d==B.d) && (A.du==B.du)
 function ==(A::Tridiagonal, B::SymTridiagonal)
     iseq = all(Iterators.map((x, y) -> x == transpose(y), A.du, A.dl))
-    iseq = iseq && A.du == _evview(B)
+    iseq = iseq && A.du == B.ev
     iseq && all(Iterators.map((x, y) -> x == symmetric(y, :U), A.d, B.dv))
 end
 ==(A::SymTridiagonal, B::Tridiagonal) = B == A
@@ -947,7 +947,7 @@ end
 
 Base._sum(A::Tridiagonal, ::Colon) = sum(A.d) + sum(A.dl) + sum(A.du)
 function Base._sum(A::SymTridiagonal, ::Colon)
-    se = sum(_evview(A))
+    se = sum(A.ev)
     symmetric(sum(A.dv), :U) + se + transpose(se)
 end
 
@@ -1124,7 +1124,7 @@ end
 # combinations of Tridiagonal and Symtridiagonal
 # copyto! for matching axes
 function _copyto_banded!(A::Tridiagonal, B::SymTridiagonal)
-    Bev = _evview(B)
+    Bev = B.ev
     A.du .= Bev
     # Broadcast identity for numbers to access the faster copyto! path
     # This uses the fact that transpose(x::Number) = x and symmetric(x::Number) = x
@@ -1135,7 +1135,7 @@ end
 function _copyto_banded!(A::SymTridiagonal, B::Tridiagonal)
     issymmetric(B) || throw(ArgumentError("cannot copy an asymmetric Tridiagonal matrix to a SymTridiagonal"))
     A.dv .= B.d
-    _evview(A) .= B.du
+    A.ev .= B.du
     return A
 end
 

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1009,8 +1009,8 @@ end
 end
 
 @testset "(Sym)Tridiagonal division by Diagonal" begin
-    for K in (5, 1), elty in (Float64, ComplexF32), overlength in (1, 0)
-        S = SymTridiagonal(randn(elty, K), randn(elty, K-overlength))
+    for K in (5, 1), elty in (Float64, ComplexF32)
+        S = SymTridiagonal(randn(elty, K), randn(elty, K-1))
         T = Tridiagonal(randn(elty, K-1), randn(elty, K), randn(elty, K-1))
         D = Diagonal(randn(elty, K))
         D0 = Diagonal(zeros(elty, K))
@@ -1033,7 +1033,7 @@ end
     @test (T / D)::Tridiagonal{Float64} == T
     # matrix eltype case
     K = 5
-    for elty in (Float64, ComplexF32), overlength in (1, 0)
+    for elty in (Float64, ComplexF32), overlength in (1,)
         S = SymTridiagonal([rand(elty, 2, 2) for _ in 1:K], [rand(elty, 2, 2) for _ in 1:K-overlength])
         T = Tridiagonal([rand(elty, 2, 2) for _ in 1:K-1], [rand(elty, 2, 2) for _ in 1:K], [rand(elty, 2, 2) for _ in 1:K-1])
         D = Diagonal(randn(elty, K))

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1031,8 +1031,8 @@ end
     @test (T / D)::Tridiagonal{Float64} == T
     # matrix eltype case
     K = 5
-    for elty in (Float64, ComplexF32), overlength in (1,)
-        S = SymTridiagonal([rand(elty, 2, 2) for _ in 1:K], [rand(elty, 2, 2) for _ in 1:K-overlength])
+    for elty in (Float64, ComplexF32)
+        S = SymTridiagonal([rand(elty, 2, 2) for _ in 1:K], [rand(elty, 2, 2) for _ in 1:K-1])
         T = Tridiagonal([rand(elty, 2, 2) for _ in 1:K-1], [rand(elty, 2, 2) for _ in 1:K], [rand(elty, 2, 2) for _ in 1:K-1])
         D = Diagonal(randn(elty, K))
         SM = fill(zeros(elty, 2, 2), K, K)

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -552,12 +552,10 @@ Base.size(x::SimpleVector) = size(x.vec)
     BL = Bidiagonal(repr(randn(10)), repr(randn(9)), :L)
     BU = Bidiagonal(repr(randn(10)), repr(randn(9)), :U)
     C = SymTridiagonal(repr(randn(10)), repr(randn(9)))
-    Cl = SymTridiagonal(repr(randn(10)), repr(randn(10)))
     D = Tridiagonal(repr(randn(9)), repr(randn(10)), repr(randn(9)))
     @test kron(A, BL)::Bidiagonal == kron(M, Array(BL))
     @test kron(A, BU)::Bidiagonal == kron(M, Array(BU))
     @test kron(A, C)::SymTridiagonal == kron(M, Array(C))
-    @test kron(A, Cl)::SymTridiagonal == kron(M, Array(Cl))
     @test kron(A, D)::Tridiagonal == kron(M, Array(D))
 end
 

--- a/test/special.jl
+++ b/test/special.jl
@@ -480,29 +480,6 @@ end
     end
 end
 
-@testset "Ops on SymTridiagonal ev has the same length as dv" begin
-    x = rand(3)
-    y = rand(3)
-    z = rand(2)
-
-    S = SymTridiagonal(x, y)
-    T = Tridiagonal(z, x, z)
-    Bu = Bidiagonal(x, z, :U)
-    Bl = Bidiagonal(x, z, :L)
-
-    Ms = Matrix(S)
-    Mt = Matrix(T)
-    Mbu = Matrix(Bu)
-    Mbl = Matrix(Bl)
-
-    @test S + T ≈ Ms + Mt
-    @test T + S ≈ Mt + Ms
-    @test S + Bu ≈ Ms + Mbu
-    @test Bu + S ≈ Mbu + Ms
-    @test S + Bl ≈ Ms + Mbl
-    @test Bl + S ≈ Mbl + Ms
-end
-
 @testset "Ensure Strided * (Sym)Tridiagonal is Dense" begin
     x = rand(3)
     y = rand(3)
@@ -514,7 +491,7 @@ end
     M_v = Matrix(v)
     m = rand(3, 3)
 
-    S = SymTridiagonal(x, y)
+    S = SymTridiagonal(x, z)
     T = Tridiagonal(z, x, z)
     M_S = Matrix(S)
     M_T = Matrix(T)
@@ -568,11 +545,9 @@ end
             end
         end
         @testset "to SymTridiagonal" begin
-            for du2 in (similar(du, BigInt), similar(d, BigInt))
-                S = SymTridiagonal(similar(d), du2)
-                copyto!(S, D)
-                @test S == D
-            end
+            S = SymTridiagonal(similar(d), similar(du, BigInt))
+            copyto!(S, D)
+            @test S == D
 
             @testset "mismatched size" begin
                 S = SymTridiagonal(zero(d), zero(du))
@@ -630,16 +605,14 @@ end
             end
         end
         @testset "to SymTridiagonal" begin
-            for du2 in (similar(du, BigInt), similar(d, BigInt))
-                S = SymTridiagonal(similar(d, BigInt), du2)
-                for B in (BL, BU)
-                    copyto!(S, B)
-                    @test S == B
-                end
-                errmsg = "cannot copy a non-symmetric Bidiagonal matrix to a SymTridiagonal"
-                @test_throws errmsg copyto!(S, BUones)
-                @test_throws errmsg copyto!(S, BLones)
+            S = SymTridiagonal(similar(d, BigInt), similar(du, BigInt))
+            for B in (BL, BU)
+                copyto!(S, B)
+                @test S == B
             end
+            errmsg = "cannot copy a non-symmetric Bidiagonal matrix to a SymTridiagonal"
+            @test_throws errmsg copyto!(S, BUones)
+            @test_throws errmsg copyto!(S, BLones)
 
             @testset "mismatched size" begin
                 S = SymTridiagonal(zero(d), zero(du))
@@ -709,46 +682,47 @@ end
     end
 
     @testset "from SymTridiagonal" begin
-        S2 = SymTridiagonal(d, ones(Int,size(d)))
-        for S in (SymTridiagonal(d, du), SymTridiagonal(d, zero(d)))
-            @testset "to Diagonal" begin
-                D = Diagonal(zero(d))
-                @test copyto!(D, S) == Diagonal(d)
+        S2 = SymTridiagonal(d, ones(Int,size(du)))
+        S = SymTridiagonal(d, du)
+
+        @testset "to Diagonal" begin
+            D = Diagonal(zero(d))
+            @test copyto!(D, S) == Diagonal(d)
+            D .= 0
+            errmsg = "cannot copy a SymTridiagonal with a non-zero off-diagonal band to a Diagonal"
+            @test_throws errmsg copyto!(D, S2)
+            @test iszero(D)
+
+            @testset "mismatched size" begin
                 D .= 0
-                errmsg = "cannot copy a SymTridiagonal with a non-zero off-diagonal band to a Diagonal"
-                @test_throws errmsg copyto!(D, S2)
+                copyto!(D, SymTridiagonal(Int[1], Int[]))
+                @test D[1,1] == 1
+                D[1,1] = 0
                 @test iszero(D)
-
-                @testset "mismatched size" begin
-                    D .= 0
-                    copyto!(D, SymTridiagonal(Int[1], Int[]))
-                    @test D[1,1] == 1
-                    D[1,1] = 0
-                    @test iszero(D)
-                end
             end
-            @testset "to Bidiagonal" begin
-                BU = Bidiagonal(zero(d), zero(du), :U)
-                BL = Bidiagonal(zero(d), zero(du), :L)
-                @test copyto!(BU, S) == Bidiagonal(d, du, :U)
-                @test copyto!(BL, S) == Bidiagonal(d, du, :L)
+        end
 
-                BU .= 0
-                BL .= 0
-                errmsg = "cannot copy a SymTridiagonal with a non-zero off-diagonal band to a Bidiagonal"
-                @test_throws errmsg copyto!(BU, S2)
-                @test iszero(BU)
-                @test_throws errmsg copyto!(BL, S2)
-                @test iszero(BL)
+        @testset "to Bidiagonal" begin
+            BU = Bidiagonal(zero(d), zero(du), :U)
+            BL = Bidiagonal(zero(d), zero(du), :L)
+            @test copyto!(BU, S) == Bidiagonal(d, du, :U)
+            @test copyto!(BL, S) == Bidiagonal(d, du, :L)
 
-                @testset "mismatched size" begin
-                    for B in (BU, BL)
-                        B .= 0
-                        copyto!(B, SymTridiagonal(Int[1], Int[]))
-                        @test B[1,1] == 1
-                        B[1,1] = 0
-                        @test iszero(B)
-                    end
+            BU .= 0
+            BL .= 0
+            errmsg = "cannot copy a SymTridiagonal with a non-zero off-diagonal band to a Bidiagonal"
+            @test_throws errmsg copyto!(BU, S2)
+            @test iszero(BU)
+            @test_throws errmsg copyto!(BL, S2)
+            @test iszero(BL)
+
+            @testset "mismatched size" begin
+                for B in (BU, BL)
+                    B .= 0
+                    copyto!(B, SymTridiagonal(Int[1], Int[]))
+                    @test B[1,1] == 1
+                    B[1,1] = 0
+                    @test iszero(B)
                 end
             end
         end
@@ -833,13 +807,13 @@ end
         BU = Bidiagonal(d, z, :U)
         BL = Bidiagonal(d, z, :L)
         T = Tridiagonal(z, d, z)
-        for ev in (fill(zero(m),3), fill(zero(m),4))
-            SD = SymTridiagonal(fill(m,4), ev)
-            @test SD == D == SD
-            @test SD == BU == SD
-            @test SD == BL == SD
-            @test SD == T == SD
-        end
+        ev = fill(zero(m),3)
+
+        SD = SymTridiagonal(fill(m,4), ev)
+        @test SD == D == SD
+        @test SD == BU == SD
+        @test SD == BL == SD
+        @test SD == T == SD
     end
 end
 

--- a/test/special.jl
+++ b/test/special.jl
@@ -482,7 +482,6 @@ end
 
 @testset "Ensure Strided * (Sym)Tridiagonal is Dense" begin
     x = rand(3)
-    y = rand(3)
     z = rand(2)
 
     l = rand(12, 12)

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -555,7 +555,7 @@ end
 end
 
 @testset "Issue #26994 (and the empty case)" begin
-    T = SymTridiagonal([1.0],[3.0])
+    T = SymTridiagonal([1.0],Float64[])
     x = ones(1)
     @test T*x == ones(1)
     @test SymTridiagonal(ones(0), ones(0)) * ones(0, 2) == ones(0, 2)
@@ -678,15 +678,9 @@ end
 
 # Issue #38765
 @testset "Eigendecomposition with different lengths" begin
-    # length(A.ev) can be either length(A.dv) or length(A.dv) - 1
-    A = SymTridiagonal(fill(1.0, 3), fill(-1.0, 3))
+    A = SymTridiagonal(fill(1.0, 3), fill(-1.0, 2))
     F = eigen(A)
-    A2 = SymTridiagonal(fill(1.0, 3), fill(-1.0, 2))
-    F2 = eigen(A2)
-    test_approx_eq_modphase(F.vectors, F2.vectors)
-    @test F.values ≈ F2.values ≈ eigvals(A) ≈ eigvals(A2)
-    @test eigvecs(A) ≈ eigvecs(A2)
-    @test eigvecs(A, eigvals(A)[1:1]) ≈ eigvecs(A2, eigvals(A2)[1:1])
+    @test F.values ≈ eigvals(A)
 end
 
 @testset "non-commutative algebra (#39701)" begin
@@ -728,8 +722,7 @@ end
 
     # complex
     # https://github.com/JuliaLang/julia/pull/41037#discussion_r645524081
-    S = SymTridiagonal(randn(5) .+ 0im, randn(5) .+ 0im)
-    S.ev[end] = im
+    S = SymTridiagonal(randn(5) .+ 0im, randn(4) .+ 0im)
     @test issymmetric(S)
     @test ishermitian(S)
 
@@ -773,7 +766,7 @@ end
 @testset "non-number eltype" begin
     @testset "sum for SymTridiagonal" begin
         dv = [SizedArray{(2,2)}(rand(1:2048,2,2)) for i in 1:10]
-        ev = [SizedArray{(2,2)}(rand(1:2048,2,2)) for i in 1:10]
+        ev = [SizedArray{(2,2)}(rand(1:2048,2,2)) for i in 1:9]
         S = SymTridiagonal(dv, ev)
         Sdense = Matrix(S)
         @test Sdense == collect(S)
@@ -792,7 +785,7 @@ end
     end
     @testset "== between Tridiagonal and SymTridiagonal" begin
         dv = [SizedArray{(2,2)}([1 2;3 4]) for i in 1:4]
-        ev = [SizedArray{(2,2)}([3 4;1 2]) for i in 1:4]
+        ev = [SizedArray{(2,2)}([3 4;1 2]) for i in 1:3]
         S = SymTridiagonal(dv, ev)
         Sdense = Matrix(S)
         @test S == Tridiagonal(diag(Sdense, -1), diag(Sdense),  diag(Sdense, 1)) == S
@@ -804,12 +797,6 @@ end
     ev, dv = [1:4;], [1:5;]
     S = SymTridiagonal(dv, ev)
     T = Tridiagonal(zero(ev), zero(dv), zero(ev))
-    @test copyto!(T, S) == S
-    @test copyto!(zero(S), T) == T
-
-    ev2 = [1:5;]
-    S = SymTridiagonal(dv, ev2)
-    T = Tridiagonal(zeros(length(ev2)-1), zero(dv), zeros(length(ev2)-1))
     @test copyto!(T, S) == S
     @test copyto!(zero(S), T) == T
 

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -61,6 +61,7 @@ end
             c += im*convert(Vector{elty}, randn(n - 1))
         end
     end
+    @test_throws DimensionMismatch SymTridiagonal(d, d)
     @test_throws DimensionMismatch SymTridiagonal(dl, fill(elty(1), n+1))
     @test_throws ArgumentError SymTridiagonal(rand(n, n))
     @test_throws ArgumentError Tridiagonal(dl, dl, dl)
@@ -190,19 +191,6 @@ end
         @test !isdiag(Tridiagonal(dl,d,zerosdu))
         @test !isdiag(Tridiagonal(zerosdl,d,du))
         @test !isdiag(Tridiagonal(dl,d,du))
-
-        # Test methods that could fail due to dv and ev having the same length
-        # see #41089
-
-        badev = zero(d)
-        badev[end] = 1
-        S = SymTridiagonal(d, badev)
-
-        @test istriu(S, -2)
-        @test istriu(S, 0)
-        @test !istriu(S, 2)
-
-        @test isdiag(S)
     end
 
     @testset "iszero and isone" begin
@@ -229,12 +217,6 @@ end
         @test isone(Sone)
         @test !iszero(Smix)
         @test !isone(Smix)
-
-        badev = zeros(elty, 3)
-        badev[end] = 1
-
-        @test isone(SymTridiagonal(ones(elty, 3), badev))
-        @test iszero(SymTridiagonal(zeros(elty, 3), badev))
     end
 
     @testset for mat_type in (Tridiagonal, SymTridiagonal)

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -691,13 +691,6 @@ end
     @test_throws ArgumentError SymTridiagonal{Float32}(T)
 end
 
-# Issue #38765
-@testset "Eigendecomposition with different lengths" begin
-    A = SymTridiagonal(fill(1.0, 3), fill(-1.0, 2))
-    F = eigen(A)
-    @test F.values ≈ eigvals(A)
-end
-
 @testset "non-commutative algebra (#39701)" begin
     for A in (SymTridiagonal(Quaternion.(randn(5), randn(5), randn(5), randn(5)), Quaternion.(randn(4), randn(4), randn(4), randn(4))),
               Tridiagonal(Quaternion.(randn(4), randn(4), randn(4), randn(4)), Quaternion.(randn(5), randn(5), randn(5), randn(5)), Quaternion.(randn(4), randn(4), randn(4), randn(4))))

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -529,6 +529,21 @@ end
     @test Tridiagonal([1, 2], [4, 5, 1], [6.0, 7]) == [4.0 6.0 0.0; 1.0 5.0 7.0; 0.0 2.0 1.0]
 end
 
+@testset "SymTridiagonal dv and ev lengths" begin
+    # https://github.com/JuliaLang/LinearAlgebra.jl/issues/629
+
+    # Empty matrix can have length(dv) == length(ev)
+    @test SymTridiagonal(Float64[], Float64[]) isa SymTridiagonal
+
+    @test SymTridiagonal(ones(1), Float64[]) isa SymTridiagonal
+
+    # Must have length(dv) = length(ev) + 1
+    @test_throws DimensionMismatch SymTridiagonal(ones(1), ones(1))
+    @test_throws DimensionMismatch SymTridiagonal(ones(2), ones(2))
+    @test_throws DimensionMismatch SymTridiagonal(ones(4), ones(2))
+    @test_throws DimensionMismatch SymTridiagonal(ones(4), ones(5))
+end
+
 @testset "convert for SymTridiagonal" begin
     STF32 = SymTridiagonal{Float32}(fill(1f0, 5), fill(1f0, 4))
     @test convert(typeof(STF32), STF32) === STF32


### PR DESCRIPTION
https://github.com/JuliaLang/LinearAlgebra.jl/issues/629 pointed out that is possible to initialise SymTridiagonal with subdiagonal of length equal to the diagonal. This is inconsistent with Tridiagonal and Bidiagonal.

Check the lengths and error if the subdiagonal's length is not 1 less than the diagonal's length.

Remove tests for SymTridiagonal with length(ev) == length(dv).

Todo: 
- [x] add test that `len(dv) == len(ev)` now errors
- [x] remove tests with `len(dv)==len(ev)`
- [x] fix kron
- [x] @andreasnoack mentioned that changes may be need in the wrapper for [dstemr](https://www.netlib.org/lapack/explore-html/d4/dec/group__stemr_ga71cbf49a0387762afa39582e6abbe466.html#ga71cbf49a0387762afa39582e6abbe466). 
I don't think that any changes are needed for dstemr. As far as I can tell from https://github.com/JuliaLang/LinearAlgebra.jl/issues/1491, `dstemr` is called via `dstgr!`. It already has checks in place for the lengths of `de` and `ev`:
https://github.com/JuliaLang/LinearAlgebra.jl/blob/17325b74ec807f5237228512db1131ddfe4048e3/src/lapack.jl#L4043-L4058

Possible followups:
- [x] simplify `_evview`, now that `ev` always has the same length.
- [x] remove most calls to `_evview`