### PR TITLE
bugfix: consistent ordering for composition of Givens rotations

### DIFF
--- a/src/givens.jl
+++ b/src/givens.jl
@@ -391,7 +391,7 @@ function lmul!(R::Rotation, A::AbstractVecOrMat)
     return A
 end
 function rmul!(A::AbstractMatrix, R::Rotation)
-    @inbounds for i in eachindex(R.rotations)
+    @inbounds for i in Iterators.reverse(eachindex(R.rotations))
         rmul!(A, R.rotations[i])
     end
     return A
@@ -399,7 +399,7 @@ end
 
 function lmul!(adjR::AdjointRotation{<:Any,<:Rotation}, A::AbstractVecOrMat)
     R = adjR.R
-    @inbounds for i in eachindex(R.rotations)
+    @inbounds for i in Iterators.reverse(eachindex(R.rotations))
         lmul!(adjoint(R.rotations[i]), A)
     end
     return A

--- a/test/givens.jl
+++ b/test/givens.jl
@@ -146,4 +146,16 @@ end
     @test !isfinite(r)
 end
 
+# ordering of compositions
+@testset "givens compositions ordering" begin
+    R1, R2 = givens(1.,1.,1,2)[1], givens(1.,1.,2,3)[1]
+    R = R1 * R2
+    I3 = I(3)
+    @test R1 * (R2 * I3) ≈ R * I3
+    @test R2' * (R1' * I3) ≈ R' * I3
+    @test (I3 * R1) * R2 ≈ I3 * R
+    @test (I3 * R2') * R1' ≈ I3 * R'
+    @test R' * (R * I3) ≈ R * (R' * I3) ≈ I
+end
+
 end # module TestGivens


### PR DESCRIPTION
Fixed a bug identified in [this post](https://discourse.julialang.org/t/julia-stability-vs-rust-for-scientific-computing/137094/11?u=stevengj): multiplying two `Givens` objects produces a `Rotation` object representing the composition of the Givens rotations, but adjoints and `rmul` multiplied by the individual Givens objects in an inconsistent order.

cc @dkarrasch, since the bug seems to date back to https://github.com/JuliaLang/julia/pull/46233.