### PR TITLE
fix: add missing math functions for UniformScaling

### DIFF
--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -173,8 +173,8 @@ for f in (:exp, :log, :cis,
           :asinh, :acosh, :atanh,
           :csch, :sech, :coth,
           :acsch, :asech, :acoth,
-          :abs, :abs2, :log2, :log10,
-          :sinpi, :cospi )
+          :log2, :log10,
+          :sinpi, :cospi)
     @eval Base.$f(J::UniformScaling) = UniformScaling($f(J.λ))
 end
 for f in (:sincos, :sincosd)

--- a/src/uniformscaling.jl
+++ b/src/uniformscaling.jl
@@ -162,17 +162,19 @@ isposdef(J::UniformScaling) = isposdef(J.λ)
 (-)(A::AbstractMatrix, J::UniformScaling)   = A + (-J)
 
 # matrix functions
-for f in ( :exp,   :log, :cis,
-           :expm1, :log1p,
-           :sqrt,  :cbrt,
-           :sin,   :cos,   :tan,
-           :asin,  :acos,  :atan,
-           :csc,   :sec,   :cot,
-           :acsc,  :asec,  :acot,
-           :sinh,  :cosh,  :tanh,
-           :asinh, :acosh, :atanh,
-           :csch,  :sech,  :coth,
-           :acsch, :asech, :acoth )
+for f in (:exp, :log, :cis,
+          :expm1, :log1p,
+          :sqrt, :cbrt,
+          :sin, :cos, :tan,
+          :asin, :acos, :atan,
+          :csc, :sec, :cot,
+          :acsc, :asec, :acot,
+          :sinh, :cosh, :tanh,
+          :asinh, :acosh, :atanh,
+          :csch, :sech, :coth,
+          :acsch, :asech, :acoth,
+          :abs, :abs2, :log2, :log10,
+          :sinpi, :cospi )
     @eval Base.$f(J::UniformScaling) = UniformScaling($f(J.λ))
 end
 for f in (:sincos, :sincosd)

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -597,15 +597,12 @@ end
     @test 0*A != 0*I
 end
 
-@testset "math functions" begin
-    J = UniformScaling(4.0)
-    @test abs(J) == UniformScaling(4.0)
-    @test abs(UniformScaling(-3.0)) == UniformScaling(3.0)
-    @test abs2(J) == UniformScaling(16.0)
-    @test log2(J) == UniformScaling(2.0)
+@testset "log2, log10, sinpi, cospi for UniformScaling" begin
+    @test log2(UniformScaling(4.0))   == UniformScaling(2.0)
     @test log10(UniformScaling(100.0)) == UniformScaling(2.0)
-    @test sinpi(UniformScaling(0.5)) == UniformScaling(1.0)
-    @test cospi(UniformScaling(0.0)) == UniformScaling(1.0)
+    @test sinpi(UniformScaling(0.5))  ≈  UniformScaling(1.0)
+    @test cospi(UniformScaling(0.0))  == UniformScaling(1.0)
+    @test cospi(UniformScaling(1.0))  == UniformScaling(-1.0)
 end
 
 end # module TestUniformscaling

--- a/test/uniformscaling.jl
+++ b/test/uniformscaling.jl
@@ -597,4 +597,15 @@ end
     @test 0*A != 0*I
 end
 
+@testset "math functions" begin
+    J = UniformScaling(4.0)
+    @test abs(J) == UniformScaling(4.0)
+    @test abs(UniformScaling(-3.0)) == UniformScaling(3.0)
+    @test abs2(J) == UniformScaling(16.0)
+    @test log2(J) == UniformScaling(2.0)
+    @test log10(UniformScaling(100.0)) == UniformScaling(2.0)
+    @test sinpi(UniformScaling(0.5)) == UniformScaling(1.0)
+    @test cospi(UniformScaling(0.0)) == UniformScaling(1.0)
+end
+
 end # module TestUniformscaling


### PR DESCRIPTION
Fixes #695

Found some missing math functions for UniformScaling while going 
through open issues.

```julia
abs(5.0I)     # errors
abs2(5.0I)    # errors
log2(4.0I)    # errors
log10(100.0I) # errors
sinpi(0.5I)   # errors
cospi(0.0I)   # errors
```

The fix was pretty straightforward — I just added them to the 
existing loop that handles the other math functions in 
uniformscaling.jl. After the fix they all work as expected.
