### PR TITLE
Extend `matop_dest` mechanism to `UpperHessenberg` and `Factorization`

### DIFF
--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -135,8 +135,7 @@ end
 
 function (\)(F::Factorization, B::AbstractVecOrMat)
     require_one_based_indexing(B)
-    TFB = typeof(oneunit(eltype(F)) \ oneunit(eltype(B)))
-    ldiv!(F, copy_similar(B, TFB))
+    ldiv!(F, copyto!(matop_dest(\, F, B), B))
 end
 (\)(F::TransposeFactorization, B::AbstractVecOrMat) = conj!(adjoint(F.parent) \ conj.(B))
 # With a real lhs and complex rhs with the same precision, we can reinterpret
@@ -179,8 +178,7 @@ end
 
 function (/)(B::AbstractMatrix, F::Factorization)
     require_one_based_indexing(B)
-    TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
-    rdiv!(copy_similar(B, TFB), F)
+    rdiv!(copyto!(matop_dest(/, B, F), B), F)
 end
 # reinterpretation trick for complex lhs and real factorization
 function (/)(B::Union{Matrix{Complex{T}},AdjOrTrans{Complex{T},Vector{Complex{T}}}}, F::Factorization{T}) where {T<:BlasReal}

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -176,18 +176,14 @@ AdjUpperHessenberg{T,S<:UpperHessenberg{T}} = Adjoint{T, S}
 TransUpperHessenberg{T,S<:UpperHessenberg{T}} = Transpose{T, S}
 AdjOrTransUpperHessenberg{T,S<:UpperHessenberg{T}} = AdjOrTrans{T, S}
 
-function (\)(H::Union{UpperHessenberg,AdjOrTransUpperHessenberg}, B::AbstractVecOrMat)
-    TFB = typeof(oneunit(eltype(H)) \ oneunit(eltype(B)))
-    return ldiv!(H, copy_similar(B, TFB))
-end
+(\)(H::Union{UpperHessenberg,AdjOrTransUpperHessenberg}, B::AbstractVecOrMat) =
+    ldiv!(H, copyto!(matop_dest(\, H, B), B))
 
 (/)(B::AbstractMatrix, H::UpperHessenberg) = _rdiv(B, H)
 (/)(B::AbstractMatrix, H::AdjUpperHessenberg) = _rdiv(B, H)
 (/)(B::AbstractMatrix, H::TransUpperHessenberg) = _rdiv(B, H)
-function _rdiv(B, H)
-    TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(H)))
-    return rdiv!(copy_similar(B, TFB), H)
-end
+
+_rdiv(B, H) = rdiv!(copyto!(matop_dest(/, B, H), B), H)
 
 ldiv!(H::AdjOrTransUpperHessenberg, B::AbstractVecOrMat) =
     (rdiv!(wrapperop(H)(B), parent(H)); B)


### PR DESCRIPTION
I'm not sure if extending this to `Factorization` goes against the `[MAT]op_dest` naming, but this came up in the SparseArrays.jl PR: `\(S::SymTridiagional, b::SparseVector)` calls `ldlt(S) \ b`, so we want to allocate a dense output vector by the same mechanism as with matrices.