### PR TITLE
Improving linear solves: reduction of methods, destination array type mechanism

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -666,6 +666,7 @@ _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B
 # without defining methods for both the orderings
 matprod_dest(A, B::Diagonal, TS) = _matprod_dest_diag(A, TS)
 matprod_dest(A::Diagonal, B, TS) = _matprod_dest_diag(B, TS)
+matprod_dest(A::Diagonal, B::AbstractVector, TS) = _matprod_dest_diag(B, TS)
 matprod_dest(A::Diagonal, B::Diagonal, TS) = _matprod_dest_diag(B, TS)
 _matprod_dest_diag(A, TS) = similar(A, TS)
 _matprod_dest_diag(A::HermOrSym, TS) = similar(A, TS, size(A))

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1357,9 +1357,7 @@ function ldiv!(c::AbstractVecOrMat, A::Bidiagonal, b::AbstractVecOrMat)
 end
 
 ### Generic promotion methods and fallbacks
-\(A::Bidiagonal, B::AbstractVector) =
-    ldiv!(similar(B, promote_op(\, eltype(A), eltype(B))), A, B)
-\(A::Bidiagonal, B::AbstractMatrix) =
+\(A::Bidiagonal, B::AbstractVecOrMat) =
     ldiv!(matprod_dest(A, B, promote_op(\, eltype(A), eltype(B))), A, B)
 
 ### Triangular specializations

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1358,33 +1358,33 @@ end
 
 ### Generic promotion methods and fallbacks
 \(A::Bidiagonal, B::AbstractVecOrMat) =
-    ldiv!(matprod_dest(A, B, promote_op(\, eltype(A), eltype(B))), A, B)
+    ldiv!(matldiv_dest(A, B), A, B)
 
 ### Triangular specializations
 for tri in (:UpperTriangular, :UnitUpperTriangular)
     @eval function \(B::Bidiagonal, U::$tri)
-        A = ldiv!(matprod_dest(B, U, promote_op(\, eltype(B), eltype(U))), B, U)
+        A = ldiv!(matldiv_dest(B, U), B, U)
         return B.uplo == 'U' ? UpperTriangular(A) : A
     end
     @eval function \(U::$tri, B::Bidiagonal)
-        A = ldiv!(matprod_dest(U, B, promote_op(\, eltype(U), eltype(B))), U, B)
+        A = ldiv!(matldiv_dest(U, B), U, B)
         return B.uplo == 'U' ? UpperTriangular(A) : A
     end
 end
 for tri in (:LowerTriangular, :UnitLowerTriangular)
     @eval function \(B::Bidiagonal, L::$tri)
-        A = ldiv!(matprod_dest(B, L, promote_op(\, eltype(B), eltype(L))), B, L)
+        A = ldiv!(matldiv_dest(B, L), B, L)
         return B.uplo == 'L' ? LowerTriangular(A) : A
     end
     @eval function \(L::$tri, B::Bidiagonal)
-        A = ldiv!(matprod_dest(L, B, promote_op(\, eltype(L), eltype(B))), L, B)
+        A = ldiv!(matldiv_dest(L, B), L, B)
         return B.uplo == 'L' ? LowerTriangular(A) : A
     end
 end
 
 ### Diagonal specialization
 function \(B::Bidiagonal, D::Diagonal)
-    A = ldiv!(similar(D, promote_op(\, eltype(B), eltype(D)), size(D)), B, D)
+    A = ldiv!(matldiv_dest(B, D), B, D)
     return B.uplo == 'U' ? UpperTriangular(A) : LowerTriangular(A)
 end
 
@@ -1431,34 +1431,33 @@ function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
 end
 rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(A, A, B)
 
-/(A::AbstractMatrix, B::Bidiagonal) =
-    _rdiv!(similar(A, promote_op(/, eltype(A), eltype(B)), size(A)), A, B)
+/(A::AbstractMatrix, B::Bidiagonal) = _rdiv!(matrdiv_dest(A, B), A, B)
 
 ### Triangular specializations
 for tri in (:UpperTriangular, :UnitUpperTriangular)
     @eval function /(U::$tri, B::Bidiagonal)
-        A = _rdiv!(matprod_dest(U, B, promote_op(/, eltype(U), eltype(B))), U, B)
+        A = _rdiv!(matrdiv_dest(U, B), U, B)
         return B.uplo == 'U' ? UpperTriangular(A) : A
     end
     @eval function /(B::Bidiagonal, U::$tri)
-        A = _rdiv!(matprod_dest(B, U, promote_op(/, eltype(B), eltype(U))), B, U)
+        A = _rdiv!(matrdiv_dest(B, U), B, U)
         return B.uplo == 'U' ? UpperTriangular(A) : A
     end
 end
 for tri in (:LowerTriangular, :UnitLowerTriangular)
     @eval function /(L::$tri, B::Bidiagonal)
-        A = _rdiv!(matprod_dest(L, B, promote_op(/, eltype(L), eltype(B))), L, B)
+        A = _rdiv!(matrdiv_dest(L, B), L, B)
         return B.uplo == 'L' ? LowerTriangular(A) : A
     end
     @eval function /(B::Bidiagonal, L::$tri)
-        A = _rdiv!(matprod_dest(B, L, promote_op(/, eltype(B), eltype(L))), B, L)
+        A = _rdiv!(matrdiv_dest(B, L), B, L)
         return B.uplo == 'L' ? LowerTriangular(A) : A
     end
 end
 
 ### Diagonal specialization
 function /(D::Diagonal, B::Bidiagonal)
-    A = _rdiv!(similar(D, promote_op(/, eltype(D), eltype(B)), size(D)), D, B)
+    A = _rdiv!(matrdiv_dest(D, B), D, B)
     return B.uplo == 'U' ? UpperTriangular(A) : LowerTriangular(A)
 end
 

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1267,25 +1267,8 @@ function _dibimul_nonzeroalpha!(C::Bidiagonal, A::Diagonal, B::Bidiagonal, _add)
     C
 end
 
-function mul(A::UpperOrUnitUpperTriangular, B::Bidiagonal)
-    C = _mul(A, B)
-    return B.uplo == 'U' ? UpperTriangular(C) : C
-end
-
-function mul(A::LowerOrUnitLowerTriangular, B::Bidiagonal)
-    C = _mul(A, B)
-    return B.uplo == 'L' ? LowerTriangular(C) : C
-end
-
-function mul(A::Bidiagonal, B::UpperOrUnitUpperTriangular)
-    C = _mul(A, B)
-    return A.uplo == 'U' ? UpperTriangular(C) : C
-end
-
-function mul(A::Bidiagonal, B::LowerOrUnitLowerTriangular)
-    C = _mul(A, B)
-    return A.uplo == 'L' ? LowerTriangular(C) : C
-end
+mul(A::UpperOrLowerTriangular, B::Bidiagonal) = (C = _mul(A, B); postop_proc(C, A, B))
+mul(A::Bidiagonal, B::UpperOrLowerTriangular) = (C = _mul(A, B); postop_proc(C, A, B))
 
 function dot(x::AbstractVector, B::Bidiagonal, y::AbstractVector)
     require_one_based_indexing(x, y)
@@ -1358,35 +1341,14 @@ end
 
 ### Generic promotion methods and fallbacks
 \(A::Bidiagonal, B::AbstractVecOrMat) =
-    ldiv!(matldiv_dest(A, B), A, B)
+    postop_proc(ldiv!(matldiv_dest(A, B), A, B), A, B)
 
-### Triangular specializations
-for tri in (:UpperTriangular, :UnitUpperTriangular)
-    @eval function \(B::Bidiagonal, U::$tri)
-        A = ldiv!(matldiv_dest(B, U), B, U)
-        return B.uplo == 'U' ? UpperTriangular(A) : A
-    end
-    @eval function \(U::$tri, B::Bidiagonal)
-        A = ldiv!(matldiv_dest(U, B), U, B)
-        return B.uplo == 'U' ? UpperTriangular(A) : A
-    end
-end
-for tri in (:LowerTriangular, :UnitLowerTriangular)
-    @eval function \(B::Bidiagonal, L::$tri)
-        A = ldiv!(matldiv_dest(B, L), B, L)
-        return B.uplo == 'L' ? LowerTriangular(A) : A
-    end
-    @eval function \(L::$tri, B::Bidiagonal)
-        A = ldiv!(matldiv_dest(L, B), L, B)
-        return B.uplo == 'L' ? LowerTriangular(A) : A
-    end
-end
-
-### Diagonal specialization
-function \(B::Bidiagonal, D::Diagonal)
-    A = ldiv!(matldiv_dest(B, D), B, D)
-    return B.uplo == 'U' ? UpperTriangular(A) : LowerTriangular(A)
-end
+postop_proc(C, B::Bidiagonal, ::UpperOrUnitUpperTriangular) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(C, ::UpperOrUnitUpperTriangular, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(C, B::Bidiagonal, ::LowerOrUnitLowerTriangular) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(C, ::LowerOrUnitLowerTriangular, B::Bidiagonal) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(C, B::Bidiagonal, ::Diagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
+postop_proc(C, ::Diagonal, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
 
 function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
     require_one_based_indexing(C, A, B)
@@ -1431,35 +1393,8 @@ function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
 end
 rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(A, A, B)
 
-/(A::AbstractMatrix, B::Bidiagonal) = _rdiv!(matrdiv_dest(A, B), A, B)
-
-### Triangular specializations
-for tri in (:UpperTriangular, :UnitUpperTriangular)
-    @eval function /(U::$tri, B::Bidiagonal)
-        A = _rdiv!(matrdiv_dest(U, B), U, B)
-        return B.uplo == 'U' ? UpperTriangular(A) : A
-    end
-    @eval function /(B::Bidiagonal, U::$tri)
-        A = _rdiv!(matrdiv_dest(B, U), B, U)
-        return B.uplo == 'U' ? UpperTriangular(A) : A
-    end
-end
-for tri in (:LowerTriangular, :UnitLowerTriangular)
-    @eval function /(L::$tri, B::Bidiagonal)
-        A = _rdiv!(matrdiv_dest(L, B), L, B)
-        return B.uplo == 'L' ? LowerTriangular(A) : A
-    end
-    @eval function /(B::Bidiagonal, L::$tri)
-        A = _rdiv!(matrdiv_dest(B, L), B, L)
-        return B.uplo == 'L' ? LowerTriangular(A) : A
-    end
-end
-
-### Diagonal specialization
-function /(D::Diagonal, B::Bidiagonal)
-    A = _rdiv!(matrdiv_dest(D, B), D, B)
-    return B.uplo == 'U' ? UpperTriangular(A) : LowerTriangular(A)
-end
+/(A::AbstractMatrix, B::Bidiagonal) =
+    postop_proc(_rdiv!(matrdiv_dest(A, B), A, B), A, B)
 
 # disambiguation
 /(A::AdjointAbsVec, B::Bidiagonal) = adjoint(adjoint(B) \ parent(A))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -606,8 +606,10 @@ function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
     return Diagonal(Da.diag .* Db.diag .* Dc.diag)
 end
 
-# flipped order in matprod_dest is on purpose, to put the vector argument on second place
-/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matprod_dest(D, A, promote_op(/, eltype(A), eltype(D))), A, D)
+matrdiv_dest(A, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)))
+matrdiv_dest(A::HermOrSym, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)), size(A))
+
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matrdiv_dest(A, D), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -628,7 +630,10 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matprod_dest(D, B, promote_op(\, eltype(D), eltype(B))), D, B)
+matldiv_dest(D::Diagonal, B) = similar(B, promote_op(\, eltype(D), eltype(B)))
+matldiv_dest(D::Diagonal, B::HermOrSym) = similar(B, promote_op(\, eltype(D), eltype(B)), size(B))
+
+\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matldiv_dest(D, B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
@@ -675,14 +680,14 @@ ldiv!(Dc::Diagonal, Da::Diagonal, Db::Diagonal) = Diagonal(ldiv!(Dc.diag, Da, Db
 @propagate_inbounds _getldiag(T::Tridiagonal, i) = T.dl[i]
 @propagate_inbounds _getldiag(S::SymTridiagonal, i) = transpose(S.ev[i])
 
-function (\)(D::Diagonal, S::SymTridiagonal)
+function matldiv_dest(D::Diagonal, S::SymTridiagonal)
     T = promote_op(\, eltype(D), eltype(S))
     du = similar(S.ev, T, max(length(S.dv)-1, 0))
     d  = similar(S.dv, T, length(S.dv))
     dl = similar(S.ev, T, max(length(S.dv)-1, 0))
-    ldiv!(Tridiagonal(dl, d, du), D, S)
+    return Tridiagonal(dl, d, du)
 end
-(\)(D::Diagonal, T::Tridiagonal) = ldiv!(similar(T, promote_op(\, eltype(D), eltype(T))), D, T)
+
 function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal})
     m = size(S, 1)
     dd = D.diag
@@ -712,14 +717,15 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
     return T
 end
 
-function (/)(S::SymTridiagonal, D::Diagonal)
+function matrdiv_dest(S::SymTridiagonal, D::Diagonal)
     T = promote_op(\, eltype(D), eltype(S))
     du = similar(S.ev, T, max(length(S.dv)-1, 0))
     d  = similar(S.dv, T, length(S.dv))
     dl = similar(S.ev, T, max(length(S.dv)-1, 0))
-    _rdiv!(Tridiagonal(dl, d, du), S, D)
+    return Tridiagonal(dl, d, du)
 end
-(/)(T::Tridiagonal, D::Diagonal) = _rdiv!(matprod_dest(T, D, promote_op(/, eltype(T), eltype(D))), T, D)
+(/)(T::Union{SymTridiagonal,Tridiagonal}, D::Diagonal) =
+    _rdiv!(matrdiv_dest(T, D), T, D)
 function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagonal)
     n = size(S, 2)
     dd = D.diag

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -724,8 +724,7 @@ function matrdiv_dest(S::SymTridiagonal, D::Diagonal)
     dl = similar(S.ev, T, max(length(S.dv)-1, 0))
     return Tridiagonal(dl, d, du)
 end
-(/)(T::Union{SymTridiagonal,Tridiagonal}, D::Diagonal) =
-    _rdiv!(matrdiv_dest(T, D), T, D)
+
 function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagonal)
     n = size(S, 2)
     dd = D.diag

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -717,13 +717,7 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
     return T
 end
 
-function matrdiv_dest(S::SymTridiagonal, D::Diagonal)
-    T = promote_op(/, eltype(S), eltype(D))
-    du = similar(S.ev, T, max(length(S.dv)-1, 0))
-    d  = similar(S.dv, T, length(S.dv))
-    dl = similar(S.ev, T, max(length(S.dv)-1, 0))
-    return Tridiagonal(dl, d, du)
-end
+matrdiv_dest(S::SymTridiagonal, D::Diagonal) = matldiv_dest(D, S)
 
 function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagonal)
     n = size(S, 2)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -718,7 +718,7 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
 end
 
 function matrdiv_dest(S::SymTridiagonal, D::Diagonal)
-    T = promote_op(\, eltype(D), eltype(S))
+    T = promote_op(/, eltype(S), eltype(D))
     du = similar(S.ev, T, max(length(S.dv)-1, 0))
     d  = similar(S.dv, T, length(S.dv))
     dl = similar(S.ev, T, max(length(S.dv)-1, 0))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -606,8 +606,8 @@ function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
     return Diagonal(Da.diag .* Db.diag .* Dc.diag)
 end
 
-/(A::AbstractVector, D::Diagonal) = _rdiv!(similar(A, promote_op(/, eltype(A), eltype(D))), A, D)
-/(A::AbstractMatrix, D::Diagonal) = _rdiv!(matprod_dest(A, D, promote_op(/, eltype(A), eltype(D))), A, D)
+# flipped order in matprod_dest is on purpose, to put the vector argument on second place
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matprod_dest(D, A, promote_op(/, eltype(A), eltype(D))), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -628,12 +628,7 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-function \(D::Diagonal, B::AbstractVector)
-    j = findfirst(iszero, D.diag)
-    isnothing(j) || throw(SingularException(j))
-    return D.diag .\ B
-end
-\(D::Diagonal, B::AbstractMatrix) = ldiv!(matprod_dest(D, B, promote_op(\, eltype(D), eltype(B))), D, B)
+\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matprod_dest(D, B, promote_op(\, eltype(D), eltype(B))), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -172,22 +172,14 @@ function mul(U::UpperOrUnitUpperTriangular, H::UpperHessenberg)
 end
 
 /(H::UpperHessenberg, D::Diagonal) = UpperHessenberg(H.data / D)
-function /(H::UpperHessenberg, U::UpperTriangular)
-    HH = _rdiv!(matprod_dest(H, U, promote_op(/, eltype(H), eltype(U))), H, U)
-    UpperHessenberg(HH)
-end
-\(D::Diagonal, H::UpperHessenberg) = UpperHessenberg(D \ H.data)
-function /(H::UpperHessenberg, U::UnitUpperTriangular)
-    HH = _rdiv!(matprod_dest(H, U, promote_op(/, eltype(H), eltype(U))), H, U)
+function /(H::UpperHessenberg, U::UpperOrUnitUpperTriangular)
+    HH = _rdiv!(matrdiv_dest(H, U), H, U)
     UpperHessenberg(HH)
 end
 
-function \(U::UpperTriangular, H::UpperHessenberg)
-    HH = ldiv!(matprod_dest(U, H, promote_op(\, eltype(U), eltype(H))), U, H)
-    UpperHessenberg(HH)
-end
-function \(U::UnitUpperTriangular, H::UpperHessenberg)
-    HH = ldiv!(matprod_dest(U, H, promote_op(\, eltype(U), eltype(H))), U, H)
+\(D::Diagonal, H::UpperHessenberg) = UpperHessenberg(D \ H.data)
+function \(U::UpperOrUnitUpperTriangular, H::UpperHessenberg)
+    HH = ldiv!(matldiv_dest(U, H), U, H)
     UpperHessenberg(HH)
 end
 

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -162,26 +162,13 @@ end
 
 mul(H::UpperHessenberg, D::Diagonal) = UpperHessenberg(H.data * D)
 mul(D::Diagonal, H::UpperHessenberg) = UpperHessenberg(D * H.data)
-function mul(H::UpperHessenberg, U::UpperOrUnitUpperTriangular)
-    HH = mul!(matprod_dest(H, U, promote_op(matprod, eltype(H), eltype(U))), H, U)
-    UpperHessenberg(HH)
-end
-function mul(U::UpperOrUnitUpperTriangular, H::UpperHessenberg)
-    HH = mul!(matprod_dest(U, H, promote_op(matprod, eltype(U), eltype(H))), U, H)
-    UpperHessenberg(HH)
-end
+
+postop_proc(C, ::UpperHessenberg, ::UpperOrUnitUpperTriangular) = UpperHessenberg(C)
+postop_proc(C, ::UpperOrUnitUpperTriangular, ::UpperHessenberg) = UpperHessenberg(C)
 
 /(H::UpperHessenberg, D::Diagonal) = UpperHessenberg(H.data / D)
-function /(H::UpperHessenberg, U::UpperOrUnitUpperTriangular)
-    HH = _rdiv!(matrdiv_dest(H, U), H, U)
-    UpperHessenberg(HH)
-end
 
 \(D::Diagonal, H::UpperHessenberg) = UpperHessenberg(D \ H.data)
-function \(U::UpperOrUnitUpperTriangular, H::UpperHessenberg)
-    HH = ldiv!(matldiv_dest(U, H), U, H)
-    UpperHessenberg(HH)
-end
 
 AdjUpperHessenberg{T,S<:UpperHessenberg{T}} = Adjoint{T, S}
 TransUpperHessenberg{T,S<:UpperHessenberg{T}} = Transpose{T, S}

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -132,7 +132,6 @@ Return an appropriate `AbstractArray` with element type `T` that may be used to 
     This function requires at least Julia 1.11
 """
 matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
-matprod_dest(A, B::AbstractVector, T) = similar(B, T, (size(A, 1),))
 
 """
     matldiv_dest(A, B)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -132,6 +132,7 @@ Return an appropriate `AbstractArray` with element type `T` that may be used to 
     This function requires at least Julia 1.11
 """
 matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
+matprod_dest(A, B::AbstractVector, T) = similar(B, T, (size(A, 1),))
 
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -134,6 +134,26 @@ Return an appropriate `AbstractArray` with element type `T` that may be used to 
 matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
 matprod_dest(A, B::AbstractVector, T) = similar(B, T, (size(A, 1),))
 
+"""
+    matldiv_dest(A, B)
+
+Return an appropriate `AbstractArray` that may be used to store the result of `A \\ B`.
+
+!!! compat
+    This function requires at least Julia 1.14
+"""
+matldiv_dest(A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
+
+"""
+    matrdiv_dest(A, B)
+
+Return an appropriate `AbstractArray` that may be used to store the result of `A / B`.
+
+!!! compat
+    This function requires at least Julia 1.14
+"""
+matrdiv_dest(A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
+
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})
 # which is better handled by reinterpreting rather than promotion

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -56,10 +56,10 @@ function (*)(A::StridedMaybeAdjOrTransMat{T}, x::StridedVector{S}) where {T<:Bla
     y = isconcretetype(TS) ? convert(AbstractVector{TS}, x) : x
     mul!(similar(x, TS, size(A,1)), A, y)
 end
-function (*)(A::AbstractMatrix{T}, x::AbstractVector{S}) where {T,S}
+function (*)(A::AbstractMatrix, x::AbstractVector)
     matmul_size_check(size(A), size(x))
-    TS = promote_op(matprod, T, S)
-    mul!(similar(x, TS, axes(A,1)), A, x)
+    TS = promote_op(matprod, eltype(A), eltype(x))
+    mul!(matprod_dest(A, x, TS), A, x)
 end
 
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
@@ -132,6 +132,7 @@ Return an appropriate `AbstractArray` with element type `T` that may be used to 
     This function requires at least Julia 1.11
 """
 matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
+matprod_dest(A, x::AbstractVector, T) = similar(x, T, axes(A,1))
 
 """
     matldiv_dest(A, B)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1988,57 +1988,41 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
     @eval function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
         require_one_based_indexing(B)
-        if size(A, 2) != size(B, 1)
-            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
-        end
         TAB = _inner_type_promotion(\, eltype(A), eltype(B))
-        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copyto!(C, B))
+            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
         else
-            ldiv!(C, A, B)
+            ldiv!(matprod_dest(A, B, TAB), A, B)
         end
     end
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
     @eval function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
         require_one_based_indexing(B)
-        if size(A, 2) != size(B, 1)
-            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
-        end
         TAB = promote_op(\, eltype(A), eltype(B))
-        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copyto!(C, B))
+            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
         else
-            ldiv!(C, A, B)
+            ldiv!(matprod_dest(A, B, TAB), A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
     @eval function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
         require_one_based_indexing(A)
-        if size(B, 1) != size(A, 2)
-            throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
-        end
         TAB = _inner_type_promotion(/, eltype(A), eltype(B))
-        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            rdiv!(copyto!(C, A), convert(AbstractArray{TAB}, B))
+            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(C, A, B)
+            _rdiv!(matprod_dest(A, B, TAB), A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
     @eval function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
         require_one_based_indexing(A)
-        if size(B, 1) != size(A, 2)
-            throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
-        end
         TAB = promote_op(/, eltype(A), eltype(B))
-        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            rdiv!(copyto!(C, A), convert(AbstractArray{TAB}, B))
+            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(C, A, B)
+            _rdiv!(matprod_dest(A, B, TAB), A, B)
         end
     end
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1975,60 +1975,66 @@ for mat in (:AbstractVector, :AbstractMatrix)
     @eval function mul(A::UpperOrLowerTriangular, B::$mat)
         require_one_based_indexing(B)
         TAB = promote_op(matprod, eltype(A), eltype(B))
+        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            lmul!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
+            lmul!(convert(AbstractArray{TAB}, A), copyto!(C, B))
         else
-            mul!(matprod_dest(A, B, TAB), A, B)
+            mul!(C, A, B)
         end
     end
     ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
     @eval function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
         require_one_based_indexing(B)
         TAB = _inner_type_promotion(\, eltype(A), eltype(B))
+        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
+            ldiv!(convert(AbstractArray{TAB}, A), copyto!(C, B))
         else
-            ldiv!(similar(B, TAB, size(B)), A, B)
+            ldiv!(C, A, B)
         end
     end
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
     @eval function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
         require_one_based_indexing(B)
         TAB = promote_op(\, eltype(A), eltype(B))
+        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
+            ldiv!(convert(AbstractArray{TAB}, A), copyto!(C, B))
         else
-            ldiv!(similar(B, TAB, size(B)), A, B)
+            ldiv!(C, A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
     @eval function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
         require_one_based_indexing(A)
         TAB = _inner_type_promotion(/, eltype(A), eltype(B))
+        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
+            rdiv!(copyto!(C, A), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(similar(A, TAB, size(A)), A, B)
+            _rdiv!(C, A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
     @eval function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
         require_one_based_indexing(A)
         TAB = promote_op(/, eltype(A), eltype(B))
+        C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
-            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
+            rdiv!(copyto!(C, A), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(similar(A, TAB, size(A)), A, B)
+            _rdiv!(C, A, B)
         end
     end
 end
 function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     require_one_based_indexing(A)
     TAB = promote_op(matprod, eltype(A), eltype(B))
+    C = matprod_dest(A, B, TAB)
     if TAB <: BlasFloat
-        rmul!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
+        rmul!(copyto!(C, A), convert(AbstractArray{TAB}, B))
     else
-        mul!(matprod_dest(A, B, TAB), A, B)
+        mul!(C, A, B)
     end
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1336,16 +1336,16 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
 end
 
 # multiplication
-generic_trimatmul!(c::StridedVector{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, b::AbstractVector{T}) where {T<:BlasFloat} =
+generic_trimatmul!(c::StridedVector{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, b::AbstractVector) where {T<:BlasFloat} =
     BLAS.trmv!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, c === b ? c : copy!(c, b))
-function generic_trimatmul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractMatrix{T}) where {T<:BlasFloat}
+function generic_trimatmul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractMatrix) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
         BLAS.trmm!('L', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), A, C === B ? C : copy!(C, B))
     else # incompatible with BLAS
         @invoke generic_trimatmul!(C::AbstractMatrix, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractMatrix)
     end
 end
-function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
+function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
         BLAS.trmm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copy!(C, A))
     else # incompatible with BLAS
@@ -1353,14 +1353,14 @@ function generic_mattrimul!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function,
     end
 end
 # division
-function generic_trimatdiv!(C::StridedVecOrMat{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractVecOrMat{T}) where {T<:BlasFloat}
+function generic_trimatdiv!(C::StridedVecOrMat{T}, uploc, isunitc, tfun::Function, A::StridedMatrix{T}, B::AbstractVecOrMat) where {T<:BlasFloat}
     if stride(C,1) == stride(A,1) == 1
         LAPACK.trtrs!(uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, A, C === B ? C : _copy_or_copyto!(C, B))
     else # incompatible with LAPACK
         @invoke generic_trimatdiv!(C::AbstractVecOrMat, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::AbstractVecOrMat)
     end
 end
-function generic_mattridiv!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat}
+function generic_mattridiv!(C::StridedMatrix{T}, uploc, isunitc, tfun::Function, A::AbstractMatrix, B::StridedMatrix{T}) where {T<:BlasFloat}
     if stride(C,1) == stride(B,1) == 1
         BLAS.trsm!('R', uploc, tfun === identity ? 'N' : tfun === transpose ? 'T' : 'C', isunitc, one(T), B, C === A ? C : copy!(C, A))
     else # incompatible with BLAS
@@ -1977,33 +1977,16 @@ matldiv_dest(A::UnitUpperOrUnitLowerTriangular, B) =
 matrdiv_dest(A, B::UnitUpperOrUnitLowerTriangular) =
     similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))    
 ## The general promotion methods
-for mat in (:AbstractVector, :AbstractMatrix)
-    @eval function mul(A::UpperOrLowerTriangular, B::$mat)
-        require_one_based_indexing(B)
-        if size(A, 2) != size(B, 1)
-            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
-        end
-        T = promote_op(matprod, eltype(A), eltype(B))
-        C = matprod_dest(A, B, T)
-        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
-        mul!(C, Ap, B)
+function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
+    require_one_based_indexing(B)
+    if size(A, 2) != size(B, 1)
+        throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
     end
-    @eval function \(A::UpperOrLowerTriangular, B::$mat)
-        require_one_based_indexing(B)
-        C = matldiv_dest(A, B)
-        T = eltype(C)
-        # promote eltype of A in case BLAS becomes accessible
-        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
-        ldiv!(C, Ap, B)
-    end
-    @eval function /(A::$mat, B::UpperOrLowerTriangular)
-        require_one_based_indexing(A)
-        C = matrdiv_dest(A, B)
-        T = eltype(C)
-        # promote eltype of B in case BLAS becomes accessible
-        Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
-        _rdiv!(C, A, Bp)
-    end
+    T = promote_op(matprod, eltype(A), eltype(B))
+    C = matprod_dest(A, B, T)
+    Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+    mul!(C, Ap, B)
+    postop_proc(C, Ap, B)
 end
 function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     require_one_based_indexing(A)
@@ -2014,49 +1997,46 @@ function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     C = matprod_dest(A, B, T)
     Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
     mul!(C, A, Bp)
+    postop_proc(C, A, Bp)
 end
-
-## Some Triangular-Triangular cases. We might want to write tailored methods
-## for these cases, but I'm not sure it is worth it.
-# disambiguation from the above methods
 mul(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
     @invoke mul(A::typeof(A), B::AbstractMatrix)
-for f in (:mul, :\)
-    @eval begin
-        ($f)(A::LowerTriangular, B::LowerTriangular) =
-            LowerTriangular(@invoke $f(A::LowerTriangular, B::AbstractMatrix))
-        ($f)(A::LowerTriangular, B::UnitLowerTriangular) =
-            LowerTriangular(@invoke $f(A::LowerTriangular, B::AbstractMatrix))
-        ($f)(A::UnitLowerTriangular, B::LowerTriangular) =
-            LowerTriangular(@invoke $f(A::UnitLowerTriangular, B::AbstractMatrix))
-        ($f)(A::UnitLowerTriangular, B::UnitLowerTriangular) =
-            UnitLowerTriangular(@invoke $f(A::UnitLowerTriangular, B::AbstractMatrix))
-        ($f)(A::UpperTriangular, B::UpperTriangular) =
-            UpperTriangular(@invoke $f(A::UpperTriangular, B::AbstractMatrix))
-        ($f)(A::UpperTriangular, B::UnitUpperTriangular) =
-            UpperTriangular(@invoke $f(A::UpperTriangular, B::AbstractMatrix))
-        ($f)(A::UnitUpperTriangular, B::UpperTriangular) =
-            UpperTriangular(@invoke $f(A::UnitUpperTriangular, B::AbstractMatrix))
-        ($f)(A::UnitUpperTriangular, B::UnitUpperTriangular) =
-            UnitUpperTriangular(@invoke $f(A::UnitUpperTriangular, B::AbstractMatrix))
+
+for mat in (:AbstractVector, :AbstractMatrix)
+    @eval function \(A::UpperOrLowerTriangular, B::$mat)
+        require_one_based_indexing(B)
+        C = matldiv_dest(A, B)
+        T = eltype(C)
+        # promote eltype of A in case BLAS becomes accessible
+        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+        ldiv!(C, Ap, B)
+        postop_proc(C, Ap, B)
+    end
+    @eval function /(A::$mat, B::UpperOrLowerTriangular)
+        require_one_based_indexing(A)
+        C = matrdiv_dest(A, B)
+        T = eltype(C)
+        # promote eltype of B in case BLAS becomes accessible
+        Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
+        _rdiv!(C, A, Bp)
+        postop_proc(C, A, Bp)
     end
 end
-(/)(A::LowerTriangular, B::LowerTriangular) =
-    LowerTriangular(@invoke /(A::AbstractMatrix, B::LowerTriangular))
-(/)(A::LowerTriangular, B::UnitLowerTriangular) =
-    LowerTriangular(@invoke /(A::AbstractMatrix, B::UnitLowerTriangular))
-(/)(A::UnitLowerTriangular, B::LowerTriangular) =
-    LowerTriangular(@invoke /(A::AbstractMatrix, B::LowerTriangular))
-(/)(A::UnitLowerTriangular, B::UnitLowerTriangular) =
-    UnitLowerTriangular(@invoke /(A::AbstractMatrix, B::UnitLowerTriangular))
-(/)(A::UpperTriangular, B::UpperTriangular) =
-    UpperTriangular(@invoke /(A::AbstractMatrix, B::UpperTriangular))
-(/)(A::UpperTriangular, B::UnitUpperTriangular) =
-    UpperTriangular(@invoke /(A::AbstractMatrix, B::UnitUpperTriangular))
-(/)(A::UnitUpperTriangular, B::UpperTriangular) =
-    UpperTriangular(@invoke /(A::AbstractMatrix, B::UpperTriangular))
-(/)(A::UnitUpperTriangular, B::UnitUpperTriangular) =
-    UnitUpperTriangular(@invoke /(A::AbstractMatrix, B::UnitUpperTriangular))
+\(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
+    @invoke \(A::typeof(A), B::AbstractMatrix)
+/(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
+    @invoke /(A::AbstractMatrix, B::typeof(B))
+
+
+postop_proc(C, _, _) = C
+postop_proc(C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)
+postop_proc(C, ::UnitLowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(C, ::UnitLowerTriangular, ::UnitLowerTriangular) = UnitLowerTriangular(C)
+postop_proc(C, ::UpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(C, ::UpperTriangular, ::UnitUpperTriangular) = UpperTriangular(C)
+postop_proc(C, ::UnitUpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(C, ::UnitUpperTriangular, ::UnitUpperTriangular) = UnitUpperTriangular(C)
 
 # Complex matrix power for upper triangular factor, see:
 #   Higham and Lin, "A Schur-Padé algorithm for fractional powers of a Matrix",

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1970,6 +1970,12 @@ _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA<:Integer,TB<:Integer
     promote_op(matprod, TA, TB)
 _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA,TB} =
     promote_op(op, TA, TB)
+
+matldiv_dest(A::UnitUpperOrUnitLowerTriangular, B) =
+    similar(B, _inner_type_promotion(\, eltype(A), eltype(B)), size(B))
+
+matrdiv_dest(A, B::UnitUpperOrUnitLowerTriangular) =
+    similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))    
 ## The general promotion methods
 for mat in (:AbstractVector, :AbstractMatrix)
     @eval function mul(A::UpperOrLowerTriangular, B::$mat)
@@ -1977,53 +1983,26 @@ for mat in (:AbstractVector, :AbstractMatrix)
         if size(A, 2) != size(B, 1)
             throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
         end
-        TAB = promote_op(matprod, eltype(A), eltype(B))
-        C = matprod_dest(A, B, TAB)
-        if TAB <: BlasFloat
-            lmul!(convert(AbstractArray{TAB}, A), copyto!(C, B))
-        else
-            mul!(C, A, B)
-        end
+        T = promote_op(matprod, eltype(A), eltype(B))
+        C = matprod_dest(A, B, T)
+        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+        mul!(C, Ap, B)
     end
-    ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
-    @eval function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
+    @eval function \(A::UpperOrLowerTriangular, B::$mat)
         require_one_based_indexing(B)
-        TAB = _inner_type_promotion(\, eltype(A), eltype(B))
-        if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
-        else
-            ldiv!(similar(B, TAB, size(B)), A, B)
-        end
+        C = matldiv_dest(A, B)
+        T = eltype(C)
+        # promote eltype of A in case BLAS becomes accessible
+        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+        ldiv!(C, Ap, B)
     end
-    ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
-    @eval function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
-        require_one_based_indexing(B)
-        TAB = promote_op(\, eltype(A), eltype(B))
-        if TAB <: BlasFloat
-            ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
-        else
-            ldiv!(similar(B, TAB, size(B)), A, B)
-        end
-    end
-    ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
-    @eval function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
+    @eval function /(A::$mat, B::UpperOrLowerTriangular)
         require_one_based_indexing(A)
-        TAB = _inner_type_promotion(/, eltype(A), eltype(B))
-        if TAB <: BlasFloat
-            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
-        else
-            _rdiv!(similar(A, TAB, size(A)), A, B)
-        end
-    end
-    ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
-    @eval function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
-        require_one_based_indexing(A)
-        TAB = promote_op(/, eltype(A), eltype(B))
-        if TAB <: BlasFloat
-            rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
-        else
-            _rdiv!(similar(A, TAB, size(A)), A, B)
-        end
+        C = matrdiv_dest(A, B)
+        T = eltype(C)
+        # promote eltype of B in case BLAS becomes accessible
+        Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
+        _rdiv!(C, A, Bp)
     end
 end
 function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
@@ -2031,13 +2010,10 @@ function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     if size(B, 1) != size(A, 2)
         throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
     end
-    TAB = promote_op(matprod, eltype(A), eltype(B))
-    C = matprod_dest(A, B, TAB)
-    if TAB <: BlasFloat
-        rmul!(copyto!(C, A), convert(AbstractArray{TAB}, B))
-    else
-        mul!(C, A, B)
-    end
+    T = promote_op(matprod, eltype(A), eltype(B))
+    C = matprod_dest(A, B, T)
+    Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
+    mul!(C, A, Bp)
 end
 
 ## Some Triangular-Triangular cases. We might want to write tailored methods

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -3056,18 +3056,15 @@ end
 factorize(A::AbstractTriangular) = A
 
 # disambiguation methods: /(Adjoint of AbsVec, <:AbstractTriangular)
-/(u::AdjointAbsVec, A::Union{LowerTriangular,UpperTriangular}) = adjoint(adjoint(A) \ u.parent)
-/(u::AdjointAbsVec, A::Union{UnitLowerTriangular,UnitUpperTriangular}) = adjoint(adjoint(A) \ u.parent)
+/(u::AdjointAbsVec, A::UpperOrLowerTriangular) = adjoint(adjoint(A) \ u.parent)
 # disambiguation methods: /(Transpose of AbsVec, <:AbstractTriangular)
-/(u::TransposeAbsVec, A::Union{LowerTriangular,UpperTriangular}) = transpose(transpose(A) \ u.parent)
-/(u::TransposeAbsVec, A::Union{UnitLowerTriangular,UnitUpperTriangular}) = transpose(transpose(A) \ u.parent)
+/(u::TransposeAbsVec, A::UpperOrLowerTriangular) = transpose(transpose(A) \ u.parent)
 # disambiguation methods: /(Transpose of AbsVec, Adj/Trans of <:AbstractTriangular)
 for (tritype, comptritype) in ((:LowerTriangular, :UpperTriangular),
                                (:UnitLowerTriangular, :UnitUpperTriangular),
                                (:UpperTriangular, :LowerTriangular),
                                (:UnitUpperTriangular, :UnitLowerTriangular))
     @eval /(u::TransposeAbsVec, A::$tritype{<:Any,<:Adjoint}) = transpose($comptritype(conj(parent(parent(A)))) \ u.parent)
-    @eval /(u::TransposeAbsVec, A::$tritype{<:Any,<:Transpose}) = transpose(transpose(A) \ u.parent)
 end
 
 # Cube root of a 2x2 real-valued matrix with complex conjugate eigenvalues and equal diagonal values.

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1974,6 +1974,9 @@ _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA,TB} =
 for mat in (:AbstractVector, :AbstractMatrix)
     @eval function mul(A::UpperOrLowerTriangular, B::$mat)
         require_one_based_indexing(B)
+        if size(A, 2) != size(B, 1)
+            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
+        end
         TAB = promote_op(matprod, eltype(A), eltype(B))
         C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
@@ -1985,6 +1988,9 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
     @eval function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
         require_one_based_indexing(B)
+        if size(A, 2) != size(B, 1)
+            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
+        end
         TAB = _inner_type_promotion(\, eltype(A), eltype(B))
         C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
@@ -1996,6 +2002,9 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
     @eval function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
         require_one_based_indexing(B)
+        if size(A, 2) != size(B, 1)
+            throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
+        end
         TAB = promote_op(\, eltype(A), eltype(B))
         C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
@@ -2007,6 +2016,9 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
     @eval function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
         require_one_based_indexing(A)
+        if size(B, 1) != size(A, 2)
+            throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
+        end
         TAB = _inner_type_promotion(/, eltype(A), eltype(B))
         C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
@@ -2018,6 +2030,9 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
     @eval function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
         require_one_based_indexing(A)
+        if size(B, 1) != size(A, 2)
+            throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
+        end
         TAB = promote_op(/, eltype(A), eltype(B))
         C = matprod_dest(A, B, TAB)
         if TAB <: BlasFloat
@@ -2029,6 +2044,9 @@ for mat in (:AbstractVector, :AbstractMatrix)
 end
 function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     require_one_based_indexing(A)
+    if size(B, 1) != size(A, 2)
+        throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
+    end
     TAB = promote_op(matprod, eltype(A), eltype(B))
     C = matprod_dest(A, B, TAB)
     if TAB <: BlasFloat

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1992,7 +1992,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
         if TAB <: BlasFloat
             ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
         else
-            ldiv!(matprod_dest(A, B, TAB), A, B)
+            ldiv!(similar(B, TAB, size(B)), A, B)
         end
     end
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
@@ -2002,7 +2002,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
         if TAB <: BlasFloat
             ldiv!(convert(AbstractArray{TAB}, A), copy_similar(B, TAB))
         else
-            ldiv!(matprod_dest(A, B, TAB), A, B)
+            ldiv!(similar(B, TAB, size(B)), A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
@@ -2012,7 +2012,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
         if TAB <: BlasFloat
             rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(matprod_dest(A, B, TAB), A, B)
+            _rdiv!(similar(A, TAB, size(A)), A, B)
         end
     end
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
@@ -2022,7 +2022,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
         if TAB <: BlasFloat
             rdiv!(copy_similar(A, TAB), convert(AbstractArray{TAB}, B))
         else
-            _rdiv!(matprod_dest(A, B, TAB), A, B)
+            _rdiv!(similar(A, TAB, size(A)), A, B)
         end
     end
 end


### PR DESCRIPTION
Division by a triangular matrix is like multiplying by a triangular matrix, so we should be using the `matprod_dest` mechanism throughout. (EDIT: While this is technically true, inverses of sparse triangular matrices may still be "dense", so multiplication and division with triangular matrices are still different).

This fixes the inconsistency that left-division of a sparse matrix by a triangular matrix yields a dense matrix (hard-coded in SparseArrays.jl), whereas right-division yields a sparse matrix (because it is using the fallback). EDIT: This inconsistency will be resolved once the corresponding `mat[l/r]div_dest` methods are defined in SparseArrays.jl.