### PR TITLE
fix: check for truncation in det, inv, isposdef for Eigen

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -123,7 +123,12 @@ Base.iterate(S::Union{Eigen,GeneralizedEigen}) = (S.values, Val(:vectors))
 Base.iterate(S::Union{Eigen,GeneralizedEigen}, ::Val{:vectors}) = (S.vectors, Val(:done))
 Base.iterate(S::Union{Eigen,GeneralizedEigen}, ::Val{:done}) = nothing
 
-isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
+function isposdef(A::Union{Eigen,GeneralizedEigen})
+    if A isa Eigen && length(A.values) != size(A.vectors, 1)
+        throw(ArgumentError("isposdef not defined for truncated eigen factorization"))
+    end
+    return isreal(A.values) && all(x -> x > 0, A.values)
+end
 
 # pick a canonical ordering to avoid returning eigenvalues in "random" order
 # as is the LAPACK default (for complex λ — LAPACK sorts by λ for the Hermitian/Symmetric case)
@@ -428,8 +433,19 @@ function eigmin(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Boo
     return minimum(v)
 end
 
-inv(A::Eigen) = A.vectors * inv(Diagonal(A.values)) / A.vectors
-det(A::Eigen) = prod(A.values)
+function inv(A::Eigen)
+    if length(A.values) != size(A.vectors, 1)
+        throw(ArgumentError("inv not defined for truncated eigen factorization"))
+    end
+    return A.vectors * inv(Diagonal(A.values)) / A.vectors
+end
+
+function det(A::Eigen)
+    if length(A.values) != size(A.vectors, 1)
+        throw(ArgumentError("det not defined for truncated eigen factorization"))
+    end
+    return prod(A.values)
+end
 
 # Generalized eigenproblem
 function eigen!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Function,Nothing}=eigsortby) where T<:BlasReal

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -306,4 +306,12 @@ end
     @test Base.summarysize(V) == Base.summarysize(V1)
 end
 
+@testset "truncated eigen checks" begin
+    A = Symmetric([4.0 2.0; 2.0 3.0])
+    F = eigen(A, 1:1)
+    @test_throws ArgumentError det(F)
+    @test_throws ArgumentError inv(F)
+    @test_throws ArgumentError isposdef(F)
+end
+
 end # module TestEigen


### PR DESCRIPTION
Fixes #390

Found this while going through good first issues!

When you call eigen with a range like eigen(A, 1:1), you only 
get back some of the eigenvalues. But det, inv and isposdef 
don't know about this — they just compute anyway and give 
completely wrong answers without any warning.

For example:

```julia
A = Symmetric([4.0 2.0; 2.0 3.0])
F = eigen(A, 1:1)
det(F)     # gives wrong value
inv(F)     # gives wrong matrix  
isposdef(F) # gives wrong answer
```

The fix just adds a simple check at the start of each function — 
if the number of eigenvalues doesn't match the matrix size, 
throw an error.