### PR TITLE
buildkite: add per-job timeouts and automatic retries

### DIFF
--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -6,9 +6,9 @@ steps:
     retry:
       automatic:
         - exit_status: -1
-          limit: 2
+          limit: 1
         - signal_reason: agent_stop
-          limit: 2
+          limit: 1
     plugins:
       # Julia installation outside the sandbox
       - JuliaCI/julia#v1:
@@ -35,9 +35,9 @@ steps:
     retry:
       automatic:
         - exit_status: -1
-          limit: 2
+          limit: 1
         - signal_reason: agent_stop
-          limit: 2
+          limit: 1
     plugins:
       # Julia installation outside the sandbox
       - JuliaCI/julia#v1:
@@ -65,9 +65,9 @@ steps:
     retry:
       automatic:
         - exit_status: -1
-          limit: 2
+          limit: 1
         - signal_reason: agent_stop
-          limit: 2
+          limit: 1
     plugins:
       - JuliaCI/julia#v1:
           version: "nightly"
@@ -85,9 +85,9 @@ steps:
     retry:
       automatic:
         - exit_status: -1
-          limit: 2
+          limit: 1
         - signal_reason: agent_stop
-          limit: 2
+          limit: 1
     plugins:
       - JuliaCI/julia#v1:
           version: "nightly"

--- a/.buildkite/runtests.yml
+++ b/.buildkite/runtests.yml
@@ -2,6 +2,13 @@
 steps:
   # Linux x86
   - label: ":linux: linux-i686"
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - signal_reason: agent_stop
+          limit: 2
     plugins:
       # Julia installation outside the sandbox
       - JuliaCI/julia#v1:
@@ -24,6 +31,13 @@ steps:
       cpuset_limited: "true"
   # Linux x86_64
   - label: ":linux: linux-x86_64"
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - signal_reason: agent_stop
+          limit: 2
     plugins:
       # Julia installation outside the sandbox
       - JuliaCI/julia#v1:
@@ -47,6 +61,13 @@ steps:
       cpuset_limited: "true"
   # macOS aarch64
   - label: ":macos: macos-aarch64"
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - signal_reason: agent_stop
+          limit: 2
     plugins:
       - JuliaCI/julia#v1:
           version: "nightly"
@@ -60,6 +81,13 @@ steps:
       arch: "aarch64"
   # windows x86_64
   - label: ":windows: windows-x86_64"
+    timeout_in_minutes: 90
+    retry:
+      automatic:
+        - exit_status: -1
+          limit: 2
+        - signal_reason: agent_stop
+          limit: 2
     plugins:
       - JuliaCI/julia#v1:
           version: "nightly"


### PR DESCRIPTION
## Summary
- Add `timeout_in_minutes: 90` to all four Buildkite jobs so a hung test can't hold a shared agent indefinitely.
- Add `retry.automatic` for `exit_status: -1` and `signal_reason: agent_stop` (limit 2) so transient agent disconnects self-heal instead of turning PRs red.

## Motivation
Recent dependabot PR #1585 went red because the `macos-aarch64` agent dropped ~4 seconds into the job — a clear infra flake, not a test failure. With these settings Buildkite would have retried automatically and the PR would have stayed green. The `timeout_in_minutes` is defensive: today there's no upper bound on how long a stuck job can hold an agent.

## Test plan
- [ ] Confirm the four jobs still run on this PR's Buildkite build
- [ ] Confirm the `retry` block parses and shows up in the Buildkite UI for each step

🤖 Generated with [Claude Code](https://claude.com/claude-code)