### PR TITLE
matmul: Fix sparse perf regression - route default `matop_dest(*, …)` through `matprod_dest`

### DIFF
--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -125,12 +125,11 @@ end
     matprod_dest(A, B, T)
 
 Return an appropriate `AbstractArray` with element type `T` that may be used to store the result of `A * B`.
-This function is only kept for backwards compatibility, use `matop_dest` instead.
 
 !!! compat "Julia 1.11"
     This function requires at least Julia 1.11.
 """
-matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(*, A, B))
+matprod_dest(A, B, T) = similar(B, T, (size(A, 1), size(B, 2)))
 
 """
     matop_dest(op, A, B)
@@ -138,12 +137,16 @@ matprod_dest(A, B, T) = convert(AbstractArray{T}, matop_dest(*, A, B))
 Return an appropriate `AbstractArray` that may be used to store the result of `op(A, B)`,
 where `op` is one of `*`, `/`, or `\\`.
 
+For `op === *`, this defaults to calling [`matprod_dest`](@ref), so packages that
+already specialize `matprod_dest` to control the destination of `A * B` continue
+to do so.
+
 !!! compat "Julia 1.14"
     This function requires at least Julia 1.14.
 """
 matop_dest(::typeof(\), A, B) = similar(B, promote_op(\, eltype(A), eltype(B)), size(B))
 matop_dest(::typeof(/), A, B) = similar(A, promote_op(/, eltype(A), eltype(B)), size(A))
-matop_dest(::typeof(*), A, B) = similar(B, promote_op(matprod, eltype(A), eltype(B)), (size(A, 1), size(B, 2)))
+matop_dest(::typeof(*), A, B::AbstractMatrix) = matprod_dest(A, B, promote_op(matprod, eltype(A), eltype(B)))
 matop_dest(::typeof(*), A, b::AbstractVector) = similar(b, promote_op(matprod, eltype(A), eltype(b)), axes(A, 1))
 
 const MulOrDiv = Union{typeof(*), typeof(\), typeof(/)}

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -333,6 +333,25 @@ end
     @test LinearAlgebra.generic_matmatmul!(zeros(2, 2), 'N', 'T', A, B, 1.0, 0.0) ≈ A * transpose(B)
 end
 
+# Ensure that an out-of-tree `matprod_dest` overload is honored by `*`.
+# This is a regression test for the SparseArrays performance regression caused by
+# routing `*` through `matop_dest` without a fallback to `matprod_dest`.
+struct MatProdDestMarker{T} <: AbstractMatrix{T}
+    data::Matrix{T}
+end
+Base.size(A::MatProdDestMarker) = size(A.data)
+Base.getindex(A::MatProdDestMarker, i::Int, j::Int) = A.data[i, j]
+const matprod_dest_called = Ref(0)
+LinearAlgebra.matprod_dest(A::MatProdDestMarker, B::AbstractMatrix, T) =
+    (matprod_dest_called[] += 1; similar(A.data, T, (size(A, 1), size(B, 2))))
+@testset "matprod_dest overrides are respected by *" begin
+    A = MatProdDestMarker(rand(2, 2))
+    B = rand(2, 2)
+    matprod_dest_called[] = 0
+    @test A * B ≈ A.data * B
+    @test matprod_dest_called[] == 1
+end
+
 @testset "fallbacks & such for BlasFloats" begin
     AA = rand(Float64, 6, 6)
     BB = rand(Float64, 6, 6)


### PR DESCRIPTION
Developed with Claude:

---

After #1588, `*` dispatches through `matop_dest(*, A, B)`, whose default allocates the destination directly via `similar(B, …)`. This bypassed out-of-tree `matprod_dest` overloads (notably the SparseArrays ones for dense × sparse, sparse × dense_triangular, etc.), causing major performance regressions where the destination is now an empty `SparseMatrixCSC` instead of a dense matrix:
https://github.com/JuliaCI/NanosoldierReports/blob/master/benchmark/by_date/2026-05/11/report.md

<img width="900" height="486" alt="image" src="https://github.com/user-attachments/assets/0da106eb-99bb-4eca-b393-556a1521f9b3" />



Restore the previous extension point by making the matrix-matrix `matop_dest(*, …)` fallback delegate to `matprod_dest(A, B, T)`, and keep `matprod_dest` as the documented hook (no longer a backwards-compat-only shim).