### PR TITLE
remove Hessenberg fallbacks

### DIFF
--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -463,15 +463,7 @@ end
 # preserve the wrapper for eigensolves with UpperHessenberg
 eigencopy_oftype(H::UpperHessenberg, S) = UpperHessenberg(eigencopy_oftype(H.data, S))
 
-# fallback to dense algorithms
-eigvals!(H::UpperHessenberg; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) =
-    eigvals!(triu!(H.data,-1); permute, scale, sortby)
-eigen!(H::UpperHessenberg; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) =
-    eigen!(triu!(H.data,-1); permute, scale, sortby)
-
-
 schur!(H::UpperHessenberg{T}) where {T<:BlasFloat} = Schur(LinearAlgebra.LAPACK.hseqr!(H.data)...)
-schur!(H::UpperHessenberg) = schur!(triu!(H.data, -1)) # fallback to dense algorithm
 
 ######################################################################################
 # Hessenberg factorizations Q(H+μI)Q' of A+μI:

--- a/test/hessenberg.jl
+++ b/test/hessenberg.jl
@@ -332,13 +332,6 @@ end
         @test λ ≈ eigvals(Matrix(H)) ≈ F.values
         @test H * F.vectors ≈ F.vectors * Diagonal(λ)
         @test Diagonal(F.vectors' * F.vectors) ≈ I
-        if T <: LinearAlgebra.BlasFloat
-            λ2 = @invoke eigvals!(copy(H)::UpperHessenberg) # test fallback
-            F2 = @invoke eigen!(copy(H)::UpperHessenberg) # fallback
-            @test λ ≈ λ2 ≈ F2.values
-            @test H * F2.vectors ≈ F2.vectors * Diagonal(λ)
-            @test Diagonal(F2.vectors' * F2.vectors) ≈ I
-        end
     end
 
     # be sure to test real-H cases with both purely real and complex eigvals

--- a/test/schur.jl
+++ b/test/schur.jl
@@ -211,11 +211,8 @@ end
     B = Array(A)
     fact1 = schur(A)
     fact2 = schur(B)
-    fact3 = @invoke schur!(copy(A)::UpperHessenberg) # test fallback
-    fact4 = Schur(LinearAlgebra.LAPACK.hseqr!(copy(A.data))...) # call specialized method
-    @test fact1 == fact4
-    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim) ≈ sort(fact3.values, by=reim)
-    @test fact1.Z * fact1.T * fact1.Z' ≈ B ≈ fact3.Z * fact3.T * fact3.Z'
+    @test sort(fact1.values, by=reim) ≈ sort(fact2.values, by=reim)
+    @test fact1.Z * fact1.T * fact1.Z' ≈ B
 
     A = UpperHessenberg(rand(Int32, 50, 50))
     B = Array(A)


### PR DESCRIPTION
Remove the generic fallbacks added in #1557 and #1565, because they break `GenericLinearAlgebra` (and presumably any other package that wants to extend these methods to generic types).

Removing them will break any hypothetical package that defines `eigvals!`, `eigen!`, and `schur!` for a general matrix but not a `UpperHessenberg` one. But I believe it's better to break hypothetical packages than existing ones. Moreover, the hypothetical fix for the hypothetical package is straightforward, but I don't know how `GenericLinearAlgebra` could be fixed without the removal.