### PR TITLE
Move dispatch in matrix operations to lower-level functions

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -666,14 +666,14 @@ _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B
 # we call similar without a size to preserve the type of the matrix wherever possible
 # reroute through _matprod_dest_diag to allow speicalizing on the type of the StructuredMatrix
 # without defining methods for both the orderings
-matprod_dest(A, B::Diagonal, TS) = _matprod_dest_diag(A, TS)
-matprod_dest(A::Diagonal, B, TS) = _matprod_dest_diag(B, TS)
-matprod_dest(A::Diagonal, B::AbstractVector, TS) = _matprod_dest_diag(B, TS)
-matprod_dest(A::Diagonal, B::Diagonal, TS) = _matprod_dest_diag(B, TS)
+matop_dest(::typeof(*), A, B::Diagonal) = _matprod_dest_diag(A, promote_op(matprod, eltype(A), eltype(B)))
+matop_dest(::typeof(*), A::Diagonal, B) = _matprod_dest_diag(B, promote_op(matprod, eltype(A), eltype(B)))
+matop_dest(::typeof(*), A::Diagonal, B::Diagonal) = _matprod_dest_diag(B, promote_op(matprod, eltype(A), eltype(B)))
+matop_dest(::typeof(*), A::Diagonal, b::AbstractVector) = _matprod_dest_diag(b, promote_op(matprod, eltype(A), eltype(b)))
 _matprod_dest_diag(A, TS) = similar(A, TS)
 _matprod_dest_diag(A::HermOrSym, TS) = similar(A, TS, size(A))
-_matprod_dest_diag(A::UnitUpperTriangular, TS) = UpperTriangular(similar(parent(A), TS))
-_matprod_dest_diag(A::UnitLowerTriangular, TS) = LowerTriangular(similar(parent(A), TS))
+_matprod_dest_diag(A::UpperOrUnitUpperTriangular, TS) = UpperTriangular(similar(parent(A), TS))
+_matprod_dest_diag(A::LowerOrUnitLowerTriangular, TS) = LowerTriangular(similar(parent(A), TS))
 function _matprod_dest_diag(A::SymTridiagonal, TS)
     n = size(A, 1)
     ev = similar(A, TS, max(0, n-1))

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1267,9 +1267,6 @@ function _dibimul_nonzeroalpha!(C::Bidiagonal, A::Diagonal, B::Bidiagonal, _add)
     C
 end
 
-mul(A::UpperOrLowerTriangular, B::Bidiagonal) = (C = _mul(A, B); postop_proc(C, A, B))
-mul(A::Bidiagonal, B::UpperOrLowerTriangular) = (C = _mul(A, B); postop_proc(C, A, B))
-
 function dot(x::AbstractVector, B::Bidiagonal, y::AbstractVector)
     require_one_based_indexing(x, y)
     nx, ny = length(x), length(y)
@@ -1341,14 +1338,18 @@ end
 
 ### Generic promotion methods and fallbacks
 \(A::Bidiagonal, B::AbstractVecOrMat) =
-    postop_proc(ldiv!(matldiv_dest(A, B), A, B), A, B)
+    postop_proc(\, ldiv!(matop_dest(\, A, B), A, B), A, B)
 
-postop_proc(C, B::Bidiagonal, ::UpperOrUnitUpperTriangular) = B.uplo == 'U' ? UpperTriangular(C) : C
-postop_proc(C, ::UpperOrUnitUpperTriangular, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : C
-postop_proc(C, B::Bidiagonal, ::LowerOrUnitLowerTriangular) = B.uplo == 'L' ? LowerTriangular(C) : C
-postop_proc(C, ::LowerOrUnitLowerTriangular, B::Bidiagonal) = B.uplo == 'L' ? LowerTriangular(C) : C
-postop_proc(C, B::Bidiagonal, ::Diagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
-postop_proc(C, ::Diagonal, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
+postop_proc(::Union{typeof(*),typeof(\)}, C, B::Bidiagonal, ::UpperOrUnitUpperTriangular) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(::typeof(/), C, B::Bidiagonal, ::UpperOrUnitUpperTriangular) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(::Union{typeof(*),typeof(/)}, C, ::UpperOrUnitUpperTriangular, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(::typeof(\), C, ::UpperOrUnitUpperTriangular, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : C
+postop_proc(::Union{typeof(*),typeof(\)}, C, B::Bidiagonal, ::LowerOrUnitLowerTriangular) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(::typeof(/), C, B::Bidiagonal, ::LowerOrUnitLowerTriangular) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(::Union{typeof(*),typeof(/)}, C, ::LowerOrUnitLowerTriangular, B::Bidiagonal) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(::typeof(\), C, ::LowerOrUnitLowerTriangular, B::Bidiagonal) = B.uplo == 'L' ? LowerTriangular(C) : C
+postop_proc(::typeof(\), C, B::Bidiagonal, ::Diagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
+postop_proc(::typeof(/), C, ::Diagonal, B::Bidiagonal) = B.uplo == 'U' ? UpperTriangular(C) : LowerTriangular(C)
 
 function _rdiv!(C::AbstractMatrix, A::AbstractMatrix, B::Bidiagonal)
     require_one_based_indexing(C, A, B)
@@ -1394,7 +1395,7 @@ end
 rdiv!(A::AbstractMatrix, B::Bidiagonal) = @inline _rdiv!(A, A, B)
 
 /(A::AbstractMatrix, B::Bidiagonal) =
-    postop_proc(_rdiv!(matrdiv_dest(A, B), A, B), A, B)
+    postop_proc(/, _rdiv!(matop_dest(/, A, B), A, B), A, B)
 
 # disambiguation
 /(A::AdjointAbsVec, B::Bidiagonal) = adjoint(adjoint(B) \ parent(A))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -339,6 +339,7 @@ postop_proc(::typeof(/), C, ::UpperOrUnitUpperTriangular, ::Diagonal) = UpperTri
 
 postop_proc(::Ops, C, _, ::Diagonal) = C
 postop_proc(::Ops, C, ::Diagonal, _) = C
+postop_proc(::Ops, C, ::Diagonal, ::Diagonal) = C
 
 function mul(Da::Diagonal, Db::Diagonal)
     matmul_size_check(size(Da), size(Db))
@@ -772,11 +773,11 @@ end
 for Tri in (:UpperTriangular, :LowerTriangular)
     UTri = Symbol(:Unit, Tri)
     # 2 args
-    for (fun, f) in zip((:rmul!, :rdiv!, :/), (:identity, :identity, :inv, :inv))
+    for (fun, f) in zip((:rmul!, :rdiv!, :/), (:identity, :inv, :inv))
         @eval $fun(A::$Tri, D::Diagonal) = $Tri($fun(A.data, D))
         @eval $fun(A::$UTri, D::Diagonal) = $Tri(_setdiag!($fun(A.data, D), $f, D.diag))
     end
-    for (fun, f) in zip((:lmul!, :ldiv!, :\), (:identity, :identity, :inv, :inv))
+    for (fun, f) in zip((:lmul!, :ldiv!, :\), (:identity, :inv, :inv))
         @eval $fun(D::Diagonal, A::$Tri) = $Tri($fun(D, A.data))
         @eval $fun(D::Diagonal, A::$UTri) = $Tri(_setdiag!($fun(D, A.data), $f, D.diag))
     end

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -786,6 +786,9 @@ for Tri in (:UpperTriangular, :LowerTriangular)
             @invoke mul(D::Diagonal, A::AbstractMatrix)
     @eval mul(D::Diagonal, A::$UTri{<:Any, <:StridedMaybeAdjOrTransMat}) =
             @invoke mul(D::Diagonal, A::AbstractMatrix)
+    # 3-arg ldiv!
+    @eval ldiv!(C::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(C.data, D, A.data))
+    @eval ldiv!(C::$Tri, D::Diagonal, A::$UTri) = $Tri(_setdiag!(ldiv!(C.data, D, A.data), inv, D.diag))
 end
 
 @inline function kron!(C::AbstractMatrix, A::Diagonal, B::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,6 +332,14 @@ Base.literal_pow(::typeof(^), D::Diagonal, valp::Val) =
     Diagonal(Base.literal_pow.(^, D.diag, valp)) # for speed
 Base.literal_pow(::typeof(^), D::Diagonal, ::Val{-1}) = inv(D) # for disambiguation
 
+postop_proc(::typeof(\), C, ::Diagonal, ::LowerOrUnitLowerTriangular) = LowerTriangular(C)
+postop_proc(::typeof(/), C, ::LowerOrUnitLowerTriangular, ::Diagonal) = LowerTriangular(C)
+postop_proc(::typeof(\), C, ::Diagonal, ::UpperOrUnitUpperTriangular) = UpperTriangular(C)
+postop_proc(::typeof(/), C, ::UpperOrUnitUpperTriangular, ::Diagonal) = UpperTriangular(C)
+
+postop_proc(::Ops, C, _, ::Diagonal) = C
+postop_proc(::Ops, C, ::Diagonal, _) = C
+
 function mul(Da::Diagonal, Db::Diagonal)
     matmul_size_check(size(Da), size(Db))
     return Diagonal(Da.diag .* Db.diag)
@@ -606,10 +614,10 @@ function (*)(Da::Diagonal, Db::Diagonal, Dc::Diagonal)
     return Diagonal(Da.diag .* Db.diag .* Dc.diag)
 end
 
-matrdiv_dest(A, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)))
-matrdiv_dest(A::HermOrSym, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)), size(A))
+matop_dest(::typeof(/), A, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)))
+matop_dest(::typeof(/), A::HermOrSym, D::Diagonal) = similar(A, promote_op(/, eltype(A), eltype(D)), size(A))
 
-/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matrdiv_dest(A, D), A, D)
+/(A::AbstractVecOrMat, D::Diagonal) = _rdiv!(matop_dest(/, A, D), A, D)
 
 rdiv!(A::AbstractVecOrMat, D::Diagonal) = @inline _rdiv!(A, A, D)
 # avoid copy when possible via internal 3-arg backend
@@ -630,10 +638,10 @@ function _rdiv!(B::AbstractVecOrMat, A::AbstractVecOrMat, D::Diagonal)
     B
 end
 
-matldiv_dest(D::Diagonal, B) = similar(B, promote_op(\, eltype(D), eltype(B)))
-matldiv_dest(D::Diagonal, B::HermOrSym) = similar(B, promote_op(\, eltype(D), eltype(B)), size(B))
+matop_dest(::typeof(\), D::Diagonal, B) = similar(B, promote_op(\, eltype(D), eltype(B)))
+matop_dest(::typeof(\), D::Diagonal, B::HermOrSym) = similar(B, promote_op(\, eltype(D), eltype(B)), size(B))
 
-\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matldiv_dest(D, B), D, B)
+\(D::Diagonal, B::AbstractVecOrMat) = ldiv!(matop_dest(\, D, B), D, B)
 
 ldiv!(D::Diagonal, B::AbstractVecOrMat) = @inline ldiv!(B, D, B)
 function ldiv!(B::AbstractVecOrMat, D::Diagonal, A::AbstractVecOrMat)
@@ -680,7 +688,7 @@ ldiv!(Dc::Diagonal, Da::Diagonal, Db::Diagonal) = Diagonal(ldiv!(Dc.diag, Da, Db
 @propagate_inbounds _getldiag(T::Tridiagonal, i) = T.dl[i]
 @propagate_inbounds _getldiag(S::SymTridiagonal, i) = transpose(S.ev[i])
 
-function matldiv_dest(D::Diagonal, S::SymTridiagonal)
+function matop_dest(::typeof(\), D::Diagonal, S::SymTridiagonal)
     T = promote_op(\, eltype(D), eltype(S))
     du = similar(S.ev, T, max(length(S.dv)-1, 0))
     d  = similar(S.dv, T, length(S.dv))
@@ -717,7 +725,7 @@ function ldiv!(T::Tridiagonal, D::Diagonal, S::Union{SymTridiagonal,Tridiagonal}
     return T
 end
 
-matrdiv_dest(S::SymTridiagonal, D::Diagonal) = matldiv_dest(D, S)
+matop_dest(::typeof(/), S::SymTridiagonal, D::Diagonal) = matop_dest(\, D, S)
 
 function _rdiv!(T::Tridiagonal, S::Union{SymTridiagonal,Tridiagonal}, D::Diagonal)
     n = size(S, 2)
@@ -760,24 +768,14 @@ end
 for Tri in (:UpperTriangular, :LowerTriangular)
     UTri = Symbol(:Unit, Tri)
     # 2 args
-    for (fun, f) in zip((:mul, :rmul!, :rdiv!, :/), (:identity, :identity, :inv, :inv))
-        g = fun == :mul ? :* : fun
-        @eval $fun(A::$Tri, D::Diagonal) = $Tri($g(A.data, D))
-        @eval $fun(A::$UTri, D::Diagonal) = $Tri(_setdiag!($g(A.data, D), $f, D.diag))
+    for (fun, f) in zip((:rmul!, :rdiv!, :/), (:identity, :identity, :inv, :inv))
+        @eval $fun(A::$Tri, D::Diagonal) = $Tri($fun(A.data, D))
+        @eval $fun(A::$UTri, D::Diagonal) = $Tri(_setdiag!($fun(A.data, D), $f, D.diag))
     end
-    @eval mul(A::$Tri{<:Any, <:StridedMaybeAdjOrTransMat}, D::Diagonal) =
-            @invoke mul(A::AbstractMatrix, D::Diagonal)
-    @eval mul(A::$UTri{<:Any, <:StridedMaybeAdjOrTransMat}, D::Diagonal) =
-            @invoke mul(A::AbstractMatrix, D::Diagonal)
-    for (fun, f) in zip((:mul, :lmul!, :ldiv!, :\), (:identity, :identity, :inv, :inv))
-        g = fun == :mul ? :* : fun
-        @eval $fun(D::Diagonal, A::$Tri) = $Tri($g(D, A.data))
-        @eval $fun(D::Diagonal, A::$UTri) = $Tri(_setdiag!($g(D, A.data), $f, D.diag))
+    for (fun, f) in zip((:lmul!, :ldiv!, :\), (:identity, :identity, :inv, :inv))
+        @eval $fun(D::Diagonal, A::$Tri) = $Tri($fun(D, A.data))
+        @eval $fun(D::Diagonal, A::$UTri) = $Tri(_setdiag!($fun(D, A.data), $f, D.diag))
     end
-    @eval mul(D::Diagonal, A::$Tri{<:Any, <:StridedMaybeAdjOrTransMat}) =
-            @invoke mul(D::Diagonal, A::AbstractMatrix)
-    @eval mul(D::Diagonal, A::$UTri{<:Any, <:StridedMaybeAdjOrTransMat}) =
-            @invoke mul(D::Diagonal, A::AbstractMatrix)
     # 3-arg ldiv!
     @eval ldiv!(C::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(C.data, D, A.data))
     @eval ldiv!(C::$Tri, D::Diagonal, A::$UTri) = $Tri(_setdiag!(ldiv!(C.data, D, A.data), inv, D.diag))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,11 +332,6 @@ Base.literal_pow(::typeof(^), D::Diagonal, valp::Val) =
     Diagonal(Base.literal_pow.(^, D.diag, valp)) # for speed
 Base.literal_pow(::typeof(^), D::Diagonal, ::Val{-1}) = inv(D) # for disambiguation
 
-postop_proc(::typeof(\), C, ::Diagonal, ::LowerOrUnitLowerTriangular) = LowerTriangular(C)
-postop_proc(::typeof(/), C, ::LowerOrUnitLowerTriangular, ::Diagonal) = LowerTriangular(C)
-postop_proc(::typeof(\), C, ::Diagonal, ::UpperOrUnitUpperTriangular) = UpperTriangular(C)
-postop_proc(::typeof(/), C, ::UpperOrUnitUpperTriangular, ::Diagonal) = UpperTriangular(C)
-
 postop_proc(::Ops, C, _, ::Diagonal) = C
 postop_proc(::Ops, C, ::Diagonal, _) = C
 postop_proc(::Ops, C, ::Diagonal, ::Diagonal) = C
@@ -773,17 +768,24 @@ end
 for Tri in (:UpperTriangular, :LowerTriangular)
     UTri = Symbol(:Unit, Tri)
     # 2 args
-    for (fun, f) in zip((:rmul!, :rdiv!, :/), (:identity, :inv, :inv))
-        @eval $fun(A::$Tri, D::Diagonal) = $Tri($fun(A.data, D))
-        @eval $fun(A::$UTri, D::Diagonal) = $Tri(_setdiag!($fun(A.data, D), $f, D.diag))
+    for (fun, f) in zip((:mul, :rmul!, :rdiv!, :/), (:identity, :identity, :inv, :inv))
+        g = fun == :mul ? :* : fun
+        @eval $fun(A::$Tri, D::Diagonal) = $Tri($g(A.data, D))
+        @eval $fun(A::$UTri, D::Diagonal) = $Tri(_setdiag!($g(A.data, D), $f, D.diag))
     end
-    for (fun, f) in zip((:lmul!, :ldiv!, :\), (:identity, :inv, :inv))
-        @eval $fun(D::Diagonal, A::$Tri) = $Tri($fun(D, A.data))
-        @eval $fun(D::Diagonal, A::$UTri) = $Tri(_setdiag!($fun(D, A.data), $f, D.diag))
+    @eval mul(A::$Tri{<:Any, <:StridedMaybeAdjOrTransMat}, D::Diagonal) =
+            @invoke mul(A::AbstractMatrix, D::Diagonal)
+    @eval mul(A::$UTri{<:Any, <:StridedMaybeAdjOrTransMat}, D::Diagonal) =
+            @invoke mul(A::AbstractMatrix, D::Diagonal)
+    for (fun, f) in zip((:mul, :lmul!, :ldiv!, :\), (:identity, :identity, :inv, :inv))
+        g = fun == :mul ? :* : fun
+        @eval $fun(D::Diagonal, A::$Tri) = $Tri($g(D, A.data))
+        @eval $fun(D::Diagonal, A::$UTri) = $Tri(_setdiag!($g(D, A.data), $f, D.diag))
     end
-    # 3-arg ldiv!
-    @eval ldiv!(C::$Tri, D::Diagonal, A::$Tri) = $Tri(ldiv!(C.data, D, A.data))
-    @eval ldiv!(C::$Tri, D::Diagonal, A::$UTri) = $Tri(_setdiag!(ldiv!(C.data, D, A.data), inv, D.diag))
+    @eval mul(D::Diagonal, A::$Tri{<:Any, <:StridedMaybeAdjOrTransMat}) =
+            @invoke mul(D::Diagonal, A::AbstractMatrix)
+    @eval mul(D::Diagonal, A::$UTri{<:Any, <:StridedMaybeAdjOrTransMat}) =
+            @invoke mul(D::Diagonal, A::AbstractMatrix)
 end
 
 @inline function kron!(C::AbstractMatrix, A::Diagonal, B::Diagonal)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -332,9 +332,9 @@ Base.literal_pow(::typeof(^), D::Diagonal, valp::Val) =
     Diagonal(Base.literal_pow.(^, D.diag, valp)) # for speed
 Base.literal_pow(::typeof(^), D::Diagonal, ::Val{-1}) = inv(D) # for disambiguation
 
-postop_proc(::Ops, C, _, ::Diagonal) = C
-postop_proc(::Ops, C, ::Diagonal, _) = C
-postop_proc(::Ops, C, ::Diagonal, ::Diagonal) = C
+postop_proc(::MulOrDiv, C, _, ::Diagonal) = C
+postop_proc(::MulOrDiv, C, ::Diagonal, _) = C
+postop_proc(::MulOrDiv, C, ::Diagonal, ::Diagonal) = C
 
 function mul(Da::Diagonal, Db::Diagonal)
     matmul_size_check(size(Da), size(Db))

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -163,8 +163,10 @@ end
 mul(H::UpperHessenberg, D::Diagonal) = UpperHessenberg(H.data * D)
 mul(D::Diagonal, H::UpperHessenberg) = UpperHessenberg(D * H.data)
 
-postop_proc(C, ::UpperHessenberg, ::UpperOrUnitUpperTriangular) = UpperHessenberg(C)
-postop_proc(C, ::UpperOrUnitUpperTriangular, ::UpperHessenberg) = UpperHessenberg(C)
+postop_proc(::Union{typeof(*),typeof(/)}, C, ::UpperHessenberg, ::UpperOrUnitUpperTriangular) = UpperHessenberg(C)
+postop_proc(::Union{typeof(*),typeof(/)}, C, ::UpperHessenberg, B::Bidiagonal) = B.uplo == 'U' ? UpperHessenberg(C) : C
+postop_proc(::Union{typeof(*),typeof(\)}, C, ::UpperOrUnitUpperTriangular, ::UpperHessenberg) = UpperHessenberg(C)
+postop_proc(::Union{typeof(*),typeof(\)}, C, B::Bidiagonal, ::UpperHessenberg) = B.uplo == 'U' ? UpperHessenberg(C) : C
 
 /(H::UpperHessenberg, D::Diagonal) = UpperHessenberg(H.data / D)
 

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -125,25 +125,26 @@ end
     matprod_dest(A, B, T)
 
 Return an appropriate `AbstractArray` with element type `T` that may be used to store the result of `A * B`.
-This function is only kept for backwards compatibility, use instead `matop_dest`.
+This function is only kept for backwards compatibility, use `matop_dest` instead.
 
-!!! compat
-    This function requires at least Julia 1.11
+!!! compat "Julia 1.11"
+    This function requires at least Julia 1.11.
 """
 matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(*, A, B))
 
 """
     matop_dest(op, A, B)
 
-Return an appropriate `AbstractArray` that may be used to store the result of `op(A, B)`.
+Return an appropriate `AbstractArray` that may be used to store the result of `op(A, B)`,
+where `op` is one of `*`, `/`, or `\\`.
 
-!!! compat
-    This function requires at least Julia 1.14
+!!! compat "Julia 1.14"
+    This function requires at least Julia 1.14.
 """
 matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
 matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
 matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
-matop_dest(::typeof(*), A, b::AbstractVector) = similar(b, promote_op(matprod, eltype(A), eltype(b)), axes(A,1))
+matop_dest(::typeof(*), A, b::AbstractVector) = similar(b, promote_op(matprod, eltype(A), eltype(b)), axes(A, 1))
 
 const Ops = Union{typeof(*), typeof(\), typeof(/)}
 
@@ -154,8 +155,6 @@ Post-processing of `C`, which is assumed to be the result of `op(A, B)`.
 """
 postop_proc(::Ops, C, _, _) = C
 
-matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
-matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})
 # which is better handled by reinterpreting rather than promotion

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -146,14 +146,14 @@ matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), 
 matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
 matop_dest(::typeof(*), A, b::AbstractVector) = similar(b, promote_op(matprod, eltype(A), eltype(b)), axes(A, 1))
 
-const Ops = Union{typeof(*), typeof(\), typeof(/)}
+const MulOrDiv = Union{typeof(*), typeof(\), typeof(/)}
 
 """
     postop_proc(op, C, A, B)
 
 Post-processing of `C`, which is assumed to be the result of `op(A, B)`.
 """
-postop_proc(::Ops, C, _, _) = C
+postop_proc(::MulOrDiv, C, _, _) = C
 
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -58,8 +58,7 @@ function (*)(A::StridedMaybeAdjOrTransMat{T}, x::StridedVector{S}) where {T<:Bla
 end
 function (*)(A::AbstractMatrix, x::AbstractVector)
     matmul_size_check(size(A), size(x))
-    TS = promote_op(matprod, eltype(A), eltype(x))
-    mul!(matprod_dest(A, x, TS), A, x)
+    mul!(matop_dest(*, A, x), A, x)
 end
 
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
@@ -119,8 +118,7 @@ julia> [1 1; 0 1] * [1 0; 1 1]
 mul(A::AbstractMatrix, B::AbstractMatrix) = _mul(A, B)
 function _mul(A::AbstractMatrix, B::AbstractMatrix)
     matmul_size_check(size(A), size(B))
-    TS = promote_op(matprod, eltype(A), eltype(B))
-    mul!(matprod_dest(A, B, TS), A, B)
+    postop_proc(*, mul!(matop_dest(*, A, B), A, B), A, B)
 end
 
 """
@@ -131,28 +129,29 @@ Return an appropriate `AbstractArray` with element type `T` that may be used to 
 !!! compat
     This function requires at least Julia 1.11
 """
-matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
-matprod_dest(A, x::AbstractVector, T) = similar(x, T, axes(A,1))
+matprod_dest(A, B, _) = matop_dest(*, A, B)
 
 """
-    matldiv_dest(A, B)
+    matop_dest(op, A, B)
 
-Return an appropriate `AbstractArray` that may be used to store the result of `A \\ B`.
+Return an appropriate `AbstractArray` that may be used to store the result of `op(A, B)`.
 
 !!! compat
     This function requires at least Julia 1.14
 """
-matldiv_dest(A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
+matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
+matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
+matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A, b::AbstractVector) = similar(b, promote_op(matprod, eltype(A), eltype(b)), axes(A,1))
+
+const Ops = Union{typeof(*), typeof(\), typeof(/)}
 
 """
-    matrdiv_dest(A, B)
+    postop_proc(op, C, A, B)
 
-Return an appropriate `AbstractArray` that may be used to store the result of `A / B`.
-
-!!! compat
-    This function requires at least Julia 1.14
+Post-processing of `C`, which is assumed to be the result of `op(A, B)`.
 """
-matrdiv_dest(A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
+postop_proc(::Ops, C, _, _) = C
 
 # optimization for dispatching to BLAS, e.g. *(::Matrix{Float32}, ::Matrix{Float64})
 # but avoiding the case *(::Matrix{<:BlasComplex}, ::Matrix{<:BlasReal})

--- a/src/special.jl
+++ b/src/special.jl
@@ -118,29 +118,6 @@ _mul!(C::AbstractMatrix, A::AbstractTriangular, B::BandedMatrix, alpha::Number, 
 _mul!(C::AbstractMatrix, A::BandedMatrix, B::AbstractTriangular, alpha::Number, beta::Number) =
     @stable_muladdmul _mul!(C, A, B, MulAddMul(alpha, beta))
 
-function mul(H::UpperHessenberg, B::Bidiagonal)
-    T = promote_op(matprod, eltype(H), eltype(B))
-    A = mul!(similar(H, T, size(H)), H, B)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
-end
-function mul(B::Bidiagonal, H::UpperHessenberg)
-    T = promote_op(matprod, eltype(B), eltype(H))
-    A = mul!(similar(H, T, size(H)), B, H)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
-end
-
-function /(H::UpperHessenberg, B::Bidiagonal)
-    T = typeof(oneunit(eltype(H))/oneunit(eltype(B)))
-    A = _rdiv!(similar(H, T, size(H)), H, B)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
-end
-
-function \(B::Bidiagonal, H::UpperHessenberg)
-    T = typeof(oneunit(eltype(B))\oneunit(eltype(H)))
-    A = ldiv!(similar(H, T, size(H)), B, H)
-    return B.uplo == 'U' ? UpperHessenberg(A) : A
-end
-
 # specialized +/- for structured matrices. If these are removed, it falls
 # back to broadcasting which has ~2-10x speed regressions.
 # For the other structure matrix pairs, broadcasting works well.

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1971,10 +1971,10 @@ _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA<:Integer,TB<:Integer
 _inner_type_promotion(op, ::Type{TA}, ::Type{TB}) where {TA,TB} =
     promote_op(op, TA, TB)
 
-matldiv_dest(A::UnitUpperOrUnitLowerTriangular, B) =
+matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B) =
     similar(B, _inner_type_promotion(\, eltype(A), eltype(B)), size(B))
 
-matrdiv_dest(A, B::UnitUpperOrUnitLowerTriangular) =
+matop_dest(::typeof(/), A, B::UnitUpperOrUnitLowerTriangular) =
     similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))    
 ## The general promotion methods
 function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
@@ -1982,22 +1982,22 @@ function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
     if size(A, 2) != size(B, 1)
         throw(DimensionMismatch(lazy"second dimension of left hand side A, $(size(A, 2)), and first dimension of right hand side B, $(size(B, 1)), must be equal"))
     end
-    T = promote_op(matprod, eltype(A), eltype(B))
-    C = matprod_dest(A, B, T)
+    C = matop_dest(*, A, B)
+    T = eltype(C)
     Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
     mul!(C, Ap, B)
-    postop_proc(C, Ap, B)
+    postop_proc(*, C, Ap, B)
 end
 function mul(A::AbstractMatrix, B::UpperOrLowerTriangular)
     require_one_based_indexing(A)
     if size(B, 1) != size(A, 2)
         throw(DimensionMismatch(lazy"right hand side B needs first dimension of size $(size(A,2)), has size $(size(B,1))"))
     end
-    T = promote_op(matprod, eltype(A), eltype(B))
-    C = matprod_dest(A, B, T)
+    C = matop_dest(*, A, B)
+    T = eltype(C)
     Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
     mul!(C, A, Bp)
-    postop_proc(C, A, Bp)
+    postop_proc(*, C, A, Bp)
 end
 mul(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
     @invoke mul(A::typeof(A), B::AbstractMatrix)
@@ -2005,21 +2005,21 @@ mul(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
 for mat in (:AbstractVector, :AbstractMatrix)
     @eval function \(A::UpperOrLowerTriangular, B::$mat)
         require_one_based_indexing(B)
-        C = matldiv_dest(A, B)
+        C = matop_dest(\, A, B)
         T = eltype(C)
         # promote eltype of A in case BLAS becomes accessible
         Ap = (T <: BlasFloat && parent(A) isa StridedMatrix) ? convert(AbstractArray{T}, A) : A
         ldiv!(C, Ap, B)
-        postop_proc(C, Ap, B)
+        postop_proc(\, C, Ap, B)
     end
     @eval function /(A::$mat, B::UpperOrLowerTriangular)
         require_one_based_indexing(A)
-        C = matrdiv_dest(A, B)
+        C = matop_dest(/, A, B)
         T = eltype(C)
         # promote eltype of B in case BLAS becomes accessible
         Bp = (T <: BlasFloat && parent(B) isa StridedMatrix) ? convert(AbstractArray{T}, B) : B
         _rdiv!(C, A, Bp)
-        postop_proc(C, A, Bp)
+        postop_proc(/, C, A, Bp)
     end
 end
 \(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
@@ -2027,16 +2027,14 @@ end
 /(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
     @invoke /(A::AbstractMatrix, B::typeof(B))
 
-
-postop_proc(C, _, _) = C
-postop_proc(C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
-postop_proc(C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)
-postop_proc(C, ::UnitLowerTriangular, ::LowerTriangular) = LowerTriangular(C)
-postop_proc(C, ::UnitLowerTriangular, ::UnitLowerTriangular) = UnitLowerTriangular(C)
-postop_proc(C, ::UpperTriangular, ::UpperTriangular) = UpperTriangular(C)
-postop_proc(C, ::UpperTriangular, ::UnitUpperTriangular) = UpperTriangular(C)
-postop_proc(C, ::UnitUpperTriangular, ::UpperTriangular) = UpperTriangular(C)
-postop_proc(C, ::UnitUpperTriangular, ::UnitUpperTriangular) = UnitUpperTriangular(C)
+postop_proc(::Ops, C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(::Ops, C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)
+postop_proc(::Ops, C, ::UnitLowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(::Ops, C, ::UnitLowerTriangular, ::UnitLowerTriangular) = UnitLowerTriangular(C)
+postop_proc(::Ops, C, ::UpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(::Ops, C, ::UpperTriangular, ::UnitUpperTriangular) = UpperTriangular(C)
+postop_proc(::Ops, C, ::UnitUpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(::Ops, C, ::UnitUpperTriangular, ::UnitUpperTriangular) = UnitUpperTriangular(C)
 
 # Complex matrix power for upper triangular factor, see:
 #   Higham and Lin, "A Schur-Padé algorithm for fractional powers of a Matrix",

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2019,14 +2019,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     end
 end
 
-postop_proc(::Ops, C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
-postop_proc(::Ops, C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)
-postop_proc(::Ops, C, ::UnitLowerTriangular, ::LowerTriangular) = LowerTriangular(C)
-postop_proc(::Ops, C, ::UnitLowerTriangular, ::UnitLowerTriangular) = UnitLowerTriangular(C)
-postop_proc(::Ops, C, ::UpperTriangular, ::UpperTriangular) = UpperTriangular(C)
-postop_proc(::Ops, C, ::UpperTriangular, ::UnitUpperTriangular) = UpperTriangular(C)
-postop_proc(::Ops, C, ::UnitUpperTriangular, ::UpperTriangular) = UpperTriangular(C)
-postop_proc(::Ops, C, ::UnitUpperTriangular, ::UnitUpperTriangular) = UnitUpperTriangular(C)
+postop_proc(::MulOrDiv, C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(::MulOrDiv, C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)
+postop_proc(::MulOrDiv, C, ::UnitLowerTriangular, ::LowerTriangular) = LowerTriangular(C)
+postop_proc(::MulOrDiv, C, ::UnitLowerTriangular, ::UnitLowerTriangular) = UnitLowerTriangular(C)
+postop_proc(::MulOrDiv, C, ::UpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(::MulOrDiv, C, ::UpperTriangular, ::UnitUpperTriangular) = UpperTriangular(C)
+postop_proc(::MulOrDiv, C, ::UnitUpperTriangular, ::UpperTriangular) = UpperTriangular(C)
+postop_proc(::MulOrDiv, C, ::UnitUpperTriangular, ::UnitUpperTriangular) = UnitUpperTriangular(C)
 
 # Complex matrix power for upper triangular factor, see:
 #   Higham and Lin, "A Schur-Padé algorithm for fractional powers of a Matrix",

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -2018,10 +2018,6 @@ for mat in (:AbstractVector, :AbstractMatrix)
         postop_proc(/, C, A, Bp)
     end
 end
-\(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
-    @invoke \(A::typeof(A), B::AbstractMatrix)
-/(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) =
-    @invoke /(A::AbstractMatrix, B::typeof(B))
 
 postop_proc(::Ops, C, ::LowerTriangular, ::LowerTriangular) = LowerTriangular(C)
 postop_proc(::Ops, C, ::LowerTriangular, ::UnitLowerTriangular) = LowerTriangular(C)


### PR DESCRIPTION
This is parallel effort to #1587, for mutual inspiration. I tried to make use of the mechanisms to further reduce high-level function overloads.

This seems to currently increase runtime of `Diagonal * *Triangular` for a reason I don't understand.

I won't have time next week to work on it.