### PR TITLE
Add sizehint to syevr! to avoid potentially unnecessary allocation

### DIFF
--- a/src/lapack.jl
+++ b/src/lapack.jl
@@ -5429,7 +5429,7 @@ for (syev, syevr, syevd, sygvd, elty) in
                 end
             end
             zm = jobz == 'V' ? m[] : 0
-            resize!(W, m[]), reshape(resize!(Z, ldz * zm), ldz, zm)
+            resize!(W, m[]), reshape(sizehint!(resize!(Z, ldz * zm), ldz * zm), ldz, zm)
         end
         syevr!(jobz::AbstractChar, A::AbstractMatrix{$elty}) =
             syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)
@@ -5639,7 +5639,7 @@ for (syev, syevr, syevd, sygvd, elty, relty) in
                 end
             end
             zm = jobz == 'V' ? m[] : 0
-            resize!(W, m[]), reshape(resize!(Z, ldz * zm), ldz, zm)
+            resize!(W, m[]), reshape(sizehint!(resize!(Z, ldz * zm), ldz * zm), ldz, zm)
         end
         syevr!(jobz::AbstractChar, A::AbstractMatrix{$elty}) =
             syevr!(jobz, 'A', 'U', A, 0.0, 0.0, 0, 0, -1.0)

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -302,7 +302,8 @@ end
 @testset "memory allocation with range given (#1425)" begin
     A = Hermitian(Float64[1 2 3; 2 4 5; 3 5 1])
     e, V = eigen(A, -5, 1) # should only get 2 eigenvalues/ eigenvectors
-    @test Base.summarysize(V) == 96
+    V1 = copy(V)
+    @test Base.summarysize(V) == Base.summarysize(V1)
 end
 
 end # module TestEigen

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -299,4 +299,10 @@ end
     @test λ == [1.0, 8.0]
 end
 
+@testset "memory allocation with range given (#1425)" begin
+    A = Hermitian(Float64[1 2 3; 2 4 5; 3 5 1])
+    e, V = eigen(A, -5, 1) # should only get 2 eigenvalues/ eigenvectors
+    @test Base.summarysize(V) == 96
+end
+
 end # module TestEigen


### PR DESCRIPTION
Fixes #1425 

Adding `sizehint!` into the reshape command in syevr! seems to avoid a potentially large allocation that happens temporarily in `eigen` when a range is given and only a small subset of eigenvectors are returned. It seems that the actual array of eigenvectors returned is not taking up the whole size that `summarysize` suggests but the `MemoryRef` is not updated correctly. This fix ensures that `summarysize` is actually reflecting the correct size of the array returned. From the tests, this doesn't seem to have any adverse effects otherwise. 