### PR TITLE
make eigenvalues always sorted by default

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1039,8 +1039,8 @@ _ortho_eltype(T) = Base.promote_op(/, T, T)
 _ortho_eltype(T::Type{<:Number}) = typeof(one(T)/one(T))
 
 #Eigensystem
-eigvals(D::Diagonal{<:Number}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=nothing) = sorteig!(copy(D.diag), sortby)
-eigvals(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=nothing) =
+eigvals(D::Diagonal{<:Number}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) = sorteig!(copy(D.diag), sortby)
+eigvals(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) =
     sorteig!(reduce(vcat, eigvals(x; sortby=nothing) for x in D.diag), sortby) #For block matrices, etc.
 function _eigen(D::Diagonal{T}) where {T<:AbstractMatrix}
     facts = [eigen(x; sortby=nothing) for x in D.diag]
@@ -1064,7 +1064,7 @@ function _eigen(D::Diagonal{T}) where {T<:AbstractMatrix}
     end
     return λ, vecs
 end
-function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=nothing)
+function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby)
     if any(!isfinite, D.diag)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end
@@ -1082,7 +1082,7 @@ function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true, sortby::Union{
     end
     Eigen(λ, evecs)
 end
-function eigen(D::Diagonal{<:AbstractMatrix}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=nothing)
+function eigen(D::Diagonal{<:AbstractMatrix}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby)
     if any(any(!isfinite, x) for x in D.diag)
         throw(ArgumentError("matrix contains Infs or NaNs"))
     end
@@ -1094,7 +1094,7 @@ function eigen(D::Diagonal{<:AbstractMatrix}; permute::Bool=true, scale::Bool=tr
     end
     Eigen(λ, evecs)
 end
-function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=nothing)
+function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=eigsortby)
     if any(!isfinite, Da.diag) || any(!isfinite, Db.diag)
         throw(ArgumentError("matrices contain Infs or NaNs"))
     end
@@ -1103,7 +1103,7 @@ function eigen(Da::Diagonal, Db::Diagonal; sortby::Union{Function,Nothing}=nothi
     end
     return GeneralizedEigen(eigen(Db \ Da; sortby)...)
 end
-function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=nothing)
+function eigen(A::AbstractMatrix, D::Diagonal; sortby::Union{Function,Nothing}=eigsortby)
     if any(iszero, D.diag)
         throw(ArgumentError("right-hand side diagonal matrix is singular"))
     end

--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -217,8 +217,7 @@ make rows and columns more equal in norm. The default is `true` for both options
 
 By default, the eigenvalues and vectors are sorted lexicographically by `(real(λ),imag(λ))`.
 A different comparison function `by(λ)` can be passed to `sortby`, or you can pass
-`sortby=nothing` to leave the eigenvalues in an arbitrary order. Some special matrix types
-(e.g. [`Diagonal`](@ref)) may have a different default.
+`sortby=nothing` to leave the eigenvalues in an arbitrary order.
 
 # Examples
 ```jldoctest

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1377,7 +1377,7 @@ end
 
 # Eigensystems
 ## Notice that trecv works for quasi-triangular matrices and therefore the lower sub diagonal must be zeroed before calling the subroutine
-function eigvecs(A::UpperTriangular{<:BlasFloat,<:StridedMatrix}; sortby = nothing)
+function eigvecs(A::UpperTriangular{<:BlasFloat,<:StridedMatrix}; sortby = eigsortby)
     vecs = eigvec_normalize!(LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
     return sorteig!(diag(A), vecs, sortby)[2]
 end
@@ -1387,7 +1387,7 @@ function eigvecs(A::UnitUpperTriangular{<:BlasFloat,<:StridedMatrix}; sortby = n
     end
     eigvec_normalize!(LAPACK.trevc!('R', 'A', BlasInt[], triu!(A.data)))
 end
-function eigvecs(A::LowerTriangular{<:BlasFloat,<:StridedMatrix}; sortby = nothing)
+function eigvecs(A::LowerTriangular{<:BlasFloat,<:StridedMatrix}; sortby = eigsortby)
     vecs = eigvec_normalize!(LAPACK.trevc!('L', 'A', BlasInt[], copy(tril!(A.data)')))
     return sorteig!(diag(A), vecs, sortby)[2]
 end
@@ -2157,7 +2157,7 @@ function _log_quasitriu!(A0, A)
         R[i,i+1] = i / sqrt((2 * i)^2 - 1)
         R[i+1,i] = R[i,i+1]
     end
-    x,V = eigen(R)
+    x,V = eigen(R; sortby=nothing)
     w = Vector{Float64}(undef, m)
     for i in 1:m
         x[i] = (x[i] + 1) / 2
@@ -2980,16 +2980,16 @@ end
 # End of auxiliary functions for matrix square root
 
 # Generic eigensystems
-eigvals(A::AbstractTriangular; sortby = nothing) = sorteig!(diag(A), sortby)
+eigvals(A::AbstractTriangular; sortby = eigsortby) = sorteig!(diag(A), sortby)
 # fallback for unknown types
-function eigvecs(A::AbstractTriangular{<:BlasFloat}; sortby = nothing)
+function eigvecs(A::AbstractTriangular{<:BlasFloat}; sortby = eigsortby)
     if istriu(A)
         eigvecs(UpperTriangular(Matrix(A)); sortby)
     else # istril(A)
         eigvecs(LowerTriangular(Matrix(A)); sortby)
     end
 end
-function eigvecs(A::AbstractTriangular{T}; sortby = nothing) where T
+function eigvecs(A::AbstractTriangular{T}; sortby = eigsortby) where T
     TT = promote_type(T, Float32)
     if TT <: BlasFloat
         return eigvecs(convert(AbstractMatrix{TT}, A); sortby)
@@ -3016,7 +3016,7 @@ function logabsdet(A::Union{UpperTriangular{T},LowerTriangular{T}}) where T
     return abs_det, sgn
 end
 
-eigen(A::AbstractTriangular; sortby = nothing) = Eigen(sorteig!(eigvals(A; sortby=nothing), eigvecs(A; sortby=nothing), sortby)...)
+eigen(A::AbstractTriangular; sortby = eigsortby) = Eigen(sorteig!(eigvals(A; sortby=nothing), eigvecs(A; sortby=nothing), sortby)...)
 
 # Generic singular systems
 for func in (:svd, :svd!, :svdvals)

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1068,6 +1068,7 @@ end
 
 @testset "eigenvalue sorting" begin
     D = Diagonal([0.4, 0.2, -1.3])
+    @test eigvals(D) == eigen(D).values == [-1.3, 0.2, 0.4] #sorted by default
     @test eigvals(D; sortby=nothing) == eigen(D; sortby=nothing).values == [0.4, 0.2, -1.3]
     @test eigvals(D; sortby=LinearAlgebra.eigsortby) == [-1.3, 0.2, 0.4] # sortby keyword supported for eigvals(::Diagonal)
     @test eigvals(Matrix(D)) == eigen(Matrix(D)).values == [-1.3, 0.2, 0.4] # sorted even if diagonal special case is detected

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1068,7 +1068,7 @@ end
 
 @testset "eigenvalue sorting" begin
     D = Diagonal([0.4, 0.2, -1.3])
-    @test eigvals(D) == eigen(D).values == [0.4, 0.2, -1.3] # not sorted by default
+    @test eigvals(D; sortby=nothing) == eigen(D; sortby=nothing).values == [0.4, 0.2, -1.3]
     @test eigvals(D; sortby=LinearAlgebra.eigsortby) == [-1.3, 0.2, 0.4] # sortby keyword supported for eigvals(::Diagonal)
     @test eigvals(Matrix(D)) == eigen(Matrix(D)).values == [-1.3, 0.2, 0.4] # sorted even if diagonal special case is detected
     E = eigen(D; sortby=abs) # sortby keyword supported for eigen(::Diagonal)

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1118,8 +1118,9 @@ end
         A = randn(T, 4, 4)
         for wrapper in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
             B = wrapper(A)
-            @test eigvals(B) == diag(B) #don't sort by default
-            F = eigen(B; sortby = LinearAlgebra.eigsortby)
+            @test eigvals(B; sortby=nothing) == diag(B)
+            F = eigen(B)
+            @test issorted(F.values, by=LinearAlgebra.eigsortby) #sort by default
             @test B * F.vectors ≈ F.vectors * Diagonal(F.values)
             @test F.values ≈ eigvals(B; sortby = LinearAlgebra.eigsortby)
             @test F.vectors ≈ eigvecs(B; sortby = LinearAlgebra.eigsortby)


### PR DESCRIPTION
Followup to #1477, #1595, and #1626: this PR changes the default sorting from `nothing` to `eigsortby` for `Diagonal` and *`Triangular` matrices. With this there are no exceptions remaining, and we can change the docstring to state that eigenvalues are always sorted by default.

In the `Diagonal` case I think it's a no-brainer: nobody calls `eigvals` intentionally on a diagonal matrix. This only happens in generic code, and in this case it can cause bugs.

In the *`Triangular` case it's not so clear-cut: people might very well call `eigvecs` on a triangular matrix, and the sorted output will be surprising and unhelpful. I think it's still worth it for consistency.