### PR TITLE
rm trailing whitespace

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -45,7 +45,7 @@ LinearAlgebra v1.8 Release Notes
 
 - The `BLAS` submodule now supports the level-2 BLAS subroutine `spr!` ([#42830](https://github.com/JuliaLang/julia/pull/42830)).
 - `cholesky[!]` now supports `LinearAlgebra.PivotingStrategy` (singleton type) values as its optional pivot argument. The default remains `cholesky(A, NoPivot())` instead of `cholesky(A, RowMaximum())`; the previous `Val{true/false}`-based calls are now deprecated ([#41640](https://github.com/JuliaLang/julia/pull/41640)).
-- `LinearAlgebra.jl` is now completely independent of `SparseArrays.jl`, both in source code and unit testing ([#43127](https://github.com/JuliaLang/julia/pull/43127)).  
+- `LinearAlgebra.jl` is now completely independent of `SparseArrays.jl`, both in source code and unit testing ([#43127](https://github.com/JuliaLang/julia/pull/43127)).
   As a result, sparse arrays are no longer silently returned by LinearAlgebra methods applied to Base or LinearAlgebra objects. Specifically, this introduces the following breaking changes:
   - Concatenations involving special "sparse" matrices (e.g., `*diagonal`) now return dense matrices. Consequently, the `D1` and `D2` fields of `SVD` objects constructed via `getproperty` are now dense matrices.
   - `3-arg similar(::SpecialSparseMatrix, ::Type, ::Dims)` now returns a dense zero matrix. As a consequence, products of bi-, tri-, and symmetric tridiagonal matrices with each other produce dense output. Constructing 3-arg similar matrices for special "sparse" (nonstatic) matrices now fails due to the lack of `zero(::Type{Matrix{T}})`.

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1016,7 +1016,7 @@ and then the complex square root of the triangular factor.
 If a real square root exists, then an extension of this method [^H87] that computes the real
 Schur form and then the real square root of the quasi-triangular factor is instead used.
 
-When a non-Hermitian matrix has two or more null eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not. 
+When a non-Hermitian matrix has two or more null eigenvalues, the square root may not exist. In this case, and when the `check` flag is true, the algorithm will verify `X^2≈A` and throw an error if not.
 
 [^BH83]:
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1744,7 +1744,7 @@ function rotate!(x::AbstractVector, y::AbstractVector, c, s)
         @inbounds begin
             xi, yi = x[i], y[i]
             x[i] = s*yi +      c *xi
-            y[i] = c*yi - conj(s)*xi 
+            y[i] = c*yi - conj(s)*xi
         end
     end
     return x, y

--- a/src/structuredbroadcast.jl
+++ b/src/structuredbroadcast.jl
@@ -212,7 +212,7 @@ const LeftAbsorbingFuncs = Union{
 fzero(::ZeroAbsorbingFuncs, ::AbstractArray{T}) where {T<:Number} = Some(haszero(T) ? zero(T) : nothing)
 fzero(::ZeroAbsorbingFuncs, s::StructuredMatrix) = fzero(s)
 fzero(::ZeroAbsorbingFuncs, x) = fzero(x)
-# Each function in LeftAbsorbingFuncs returns NaN/Inf/error when zero is on the right. 
+# Each function in LeftAbsorbingFuncs returns NaN/Inf/error when zero is on the right.
 # We check for any zeros and return nothing if true. This falls back to a dense matrix
 # as with the scalar case.
 fzero(::LeftAbsorbingFuncs, a::AbstractArray{T}) where {T<:Number} = any(iszero, a) ? nothing : Some(one(T))

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1238,7 +1238,7 @@ for (TA, TB) in ((:AbstractTriangular, :AbstractMatrix),
 end
 
 generic_matmatmul_NN!(C, A, B, alpha, beta) = generic_matmatmul!(C, 'N', 'N', A, B, alpha, beta)
-# Optimization for strided matrices, where we know that _generic_matmatmul! will be taken 
+# Optimization for strided matrices, where we know that _generic_matmatmul! will be taken
 for (TA, TB) in ((:UpperOrLowerTriangularStrided, :StridedMatrix),
                     (:StridedMatrix, :UpperOrLowerTriangularStrided),
                     (:UpperOrLowerTriangularStrided, :UpperOrLowerTriangularStrided)
@@ -1975,7 +1975,7 @@ matop_dest(::typeof(\), A::UnitUpperOrUnitLowerTriangular, B) =
     similar(B, _inner_type_promotion(\, eltype(A), eltype(B)), size(B))
 
 matop_dest(::typeof(/), A, B::UnitUpperOrUnitLowerTriangular) =
-    similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))    
+    similar(A, _inner_type_promotion(/, eltype(A), eltype(B)), size(A))
 ## The general promotion methods
 function mul(A::UpperOrLowerTriangular, B::AbstractMatrix)
     require_one_based_indexing(B)
@@ -2643,7 +2643,7 @@ end
 
 sqrt(A::UpperTriangular; check::Bool=true) = sqrt_quasitriu(A, diagview(A); check) # matrix is upper triangular, so eigenvalues are just the diagonals
 # shouldn't need to do a check for UnitUpperTriangular because the eigenvalues are all 1, flag included so the function call lines up
-function sqrt(A::UnitUpperTriangular{T}; check=true) where T 
+function sqrt(A::UnitUpperTriangular{T}; check=true) where T
     B = A.data
     t = typeof(sqrt(zero(T)))
     R = Matrix{t}(I, size(A))
@@ -2669,7 +2669,7 @@ sqrt(A::UnitLowerTriangular; check::Bool=true) = copy(transpose(sqrt(copy(transp
 # A0 is triangular or quasitriangular matrix, evals is the eigenvalues
 function sqrt_quasitriu(A0, evals::AbstractVector; blockwidth = eltype(A0) <: Complex ? 512 : 256, check::Bool=true)
     n = checksquare(A0)
-    
+
     T = eltype(A0)
     Tr = typeof(sqrt(real(zero(T))))
     Tc = typeof(sqrt(complex(zero(T))))

--- a/test/adjtrans.jl
+++ b/test/adjtrans.jl
@@ -823,7 +823,7 @@ end
         @test LinearAlgebra.fillstored!(op(U), 2im) == op(triu(fill(f(2im), size(U))))
     end
 end
-        
+
 @testset "lmul!/rmul! by numbers" begin
     @testset "$(eltype(A))" for A in (rand(4, 4), rand(ComplexF64,4,4),
                 fill([1 2; 3 4], 4, 4),

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1413,7 +1413,7 @@ end
 
     # AbstractArray out
     c = fill(0, 4, 4)
-    kron!(c, b, a) 
+    kron!(c, b, a)
     @test c == diagm([3, 6, 4, 8])
     @test c == kron!(fill(0, 4, 4), Matrix(b), Matrix(a)) # against dense kron!
     c = Matrix{Float64}(undef, 4, 4)

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -21,7 +21,7 @@ using Main.LinearAlgebraTestHelpers.SizedArrays
         D = Diagonal(rand(N))
         B = Bidiagonal(rand(N), rand(max(0,N-1)), :U)
         T = Tridiagonal(rand(max(0,N-1)), rand(N), rand(max(0,N-1)))
-        
+
         U = UpperTriangular(rand(N,N))
         L = LowerTriangular(rand(N,N))
         UH = UpperHessenberg(rand(N,N))
@@ -161,7 +161,7 @@ using Main.LinearAlgebraTestHelpers.SizedArrays
             if N > 0
                 a = copy(fV)
                 a[1] = 0
-                @test (Q = broadcast(/, D, a); Q isa Matrix 
+                @test (Q = broadcast(/, D, a); Q isa Matrix
                     && Q[2:end, :] == broadcast(/, fD, a)[2:end, :]
                     && Q[1, 1] == Inf
                     && all(isnan, Q[1, 2:end]))


### PR DESCRIPTION
I noticed that some files still have trailing whitespace, ~~which I believe we no longer allow in new commits~~ *which is not currently checked for in PRs (see below)*, and as a result I was seeing extraneous diffs in my PRs due to my editor deleting trailing whitespace when saving a file.

This PR just deletes all trailing whitespace from `.jl` and `.md` files.