### PR TITLE
unify mat*_dest functions

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -664,20 +664,20 @@ _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B
 # destination type for matmul
 # diagonal is special, as it does not change the structure of the other matrix
 # we call similar without a size to preserve the type of the matrix wherever possible
-# reroute through _matprod_dest_diag to allow speicalizing on the type of the StructuredMatrix
+# reroute through _matprod_dest_diag to allow specializing on the type of the StructuredMatrix
 # without defining methods for both the orderings
-matprod_dest(A, B::Diagonal, TS) = _matprod_dest_diag(A, TS)
-matprod_dest(A::Diagonal, B, TS) = _matprod_dest_diag(B, TS)
-matprod_dest(A::Diagonal, B::AbstractVector, TS) = _matprod_dest_diag(B, TS)
-matprod_dest(A::Diagonal, B::Diagonal, TS) = _matprod_dest_diag(B, TS)
+_matprod_type(A, B) = promote_op(matprod, eltype(A), eltype(B))
+matop_dest(::typeof(matprod), A, B::Diagonal) = _matprod_dest_diag(A, _matprod_type(A, B))
+matop_dest(::typeof(matprod), A::Diagonal, B) = _matprod_dest_diag(B, _matprod_type(A, B))
+matop_dest(::typeof(matprod), A::Diagonal, B::Diagonal) = similar(B, _matprod_type(A, B))
+matop_dest(::typeof(matprod), A::Diagonal, B::AbstractVector) = similar(B, _matprod_type(A, B))
 _matprod_dest_diag(A, TS) = similar(A, TS)
-_matprod_dest_diag(A::HermOrSym, TS) = similar(A, TS, size(A))
+_matprod_dest_diag(A::HermOrSym, TS) = similar(parent(A), TS)
 _matprod_dest_diag(A::UnitUpperTriangular, TS) = UpperTriangular(similar(parent(A), TS))
 _matprod_dest_diag(A::UnitLowerTriangular, TS) = LowerTriangular(similar(parent(A), TS))
 function _matprod_dest_diag(A::SymTridiagonal, TS)
-    n = size(A, 1)
-    ev = similar(A, TS, max(0, n-1))
-    dv = similar(A, TS, n)
+    ev = similar(A.ev, TS)
+    dv = similar(A.dv, TS)
     Tridiagonal(ev, dv, similar(ev))
 end
 

--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -667,10 +667,10 @@ _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B
 # reroute through _matprod_dest_diag to allow specializing on the type of the StructuredMatrix
 # without defining methods for both the orderings
 _matprod_type(A, B) = promote_op(matprod, eltype(A), eltype(B))
-matop_dest(::typeof(matprod), A, B::Diagonal) = _matprod_dest_diag(A, _matprod_type(A, B))
-matop_dest(::typeof(matprod), A::Diagonal, B) = _matprod_dest_diag(B, _matprod_type(A, B))
-matop_dest(::typeof(matprod), A::Diagonal, B::Diagonal) = similar(B, _matprod_type(A, B))
-matop_dest(::typeof(matprod), A::Diagonal, B::AbstractVector) = similar(B, _matprod_type(A, B))
+matop_dest(::typeof(*), A, B::Diagonal) = _matprod_dest_diag(A, _matprod_type(A, B))
+matop_dest(::typeof(*), A::Diagonal, B) = _matprod_dest_diag(B, _matprod_type(A, B))
+matop_dest(::typeof(*), A::Diagonal, B::Diagonal) = similar(B, _matprod_type(A, B))
+matop_dest(::typeof(*), A::Diagonal, B::AbstractVector) = similar(B, _matprod_type(A, B))
 _matprod_dest_diag(A, TS) = similar(A, TS)
 _matprod_dest_diag(A::HermOrSym, TS) = similar(parent(A), TS)
 _matprod_dest_diag(A::UnitUpperTriangular, TS) = UpperTriangular(similar(parent(A), TS))

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1341,7 +1341,7 @@ end
 
 ### Generic promotion methods and fallbacks
 \(A::Bidiagonal, B::AbstractVecOrMat) =
-    postop_proc(ldiv!(matldiv_dest(A, B), A, B), A, B)
+    postop_proc(ldiv!(matop_dest(\, A, B), A, B), A, B)
 
 postop_proc(C, B::Bidiagonal, ::UpperOrUnitUpperTriangular) = B.uplo == 'U' ? UpperTriangular(C) : C
 postop_proc(C, ::UpperOrUnitUpperTriangular, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : C
@@ -1394,7 +1394,7 @@ end
 rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(A, A, B)
 
 /(A::AbstractMatrix, B::Bidiagonal) =
-    postop_proc(_rdiv!(matrdiv_dest(A, B), A, B), A, B)
+    postop_proc(_rdiv!(matop_dest(/, A, B), A, B), A, B)
 
 # disambiguation
 /(A::AdjointAbsVec, B::Bidiagonal) = adjoint(adjoint(B) \ parent(A))

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1798,8 +1798,8 @@ julia> N = pinv(M)
 
 julia> M * N
 2×2 Matrix{Float64}:
- 1.0          -2.22045e-16
- 4.44089e-16   1.0
+ 1.0          -4.44089e-16
+ 2.22045e-16   1.0
 ```
 
 [^pr1387]: PR 1387, "stable pinv least-squares", [LinearAlgebra.jl#1387](https://github.com/JuliaLang/LinearAlgebra.jl/pull/1387)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -606,10 +606,10 @@ function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
     return Diagonal(Da.diag .* Db.diag .* Dc.diag)
 end
 
-matrdiv_dest(A, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)))
-matrdiv_dest(A::HermOrSym, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)), size(A))
+matop_dest(::typeof(/), A, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)))
+matop_dest(::typeof(/), A::HermOrSym, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)), size(A))
 
-/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matrdiv_dest(A, D), A, D)
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matop_dest(/, A, D), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -630,10 +630,10 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-matldiv_dest(D::Diagonal, B) = similar(B, promote_op(\, eltype(D), eltype(B)))
-matldiv_dest(D::Diagonal, B::HermOrSym) = similar(B, promote_op(\, eltype(D), eltype(B)), size(B))
+matop_dest(::typeof(\), D::Diagonal, B) = similar(B, promote_op(\, eltype(D), eltype(B)))
+matop_dest(::typeof(\), D::Diagonal, B::HermOrSym) = similar(B, promote_op(\, eltype(D), eltype(B)), size(B))
 
-\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matldiv_dest(D, B), D, B)
+\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matop_dest(\, D, B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
@@ -680,12 +680,11 @@ ldiv!(Dc::Diagonal, Da::Diagonal, Db::Diagonal) = Diagonal(ldiv!(Dc.diag, Da, Db
 @propagate_inbounds _getldiag(T::Tridiagonal, i) = T.dl[i]
 @propagate_inbounds _getldiag(S::SymTridiagonal, i) = transpose(S.ev[i])
 
-function matldiv_dest(D::Diagonal, S::SymTridiagonal)
+function matop_dest(::typeof(\), D::Diagonal, S::SymTridiagonal)
     T = promote_op(\, eltype(D), eltype(S))
-    du = similar(S.ev, T, max(length(S.dv)-1, 0))
-    d  = similar(S.dv, T, length(S.dv))
-    dl = similar(S.ev, T, max(length(S.dv)-1, 0))
-    return Tridiagonal(dl, d, du)
+    du = similar(S.ev, T)
+    d  = similar(S.dv, T)
+    return Tridiagonal(similar(du), d, du)
 end
 
 function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal})
@@ -717,7 +716,12 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
     return T
 end
 
-matrdiv_dest(S::SymTridiagonal, D::Diagonal) = matldiv_dest(D, S)
+function matop_dest(::typeof(/), S::SymTridiagonal, D::Diagonal)
+    T = promote_op(/, eltype(S), eltype(D))
+    du = similar(S.ev, T)
+    d  = similar(S.dv, T)
+    return Tridiagonal(similar(du), d, du)
+end
 
 function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagonal)
     n = size(S, 2)

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -58,7 +58,7 @@ function (*)(A::StridedMaybeAdjOrTransMat{T}, x::StridedVector{S}) where {T<:Bla
 end
 function (*)(A::AbstractMatrix, x::AbstractVector)
     matmul_size_check(size(A), size(x))
-    mul!(matop_dest(matprod, A, x), A, x)
+    mul!(matop_dest(*, A, x), A, x)
 end
 
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
@@ -118,7 +118,7 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 mul(A::AbstractMatrix, B::AbstractMatrix) = _mul(A, B)
 function _mul(A::AbstractMatrix, B::AbstractMatrix)
     matmul_size_check(size(A), size(B))
-    mul!(matop_dest(matprod, A, B), A, B)
+    mul!(matop_dest(*, A, B), A, B)
 end
 
 """
@@ -130,7 +130,7 @@ This function is only kept for backwards compatibility, use instead `matop_dest`
 !!! compat
     This function requires at least Julia 1.11
 """
-matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(matprod, A, B))
+matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(*, A, B))
 
 """
     matop_dest(op, A, B)
@@ -141,7 +141,7 @@ Return an appropriate `AbstractArray` that may be used to store the result of `o
     This function requires at least Julia 1.14
 """
 matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
-matop_dest(::typeof(matprod), A, x::AbstractVector) = similar(x, promote_op(matprod, eltype(A), eltype(x)), axes(A, 1))
+matop_dest(::typeof(*), A, x::AbstractVector) = similar(x, promote_op(matprod, eltype(A), eltype(x)), axes(A, 1))
 
 matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
 matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -58,8 +58,7 @@ function (*)(A::StridedMaybeAdjOrTransMat{T}, x::StridedVector{S}) where {T<:Bla
 end
 function (*)(A::AbstractMatrix, x::AbstractVector)
     matmul_size_check(size(A), size(x))
-    TS = promote_op(matprod, eltype(A), eltype(x))
-    mul!(matprod_dest(A, x, TS), A, x)
+    mul!(matop_dest(matprod, A, x), A, x)
 end
 
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
@@ -119,41 +118,33 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 mul(A::AbstractMatrix, B::AbstractMatrix) = _mul(A, B)
 function _mul(A::AbstractMatrix, B::AbstractMatrix)
     matmul_size_check(size(A), size(B))
-    TS = promote_op(matprod, eltype(A), eltype(B))
-    mul!(matprod_dest(A, B, TS), A, B)
+    mul!(matop_dest(matprod, A, B), A, B)
 end
 
 """
     matprod_dest(A, B, T)
 
 Return an appropriate `AbstractArray` with element type `T` that may be used to store the result of `A * B`.
+This function is only kept for backwards compatibility, use instead `matop_dest`.
 
 !!! compat
     This function requires at least Julia 1.11
 """
-matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
-matprod_dest(A, x::AbstractVector, T) = similar(x, T, axes(A,1))
+matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(matprod, A, B))
 
 """
-    matldiv_dest(A, B)
+    matop_dest(op, A, B)
 
-Return an appropriate `AbstractArray` that may be used to store the result of `A \\ B`.
+Return an appropriate `AbstractArray` that may be used to store the result of `op(A, B)`.
 
 !!! compat
     This function requires at least Julia 1.14
 """
-matldiv_dest(A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
+matop_dest(::typeof(matprod), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
+matop_dest(::typeof(matprod), A, x::AbstractVector) = similar(x, promote_op(matprod, eltype(A), eltype(x)), axes(A, 1))
 
-"""
-    matrdiv_dest(A, B)
-
-Return an appropriate `AbstractArray` that may be used to store the result of `A / B`.
-
-!!! compat
-    This function requires at least Julia 1.14
-"""
-matrdiv_dest(A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
-
+matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
+matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})
 # which is better handled by reinterpreting rather than promotion

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -140,7 +140,7 @@ Return an appropriate `AbstractArray` that may be used to store the result of `o
 !!! compat
     This function requires at least Julia 1.14
 """
-matop_dest(::typeof(matprod), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
 matop_dest(::typeof(matprod), A, x::AbstractVector) = similar(x, promote_op(matprod, eltype(A), eltype(x)), axes(A, 1))
 
 matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1971,10 +1971,10 @@ _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA<:Integer,TB<:Integer
 _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA,TB} =
     promote_op(op, TA, TB)
 
-matldiv_dest(A::UnitUpperOrUnitLowerTriangular, B) =
+matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B) =
     similar(B, _inner_type_promotion(\, eltype(A), eltype(B)), size(B))
 
-matrdiv_dest(A, B::UnitUpperOrUnitLowerTriangular) =
+matop_dest(::typeof(/), A, B::UnitUpperOrUnitLowerTriangular) =
     similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))    
 ## The general promotion methods
 function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
@@ -1982,9 +1982,8 @@ function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
     if size(A, 2) != size(B, 1)
         throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
     end
-    T = promote_op(matprod, eltype(A), eltype(B))
-    C = matprod_dest(A, B, T)
-    Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+    C = matop_dest(matprod, A, B)
+    Ap = (eltype(C) <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, A) : A
     mul!(C, Ap, B)
     postop_proc(C, Ap, B)
 end
@@ -1993,9 +1992,8 @@ function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     if size(B, 1) != size(A, 2)
         throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
     end
-    T = promote_op(matprod, eltype(A), eltype(B))
-    C = matprod_dest(A, B, T)
-    Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
+    C = matop_dest(matprod, A, B)
+    Bp = (eltype(C) <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, B) : B
     mul!(C, A, Bp)
     postop_proc(C, A, Bp)
 end
@@ -2005,19 +2003,17 @@ mul(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
 for mat in (:AbstractVector, :AbstractMatrix)
     @eval function \(A::UpperOrLowerTriangular, B::$mat)
         require_one_based_indexing(B)
-        C = matldiv_dest(A, B)
-        T = eltype(C)
+        C = matop_dest(\, A, B)
         # promote eltype of A in case BLAS becomes accessible
-        Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
+        Ap = (eltype(C) <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, A) : A
         ldiv!(C, Ap, B)
         postop_proc(C, Ap, B)
     end
     @eval function /(A::$mat, B::UpperOrLowerTriangular)
         require_one_based_indexing(A)
-        C = matrdiv_dest(A, B)
-        T = eltype(C)
+        C = matop_dest(/, A, B)
         # promote eltype of B in case BLAS becomes accessible
-        Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
+        Bp = (eltype(C) <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, B) : B
         _rdiv!(C, A, Bp)
         postop_proc(C, A, Bp)
     end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1982,7 +1982,7 @@ function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
     if size(A, 2) != size(B, 1)
         throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
     end
-    C = matop_dest(matprod, A, B)
+    C = matop_dest(*, A, B)
     Ap = (eltype(C) <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, A) : A
     mul!(C, Ap, B)
     postop_proc(C, Ap, B)
@@ -1992,7 +1992,7 @@ function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     if size(B, 1) != size(A, 2)
         throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
     end
-    C = matop_dest(matprod, A, B)
+    C = matop_dest(*, A, B)
     Bp = (eltype(C) <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{eltype(C)}, B) : B
     mul!(C, A, Bp)
     postop_proc(C, A, Bp)


### PR DESCRIPTION
Follow-up to #1578. The goal is to have a more consistent interface for packages using the mat_dest mechanism.