### PR TITLE
Normalize eigvecs(::AbstractTriangular) to unit length

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -157,6 +157,7 @@ function eigvec_normalize!(v::AbstractVector)
     end
     return v
 end
+eigvec_normalize!(X::AbstractMatrix) = (foreach(eigvec_normalize!, eachcol(X)); X)
 
 """
     eigen!(A; permute, scale, sortby)

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -438,8 +438,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs (for complex, see below)
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
     if isreal(vals)
-        eigvec_normalize!(Z)
-        return Eigen(sorteig!(real(vals), Z, sortby)...)
+return Eigen(sorteig!(real(vals), eigvec_normalize!(Z), sortby)...)
     else # complex eigenvalues: real/imag eigenvec parts stored in consecutive cols of Z
         V = complex(Z)
         k = 1

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -429,8 +429,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     _, Z, vals = LAPACK.hseqr!(H.data)
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
-    eigvec_normalize!(Z)
-    return Eigen(sorteig!(vals, Z, sortby)...)
+return Eigen(sorteig!(vals, eigvec_normalize!(Z), sortby)...)
 end
 
 function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasReal}

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -454,8 +454,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
                 k += 2
             end
         end
-        eigvec_normalize!(V)
-        return Eigen(sorteig!(vals, V, sortby)...)
+return Eigen(sorteig!(vals, eigvec_normalize!(V), sortby)...)
     end
 end
 

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -429,7 +429,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     _, Z, vals = LAPACK.hseqr!(H.data)
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
-    foreach(eigvec_normalize!, eachcol(Z)) # normalize eigenvecs
+    eigvec_normalize!(Z)
     return Eigen(sorteig!(vals, Z, sortby)...)
 end
 
@@ -439,7 +439,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs (for complex, see below)
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
     if isreal(vals)
-        foreach(eigvec_normalize!, eachcol(Z)) # normalize eigenvecs
+        eigvec_normalize!(Z)
         return Eigen(sorteig!(real(vals), Z, sortby)...)
     else # complex eigenvalues: real/imag eigenvec parts stored in consecutive cols of Z
         V = complex(Z)
@@ -455,7 +455,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
                 k += 2
             end
         end
-        foreach(eigvec_normalize!, eachcol(V)) # normalize eigenvecs
+        eigvec_normalize!(V)
         return Eigen(sorteig!(vals, V, sortby)...)
     end
 end

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -429,7 +429,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     _, Z, vals = LAPACK.hseqr!(H.data)
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
-return Eigen(sorteig!(vals, eigvec_normalize!(Z), sortby)...)
+    return Eigen(sorteig!(vals, eigvec_normalize!(Z), sortby)...)
 end
 
 function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where {T<:BlasReal}
@@ -438,7 +438,7 @@ function eigen!(H::UpperHessenberg{T, <:StridedMatrix{T}}; permute::Bool=false, 
     LAPACK.trevc!('R', 'B', BlasInt[], H.data, Z, Z) # set Z to right eigenvecs (for complex, see below)
     LAPACK.gebak!(scale ? 'S' : 'N', 'R', ilo, ihi, s, Z) # undo balancing
     if isreal(vals)
-return Eigen(sorteig!(real(vals), eigvec_normalize!(Z), sortby)...)
+        return Eigen(sorteig!(real(vals), eigvec_normalize!(Z), sortby)...)
     else # complex eigenvalues: real/imag eigenvec parts stored in consecutive cols of Z
         V = complex(Z)
         k = 1
@@ -453,7 +453,7 @@ return Eigen(sorteig!(real(vals), eigvec_normalize!(Z), sortby)...)
                 k += 2
             end
         end
-return Eigen(sorteig!(vals, eigvec_normalize!(V), sortby)...)
+        return Eigen(sorteig!(vals, eigvec_normalize!(V), sortby)...)
     end
 end
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1377,7 +1377,6 @@ end
 
 # Eigensystems
 ## Notice that trecv works for quasi-triangular matrices and therefore the lower sub diagonal must be zeroed before calling the subroutine
-
 function eigvecs(A::UpperTriangular{<:BlasFloat,<:StridedMatrix})
     eigvec_normalize!(LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
 end

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1377,23 +1377,24 @@ end
 
 # Eigensystems
 ## Notice that trecv works for quasi-triangular matrices and therefore the lower sub diagonal must be zeroed before calling the subroutine
+
 function eigvecs(A::UpperTriangular{<:BlasFloat,<:StridedMatrix})
-    LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data))
+    eigvec_normalize!(LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
 end
 function eigvecs(A::UnitUpperTriangular{<:BlasFloat,<:StridedMatrix})
     for i in axes(A, 1)
         A.data[i,i] = 1
     end
-    LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data))
+    eigvec_normalize!(LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
 end
 function eigvecs(A::LowerTriangular{<:BlasFloat,<:StridedMatrix})
-    LAPACK.trevc!('L', 'A', BlasInt[], copy(tril!(A.data)'))
+    eigvec_normalize!(LAPACK.trevc!('L', 'A', BlasInt[], copy(tril!(A.data)')))
 end
 function eigvecs(A::UnitLowerTriangular{<:BlasFloat,<:StridedMatrix})
     for i in axes(A, 1)
         A.data[i,i] = 1
     end
-    LAPACK.trevc!('L', 'A', BlasInt[], copy(tril!(A.data)'))
+    eigvec_normalize!(LAPACK.trevc!('L', 'A', BlasInt[], copy(tril!(A.data)')))
 end
 
 ####################

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -704,6 +704,7 @@ end
         V = eigvecs(U)
         λ = eigvals(U)
         @test U * V ≈ V * Diagonal(λ)
+        @test all(v -> norm(v) ≈ 1, eachcol(V))
 
         MU = MyTriangular(U)
         V = eigvecs(U)


### PR DESCRIPTION
Previously, `eigvecs` for triangular matrices used LAPACK's `trevc`, which normalizes eigenvectors so that the largest component is ±1. This behavior is inconsistent with all other matrix types in Julia, which return unit-norm eigenvectors.

This PR fixes the issue by applying `eigvec_normalize!` to each eigenvector column in the `AbstractTriangular` dispatcher, bringing it into alignment with the convention used by `zgeevx` for general matrices.

Fixes #1597