### PR TITLE
fix: zero(::Symmetric/Hermitian) should forward to parent array type

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -222,7 +222,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     end
 end
 # zero should forward to the parent array type
-Base.zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
+zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T
 

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -221,7 +221,10 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
         end
     end
 end
-
+# zero should forward to the parent array type
+for Wrapper in (:Symmetric, :Hermitian)
+    @eval Base.zero(A::$Wrapper) = $Wrapper(zero(parent(A)), A.uplo)
+end
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T
 

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -223,7 +223,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
 end
 # zero should forward to the parent array type
 for Wrapper in (:Symmetric, :Hermitian)
-    @eval Base.zero(A::$Wrapper) = $Wrapper(zero(parent(A)), A.uplo)
+    @eval Base.zero(A::$Wrapper) = $Wrapper(zero(parent(A)), Symbol(A.uplo))
 end
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -222,9 +222,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     end
 end
 # zero should forward to the parent array type
-for Wrapper in (:Symmetric, :Hermitian)
-    @eval Base.zero(A::$Wrapper) = $Wrapper(zero(parent(A)), Symbol(A.uplo))
-end
+Base.zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T
 

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1381,4 +1381,19 @@ end
     @test LinearAlgebra.uplo(H) == :L
 end
 
+@testset "zero forwarding" begin
+    struct MyWrap{T} <: AbstractArray{T,2}
+        parent::Matrix{T}
+    end
+    Base.size(A::MyWrap) = size(A.parent)
+    Base.getindex(A::MyWrap, i, j) = A.parent[i,j]
+    Base.zero(A::MyWrap) = MyWrap(zero(A.parent))
+
+    S = Symmetric(MyWrap([1 2; 2 3]))
+    @test parent(zero(S)) isa MyWrap
+
+    H = Hermitian(MyWrap([1 2; 2 3]))
+    @test parent(zero(H)) isa MyWrap
+end
+
 end # module TestSymmetric

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1390,11 +1390,12 @@ Base.getindex(A::ZeroTestWrap, i, j) = A.parent[i,j]
 Base.zero(A::ZeroTestWrap) = ZeroTestWrap(zero(A.parent))
 
 @testset "zero forwarding" begin
-    S = Symmetric(ZeroTestWrap([1 2; 2 3]))
-    @test parent(zero(S)) isa ZeroTestWrap
-
-    H = Hermitian(ZeroTestWrap([1 2; 2 3]))
-    @test parent(zero(H)) isa ZeroTestWrap
+    for T in (Symmetric, Hermitian)
+        Z = zero(T(ZeroTestWrap([1 2; 2 3])))
+        @test Z isa T
+        @test parent(Z) isa ZeroTestWrap
+        @test iszero(Z)
+    end
 end
 
 end # module TestSymmetric

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1381,19 +1381,20 @@ end
     @test LinearAlgebra.uplo(H) == :L
 end
 
+# For testing zero forwarding to parent array type
+struct ZeroTestWrap{T} <: AbstractArray{T,2}
+    parent::Matrix{T}
+end
+Base.size(A::ZeroTestWrap) = size(A.parent)
+Base.getindex(A::ZeroTestWrap, i, j) = A.parent[i,j]
+Base.zero(A::ZeroTestWrap) = ZeroTestWrap(zero(A.parent))
+
 @testset "zero forwarding" begin
-    struct MyWrap{T} <: AbstractArray{T,2}
-        parent::Matrix{T}
-    end
-    Base.size(A::MyWrap) = size(A.parent)
-    Base.getindex(A::MyWrap, i, j) = A.parent[i,j]
-    Base.zero(A::MyWrap) = MyWrap(zero(A.parent))
+    S = Symmetric(ZeroTestWrap([1 2; 2 3]))
+    @test parent(zero(S)) isa ZeroTestWrap
 
-    S = Symmetric(MyWrap([1 2; 2 3]))
-    @test parent(zero(S)) isa MyWrap
-
-    H = Hermitian(MyWrap([1 2; 2 3]))
-    @test parent(zero(H)) isa MyWrap
+    H = Hermitian(ZeroTestWrap([1 2; 2 3]))
+    @test parent(zero(H)) isa ZeroTestWrap
 end
 
 end # module TestSymmetric


### PR DESCRIPTION
Fixes #1050

Found this while going through good first issues!

When you call zero() on a Symmetric wrapping a custom array, 
it loses the parent type and returns a plain Matrix instead.

```julia
C = Symmetric(MyArray([1 2; 2 3]))
typeof(zero(C))  
# Got:  Symmetric{Int64, Matrix{Int64}}  ← wrong
# Want: Symmetric{Int64, MyArray{Int64}} ← correct
```

Fixed by adding zero methods for Symmetric and Hermitian that 
forward to the parent directly, preserving uplo as well.

Happy to make changes if needed! :)