### PR TITLE
Pass through `nothing` strides

### DIFF
--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -368,11 +368,27 @@ convert(::Type{Adjoint{T,S}}, A::Adjoint) where {T,S} = Adjoint{T,S}(convert(S, 
 convert(::Type{Transpose{T,S}}, A::Transpose) where {T,S} = Transpose{T,S}(convert(S, A.parent))::Transpose{T,S}
 
 # Strides and pointer for transposed strided arrays — but only if the elements are actually stored in memory
-Base.strides(A::Adjoint{<:Real, <:AbstractVector}) = (stride(A.parent, 2), stride(A.parent, 1))
-Base.strides(A::Transpose{<:Any, <:AbstractVector}) = (stride(A.parent, 2), stride(A.parent, 1))
+function Base.strides(A::Adjoint{<:Real, <:AbstractVector})
+    st = strides(A.parent)
+    isnothing(st) && return nothing
+    (st[1]*Int(length(A.parent)), st[1])
+end
+function Base.strides(A::Transpose{<:Any, <:AbstractVector})
+    st = strides(A.parent)
+    isnothing(st) && return nothing
+    (st[1]*Int(length(A.parent)), st[1])
+end
 # For matrices it's slightly faster to use reverse and avoid calling stride twice
-Base.strides(A::Adjoint{<:Real, <:AbstractMatrix}) = reverse(strides(A.parent))
-Base.strides(A::Transpose{<:Any, <:AbstractMatrix}) = reverse(strides(A.parent))
+function Base.strides(A::Adjoint{<:Real, <:AbstractMatrix})
+    st = strides(A.parent)
+    isnothing(st) && return nothing
+    reverse(st)
+end
+function Base.strides(A::Transpose{<:Any, <:AbstractMatrix})
+    st = strides(A.parent)
+    isnothing(st) && return nothing
+    reverse(st)
+end
 
 Base.cconvert(::Type{Ptr{T}}, A::Adjoint{<:Real, <:AbstractVecOrMat}) where {T} = Base.cconvert(Ptr{T}, A.parent)
 Base.cconvert(::Type{Ptr{T}}, A::Transpose{<:Any, <:AbstractVecOrMat}) where {T} = Base.cconvert(Ptr{T}, A.parent)

--- a/src/adjtrans.jl
+++ b/src/adjtrans.jl
@@ -373,7 +373,7 @@ function Base.strides(A::Adjoint{<:Real, <:AbstractVector})
     isnothing(st) && return nothing
     (st[1]*Int(length(A.parent)), st[1])
 end
-function Base.strides(A::Transpose{<:Any, <:AbstractVector})
+function Base.strides(A::Transpose{<:Number, <:AbstractVector})
     st = strides(A.parent)
     isnothing(st) && return nothing
     (st[1]*Int(length(A.parent)), st[1])
@@ -384,7 +384,7 @@ function Base.strides(A::Adjoint{<:Real, <:AbstractMatrix})
     isnothing(st) && return nothing
     reverse(st)
 end
-function Base.strides(A::Transpose{<:Any, <:AbstractMatrix})
+function Base.strides(A::Transpose{<:Number, <:AbstractMatrix})
     st = strides(A.parent)
     isnothing(st) && return nothing
     reverse(st)

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -571,6 +571,14 @@ end
     @test repr(transpose([1f0,2f0])) == "transpose(Float32[1.0, 2.0])"
 end
 
+function test_no_strides(x)
+    @test try
+        strides(x)
+    catch e
+        e
+    end isa Union{MethodError, Nothing}
+end
+
 @testset "strided transposes" begin
     for t in (Adjoint, Transpose)
         @test strides(t(rand(3))) == (3, 1)
@@ -583,8 +591,8 @@ end
         B = rand(3,1)
         @test pointer(t(B)) === pointer(B)
     end
-    @test_throws MethodError strides(Adjoint(rand(3) .+ rand(3).*im))
-    @test_throws MethodError strides(Adjoint(rand(3, 2) .+ rand(3, 2).*im))
+    test_no_strides(Adjoint(rand(3) .+ rand(3).*im))
+    test_no_strides(Adjoint(rand(3, 2) .+ rand(3, 2).*im))
     @test strides(Transpose(rand(3) .+ rand(3).*im)) == (3, 1)
     @test strides(Transpose(rand(3, 2) .+ rand(3, 2).*im)) == (3, 1)
 

--- a/test/blas.jl
+++ b/test/blas.jl
@@ -598,6 +598,14 @@ Base.cconvert(::Type{Ptr{T}}, A::WrappedArray{T}) where T = Base.cconvert(Ptr{T}
 Base.strides(A::WrappedArray) = strides(A.A)
 Base.elsize(::Type{WrappedArray{T,N}}) where {T,N} = Base.elsize(Array{T,N})
 
+function test_no_strides(x)
+    @test try
+        strides(x)
+    catch e
+        e
+    end isa Union{MethodError, Nothing}
+end
+
 @testset "strided interface adjtrans" begin
     x = WrappedArray([1, 2, 3, 4])
     @test stride(x,1) == 1
@@ -617,20 +625,18 @@ Base.elsize(::Type{WrappedArray{T,N}}) where {T,N} = Base.elsize(Array{T,N})
     y = WrappedArray([1+im, 2, 3, 4])
     @test strides(transpose(y)) == (4,1)
     @test pointer(transpose(y)) == pointer(y)
-    @test_throws MethodError strides(y')
+    test_no_strides(y')
     @test_throws ErrorException pointer(y')
 
     B = WrappedArray([1+im 2; 3 4; 5 6])
     @test strides(transpose(B)) == (3,1)
     @test pointer(transpose(B)) == pointer(B)
-    @test_throws MethodError strides(B')
+    test_no_strides(B')
     @test_throws ErrorException pointer(B')
 
-    @test_throws MethodError stride(1:5,0)
-    @test_throws MethodError stride(1:5,1)
-    @test_throws MethodError stride(1:5,2)
-    @test_throws MethodError strides(transpose(1:5))
-    @test_throws MethodError strides((1:5)')
+    test_no_strides(1:5)
+    test_no_strides(transpose(1:5))
+    test_no_strides((1:5)')
     @test_throws ErrorException pointer(transpose(1:5))
     @test_throws ErrorException pointer((1:5)')
 end


### PR DESCRIPTION
Companion PR to https://github.com/JuliaLang/julia/pull/61807

That PR changes `strides` to return `nothing` on non-strided arrays instead of throwing an error.

This PR changes `strides` of `Adjoint` and `Transpose` to pass through `nothing` if `strides(parent)` is `nothing`.

This PR should be merged before https://github.com/JuliaLang/julia/pull/61807 is.