### PR TITLE
LAPACK eigen(::UpperHessenberg)

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -144,6 +144,19 @@ function sorteig!(λ::AbstractVector, X::AbstractMatrix, sortby::Union{Function,
 end
 sorteig!(λ::AbstractVector, sortby::Union{Function,Nothing}=eigsortby) = sortby === nothing ? λ : sort!(λ, by=sortby)
 
+# similar to geevx!, normalize eigenvectors to unit length and make largest component real and positive
+function eigvec_normalize!(v::AbstractVector)
+    normalize!(v)
+    maxabs2, k = findmax(abs2, v) # largest component
+    if eltype(v) <: Real # just a sign flip
+        v[k] < 0 && (v .= .- v)
+    elseif maxabs2 > 0
+        v .*= conj(v[k]) / sqrt(maxabs2) # change phase to make v[k] real > 0
+        v[k] = real(v[k]) # imaginary part is just roundoff error
+    end
+    return v
+end
+
 """
     eigen!(A; permute, scale, sortby)
     eigen!(A, B; sortby)

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -144,7 +144,8 @@ function sorteig!(λ::AbstractVector, X::AbstractMatrix, sortby::Union{Function,
 end
 sorteig!(λ::AbstractVector, sortby::Union{Function,Nothing}=eigsortby) = sortby === nothing ? λ : sort!(λ, by=sortby)
 
-# similar to geevx!, normalize eigenvectors to unit length and make largest component real and positive
+# similar to geevx! (specifically zgeevx), normalize eigenvectors to unit length
+# and make largest component real and positive
 function eigvec_normalize!(v::AbstractVector)
     normalize!(v)
     maxabs2, k = findmax(abs2, v) # largest component

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -423,7 +423,42 @@ function eigvals!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false
     return sorteig!(isreal(vals) ? real(vals) : vals, sortby)
 end
 
-# to do: faster eigen!(::UpperHessenberg)
+
+function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasComplex}
+    ilo, ihi, s = LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1)) # balance by scaling
+    _, Z, vals = LAPACK.hseqr!(H.data)
+    LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs
+    LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
+    foreach(eigvec_normalize!, eachcol(Z)) # normalize eigenvecs
+    return Eigen(sorteig!(vals, Z, sortby)...)
+end
+
+function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasReal}
+    ilo, ihi, s = LAPACK.gebal!(scale ? 'S' : 'N', triu!(H.data, -1)) # balance by scaling
+    _, Z, vals = LAPACK.hseqr!(H.data)
+    LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs (for complex, see below)
+    LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
+    if isreal(vals)
+        foreach(eigvec_normalize!, eachcol(Z)) # normalize eigenvecs
+        return Eigen(sorteig!(real(vals), Z, sortby)...)
+    else # complex eigenvalues: real/imag eigenvec parts stored in consecutive cols of Z
+        V = complex(Z)
+        k = 1
+        @inbounds while k <= length(vals)
+            if isreal(vals[k])
+                k += 1
+            else # complex-conjugate pair
+                for j = 1:size(V,1)
+                    V[j, k] = complex(Z[j,k], Z[j,k+1])
+                    V[j, k+1] = complex(Z[j,k], -Z[j,k+1])
+                end
+                k += 2
+            end
+        end
+        foreach(eigvec_normalize!, eachcol(V)) # normalize eigenvecs
+        return Eigen(sorteig!(vals, V, sortby)...)
+    end
+end
 
 # preserve the wrapper for eigensolves with UpperHessenberg
 eigencopy_oftype(H::UpperHessenberg, S) = UpperHessenberg(eigencopy_oftype(H.data, S))

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -331,10 +331,21 @@ end
         F = eigen(H)
         @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
+        @test F.vectors ≈ eigvecs(Matrix(H)) # normalization should be same
         if T <: LinearAlgebra.BlasFloat
             λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
             @test λ ≈ λ2
         end
+    end
+
+    # be sure to test real-H cases with both purely real and complex eigvals
+    for H in (UpperHessenberg([-1.1 -0.3 -0.0 -0.6 0.5; -0.6 -1.8 -0.3 1.5 1.1; 0.0 1.8 -0.6 1.2 0.9; 0.0 0.0 -0.1 -0.5 -0.2; 0.0 0.0 0.0 -0.5 -1.7]),
+              UpperHessenberg([-0.6 1.0 0.4 0.4 0.3; 1.2 -0.2 -1.5 0.7 0.0; 0.0 -1.3 -1.0 0.5 0.2; 0.0 0.0 0.5 -0.6 0.0; 0.0 0.0 0.0 0.7 -1.5]))
+        λ = eigvals(H)
+        F = eigen(H)
+        @test λ ≈ eigvals(Matrix(H)) ≈ F.values
+        @test H * F.vectors ≈ F.vectors * Diagonal(λ)
+        @test F.vectors ≈ eigvecs(Matrix(H)) # normalization should be same
     end
 end
 

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -331,7 +331,7 @@ end
         F = eigen(H)
         @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
-        @test F.vectors ≈ eigvecs(Matrix(H)) # normalization should be same
+        @test Diagonal(F.vectors' * F.vectors) ≈ I
         if T <: LinearAlgebra.BlasFloat
             λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
             @test λ ≈ λ2
@@ -345,7 +345,7 @@ end
         F = eigen(H)
         @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
-        @test F.vectors ≈ eigvecs(Matrix(H)) # normalization should be same
+        @test Diagonal(F.vectors' * F.vectors) ≈ I
     end
 end
 

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -334,7 +334,7 @@ end
         @test Diagonal(F.vectors' * F.vectors) ≈ I
         if T <: LinearAlgebra.BlasFloat
             λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
-            F2 = @invoke eigen!(copy(H)::UpperHessenberg{T, <:StridedMatrix{T}}) # fallback
+            F2 = @invoke eigen!(copy(H)::UpperHessenberg) # fallback
             @test λ ≈ λ2 ≈ F2.values
             @test H * F2.vectors ≈ F2.vectors * Diagonal(λ)
             @test Diagonal(F2.vectors' * F2.vectors) ≈ I

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -337,6 +337,7 @@ end
             F2 = @invoke eigen!(copy(H)::UpperHessenberg{T, <:StridedMatrix{T}}) # fallback
             @test λ ≈ λ2 ≈ F2.values
             @test H * F2.vectors ≈ F2.vectors * Diagonal(λ)
+            @test Diagonal(F2.vectors' * F2.vectors) ≈ I
         end
     end
 

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -334,7 +334,9 @@ end
         @test Diagonal(F.vectors' * F.vectors) ≈ I
         if T <: LinearAlgebra.BlasFloat
             λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
-            @test λ ≈ λ2
+            F2 = @invoke eigen!(copy(H)::UpperHessenberg{T, <:StridedMatrix{T}}) # fallback
+            @test λ ≈ λ2 ≈ F2.values
+            @test H * F2.vectors ≈ F2.vectors * Diagonal(λ)
         end
     end
 


### PR DESCRIPTION
Closes #858, providing optimized LAPACK-based `eigen!` for `UpperHessenberg` matrices.  About 50% faster (single-threaded) than the `Matrix` eigensolver for 1000x1000 matrices on my machine.

Includes an `eigvec_normalize!` routine that can also be used for #1597.  Once #1596 is fixed, this code can also be updated to use the improved `trevc3!` for eigenvectors.