### PR TITLE
make eigvals(::SymTridiagonal) accept sortby

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -184,7 +184,7 @@ end
 Compute the eigenvalue decomposition of `A`, returning an [`Eigen`](@ref) factorization object `F`
 which contains the eigenvalues in `F.values` and the normalized eigenvectors in the columns of the
 matrix `F.vectors`. This corresponds to solving an eigenvalue problem of the form
-`Ax =  λx`, where `A` is a matrix, `x` is an eigenvector, and `λ` is an eigenvalue.
+`Ax = λx`, where `A` is a matrix, `x` is an eigenvector, and `λ` is an eigenvalue.
 (The `k`th eigenvector can be obtained from the slice `F.vectors[:, k]`.)
 
 Iterating the decomposition produces the components `F.values` and `F.vectors`.
@@ -198,9 +198,8 @@ make rows and columns more equal in norm. The default is `true` for both options
 
 By default, the eigenvalues and vectors are sorted lexicographically by `(real(λ),imag(λ))`.
 A different comparison function `by(λ)` can be passed to `sortby`, or you can pass
-`sortby=nothing` to leave the eigenvalues in an arbitrary order.   Some special matrix types
-(e.g. [`Diagonal`](@ref) or [`SymTridiagonal`](@ref)) may implement their own sorting convention and not
-accept a `sortby` keyword.
+`sortby=nothing` to leave the eigenvalues in an arbitrary order. Some special matrix types
+(e.g. [`Diagonal`](@ref)) may have a different default.
 
 # Examples
 ```jldoctest
@@ -476,7 +475,7 @@ Compute the generalized eigenvalue decomposition of `A` and `B`, returning a
 [`GeneralizedEigen`](@ref) factorization object `F` which contains the generalized eigenvalues in
 `F.values` and the generalized eigenvectors in the columns of the matrix `F.vectors`.
 This corresponds to solving a generalized eigenvalue problem of the form
-`Ax =  λBx`, where `A, B` are matrices, `x` is an eigenvector, and `λ` is an eigenvalue.
+`Ax = λBx`, where `A, B` are matrices, `x` is an eigenvector, and `λ` is an eigenvalue.
 (The `k`th generalized eigenvector can be obtained from the slice `F.vectors[:, k]`.)
 
 Iterating the decomposition produces the components `F.values` and `F.vectors`.

--- a/src/symmetriceigen.jl
+++ b/src/symmetriceigen.jl
@@ -139,7 +139,7 @@ function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Al
 end
 
 """
-    eigvals(A::Union{Hermitian, Symmetric}; alg::Algorithm = default_eigen_alg(A))) -> values
+    eigvals(A::Union{Hermitian, Symmetric}; alg::Algorithm = default_eigen_alg(A)) -> values
 
 Return the eigenvalues of `A`.
 

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -282,11 +282,12 @@ rdiv!(B::AbstractVecOrMat, A::SymTridiagonal; shift::Number=false) = rdiv!(B, ld
 # tridiagonal eigensolver meta-algorithm from LAPACK.syevr! for alg==RobustRepresentations()
 #   - if all eigenvalues are desired, call stev == sterf (eigvals) or stegr == stemr (eigen)
 #   - otherwise, and also if an error occurs, fall back to stebz and (if eigvecs wanted) stein
-function syevr_tri_eigen(range::AbstractChar, dv::AbstractVector{T}, ev::AbstractVector{T}, vl::Real, vu::Real, il::Integer, iu::Integer) where {T<:BlasReal}
+function syevr_tri_eigen(range::AbstractChar, dv::AbstractVector{T}, ev::AbstractVector{T}, vl::Real, vu::Real, il::Integer, iu::Integer; sortby = eigsortby) where {T<:BlasReal}
     if range == 'A' || (range == 'I' && il == 1 && iu == length(dv))
         try
             # need to copy dv, ev so that they are available for fallbacks, below
-            return Eigen(LAPACK.stegr!('V', range, copymutable(dv), copymutable(ev), vl, vu, il, iu)...)
+            values, vectors = LAPACK.stegr!('V', range, copymutable(dv), copymutable(ev), vl, vu, il, iu)
+            return Eigen(sorteig!(values, vectors, sortby == eigsortby ? nothing : sortby)...)
         catch ex
             ex isa LAPACKException || rethrow()
         end
@@ -294,7 +295,7 @@ function syevr_tri_eigen(range::AbstractChar, dv::AbstractVector{T}, ev::Abstrac
     # note that these functions do not actually modify dv, ev, despite the !
     values, iblock, isplit = LAPACK.stebz!(range, 'B', T(vl), T(vu), il, iu, -1.0, dv, ev)
     vectors = LAPACK.stein!(dv, ev, values, iblock, isplit)
-    return Eigen(values, vectors)
+    return Eigen(sorteig!(values, vectors, sortby)...)
 end
 function syevr_tri_eigvals(range::AbstractChar, dv::AbstractVector{T}, ev::AbstractVector{T}, vl::Real, vu::Real, il::Integer, iu::Integer) where {T<:BlasReal}
     if range == 'A' || (range == 'I' && il == 1 && iu == length(dv))
@@ -306,53 +307,54 @@ function syevr_tri_eigvals(range::AbstractChar, dv::AbstractVector{T}, ev::Abstr
         end
     end
     # note that this function does not actually modify dv, ev, despite the !
-    values, iblock, isplit = LAPACK.stebz!(range, 'B', T(vl), T(vu), il, iu, -1.0, dv, ev)
-    return values
+    return LAPACK.stebz!(range, 'E', T(vl), T(vu), il, iu, -1.0, dv, ev)[1]
 end
-syevr_tri_eigen(dv::AbstractVector{T}, ev::AbstractVector{T}) where {T<:BlasReal} =
-    syevr_tri_eigen('A', dv, ev, 0.0, 0.0, 0, 0)
-syevr_tri_eigvals(dv::AbstractVector{T}, ev::AbstractVector{T}) where {T<:BlasReal} =
-    syevr_tri_eigvals('A', dv, ev, 0.0, 0.0, 0, 0)
 
-eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}) = syevr_tri_eigen(A.dv, A.ev)
-eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}) = syevr_tri_eigen(A.dv, A.ev)
-eigen(A::SymTridiagonal{T}) where T = eigen!(copymutable_oftype(A, eigtype(T)))
+eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}; kws...) =
+    syevr_tri_eigen('A', A.dv, A.ev, 0.0, 0.0, 0, 0; kws...)
+eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}; kws...) = eigen!(A; kws...)
+eigen(A::SymTridiagonal{T}; kws...) where T = eigen!(copymutable_oftype(A, eigtype(T)); kws...)
 
-eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange) =
-    syevr_tri_eigen('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)
-eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange) =
-    syevr_tri_eigen('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)
-eigen(A::SymTridiagonal{T}, irange::UnitRange) where T =
-    eigen!(copymutable_oftype(A, eigtype(T)), irange)
+eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange; kws...) =
+    syevr_tri_eigen('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop; kws...)
+eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange; kws...) =
+    eigen!(A, irange; kws...)
+eigen(A::SymTridiagonal{T}, irange::UnitRange; kws...) where T =
+    eigen!(copymutable_oftype(A, eigtype(T)), irange; kws...)
 
-eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real) =
-    syevr_tri_eigen('V', A.dv, A.ev, vl, vu, 0, 0)
-eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real) =
-    syevr_tri_eigen('V', A.dv, A.ev, vl, vu, 0, 0)
-eigen(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
-    eigen!(copymutable_oftype(A, eigtype(T)), vl, vu)
+eigen!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real; kws...) =
+    syevr_tri_eigen('V', A.dv, A.ev, vl, vu, 0, 0; kws...)
+eigen(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real; kws...) =
+    eigen!(A, vl, vu; kws...)
+eigen(A::SymTridiagonal{T}, vl::Real, vu::Real; kws...) where T =
+    eigen!(copymutable_oftype(A, eigtype(T)), vl, vu; kws...)
 
-eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}) = syevr_tri_eigvals(A.dv, A.ev)
-eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}) = syevr_tri_eigvals(A.dv, A.ev)
-eigvals(A::SymTridiagonal{T}) where T = eigvals!(copymutable_oftype(A, eigtype(T)))
+function eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}; sortby = eigsortby)
+    vals = syevr_tri_eigvals('A', A.dv, A.ev, 0.0, 0.0, 0, 0)
+    return sorteig!(vals, sortby == eigsortby ? nothing : sortby)
+end
+eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}; kws...) = eigvals!(A; kws...)
+eigvals(A::SymTridiagonal{T}; kws...) where T = eigvals!(copymutable_oftype(A, eigtype(T)); kws...)
 
-eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange) =
-    syevr_tri_eigvals('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)
-eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange) =
-    syevr_tri_eigvals('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)
-eigvals(A::SymTridiagonal{T}, irange::UnitRange) where T =
-    eigvals!(copymutable_oftype(A, eigtype(T)), irange)
+function eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange; sortby = eigsortby)
+    vals = syevr_tri_eigvals('I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)
+    return sorteig!(vals, sortby == eigsortby ? nothing : sortby)
+end
+eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}, irange::UnitRange; kws...) = eigvals!(A, irange; kws...)
+eigvals(A::SymTridiagonal{T}, irange::UnitRange; kws...) where T =
+    eigvals!(copymutable_oftype(A, eigtype(T)), irange; kws...)
 
-eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real) =
-    syevr_tri_eigvals('V', A.dv, A.ev, vl, vu, 0, 0)
-eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real) =
-    syevr_tri_eigvals('V', A.dv, A.ev, vl, vu, 0, 0)
-eigvals(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
-    eigvals!(copymutable_oftype(A, eigtype(T)), vl, vu)
+function eigvals!(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real; sortby = eigsortby)
+    vals = syevr_tri_eigvals('V', A.dv, A.ev, vl, vu, 0, 0)
+    return sorteig!(vals, sortby == eigsortby ? nothing : sortby)
+end
+eigvals(A::SymTridiagonal{<:BlasReal,<:StridedVector}, vl::Real, vu::Real; kws...) = eigvals!(A, vl, vu; kws...)
+eigvals(A::SymTridiagonal{T}, vl::Real, vu::Real; kws...) where T =
+    eigvals!(copymutable_oftype(A, eigtype(T)), vl, vu; kws...)
 
 #Computes largest and smallest eigenvalue
-eigmax(A::SymTridiagonal) = eigvals(A, size(A, 1):size(A, 1))[1]
-eigmin(A::SymTridiagonal) = eigvals(A, 1:1)[1]
+eigmax(A::SymTridiagonal) = eigvals(A, size(A, 1):size(A, 1); sortby = eigsortby)[1]
+eigmin(A::SymTridiagonal) = eigvals(A, 1:1; sortby = eigsortby)[1]
 
 #Compute selected eigenvectors only corresponding to particular eigenvalues
 """

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -5,6 +5,7 @@ module TestTridiagonal
 isdefined(Main, :pruned_old_LA) || @eval Main include("prune_old_LA.jl")
 
 using Test, LinearAlgebra, Random
+import LinearAlgebra: eigsortby, sorteig!
 
 const TESTDIR = joinpath(dirname(pathof(LinearAlgebra)), "..", "test")
 const TESTHELPERS = joinpath(TESTDIR, "testhelpers", "testhelpers.jl")

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -1244,4 +1244,28 @@ end
     @test F.vectors ≈ Fdense.vectors
 end
 
+@testset "eigen sorting" begin
+    B = SymTridiagonal([3, 4, 1, 2],[1, 0, 2]) #block diagonal matrix to hit 'B' ordering of stebz!
+    fB = Float64.(B)
+    @test eigmin(fB) ≈ minimum(eigvals(fB))
+    @test eigmax(fB) ≈ maximum(eigvals(fB))
+    for A in (B, fB)
+        vals = eigvals(A; sortby = eigsortby)
+        @test vals == sort(vals) == eigvals!(fB; sortby = eigsortby)
+        vals = eigvals(A, 1:2; sortby = eigsortby)
+        @test vals == sort(vals) == eigvals!(fB, 1:2; sortby = eigsortby)
+        vals = eigvals(A, 2, 4; sortby = eigsortby)
+        @test vals == sort(vals) == eigvals!(fB, 2, 4; sortby = eigsortby)
+        fact = eigen(A; sortby = eigsortby)
+        @test fact == eigen!(fB; sortby = eigsortby)
+        @test fact == Eigen(sorteig!(fact.values, fact.vectors)...)
+        fact = eigen(A, 1:2; sortby = eigsortby)
+        @test fact == eigen!(fB, 1:2; sortby = eigsortby)
+        @test fact == Eigen(sorteig!(fact.values, fact.vectors)...)
+        fact = eigen(A, 2, 4; sortby = eigsortby)
+        @test fact == eigen!(fB, 2, 4; sortby = eigsortby)
+        @test fact == Eigen(sorteig!(fact.values, fact.vectors)...)
+    end
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
Follow-up to #1477. That closes the last exception, and now all matrix types accept the `sortby` argument.

Also fixes a (very unlikely) bug introduced in #1493, as eigenvalues computed from `stebz!` with ordering `'B'` are in general not ordered.