### PR TITLE
Add a type assertion to a test helper function, to avoid breaking Base Julia tests

### DIFF
--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -78,7 +78,7 @@ for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
 end
 for op in (:(==), :isequal)
     @eval $op(x::Furlong{p}, y::Furlong{q}) where {p,q} = false
-    @eval $op(x::Furlong, y::Number) = $op(x, convert(Furlong, y)::Furlong)
+    @eval $op(x::Furlong, y::Number) = $op(x, convert(Furlong{0}, y))
     @eval $op(x::Number, y::Furlong) = $op(y, x)
 end
 for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -78,7 +78,7 @@ for op in (:(==), :(!=), :<, :<=, :isless, :isequal)
 end
 for op in (:(==), :isequal)
     @eval $op(x::Furlong{p}, y::Furlong{q}) where {p,q} = false
-    @eval $op(x::Furlong, y::Number) = $op(x, convert(Furlong, y))
+    @eval $op(x::Furlong, y::Number) = $op(x, convert(Furlong, y)::Furlong)
     @eval $op(x::Number, y::Furlong) = $op(y, x)
 end
 for (f,op) in ((:_plus,:+),(:_minus,:-),(:_times,:*),(:_div,://))


### PR DESCRIPTION
Detected via the following script, which was partially written by Codex 🤖:

```julia
# julia +nightly --compiled-modules=existing --project

ENV["JULIA_PRUNE_OLD_LA"] = "true"

# Make sure you are in the LinearAlgebra directory
include("test/prune_old_LA.jl")
include("test/runtests.jl")

@info "" pathof(LinearAlgebra)

for m in methods(isequal, Tuple{Any, Any})
    sig = Base.unwrap_unionall(m.sig).parameters[2:end]
    t = Core.Compiler.return_type(isequal, Tuple{sig...})
    if t != Bool
        @info "" m t
    end
end

good = all(==(Bool), Base.return_types(isequal, Tuple{Any, Any}))
@info "" good
```

I think this should fix the CI failure seen in https://github.com/JuliaLang/julia/pull/61570.