### PR TITLE
fix: zero(::UnitUpperTriangular/UnitLowerTriangular) 

### DIFF
--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,8 +1044,8 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T)))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T)))
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
 zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,10 +1044,10 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
-zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
-zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
-zero(A::UnitUpperTriangular) = UpperTriangular(zero(parent(A)))
-zero(A::UnitLowerTriangular) = LowerTriangular(zero(parent(A)))
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = UpperTriangular(fill!(similar(parent(A), T), zero(T)))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = LowerTriangular(fill!(similar(parent(A), T), zero(T)))
+zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
+zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 
 function -(A::UpperTriangular, B::UpperTriangular)
     (parent(A) isa StridedMatrix || parent(B) isa StridedMatrix) && return A .- B

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1046,8 +1046,8 @@ end
 
 zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
 zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, T), zero(T))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, T), zero(T))
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T)))), zero(T))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
 zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,6 +1044,11 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
+zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
+zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
+zero(A::UnitUpperTriangular) = UpperTriangular(zero(parent(A)))
+zero(A::UnitLowerTriangular) = LowerTriangular(zero(parent(A)))
+
 function -(A::UpperTriangular, B::UpperTriangular)
     (parent(A) isa StridedMatrix || parent(B) isa StridedMatrix) && return A .- B
     UpperTriangular(A.data - B.data)

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,8 +1044,6 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
 zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
 zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,10 +1044,10 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
 zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
 zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, typeof(zero(T)))), zero(T))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
 zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,8 +1044,10 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T))
+zero(A::UpperTriangular) = UpperTriangular(zero(parent(A)))
+zero(A::LowerTriangular) = LowerTriangular(zero(parent(A)))
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, T), zero(T))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T<:Number} = fill!(similar(A, T), zero(T))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
 zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -1044,8 +1044,8 @@ end
 +(A::UpperOrLowerTriangular, B::UpperOrLowerTriangular) = full(A) + full(B)
 +(A::AbstractTriangular, B::AbstractTriangular) = copyto!(similar(parent(A), size(A)), A) + copyto!(similar(parent(B), size(B)), B)
 
-zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = UpperTriangular(fill!(similar(parent(A), T), zero(T)))
-zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = LowerTriangular(fill!(similar(parent(A), T), zero(T)))
+zero(A::UpperTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T)))
+zero(A::LowerTriangular{T,<:StridedMatrix}) where {T} = fill!(similar(A, T), zero(T)))
 zero(A::UnitUpperTriangular) = zero(UpperTriangular(parent(A)))
 zero(A::UnitLowerTriangular) = zero(LowerTriangular(parent(A)))
 

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1140,7 +1140,9 @@ end
         @test Z isa T
         @test parent(Z) isa ZeroTestWrapTri
         @test iszero(Z)
-=======
+    end
+end
+
 @testset "eigenvalue sorting" begin
     for T in (Float64, ComplexF64, Float16, ComplexF16)
         A = randn(T, 4, 4)
@@ -1153,7 +1155,6 @@ end
             @test F.values ≈ eigvals(B; sortby = LinearAlgebra.eigsortby)
             @test F.vectors ≈ eigvecs(B; sortby = LinearAlgebra.eigsortby)
         end
->>>>>>> master
     end
 end
 

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1112,4 +1112,18 @@ end
     end
 end
 
+@testset "zero for triangular matrices" begin
+    A = rand(4, 4)
+    @test zero(UpperTriangular(A)) isa UpperTriangular
+    @test zero(LowerTriangular(A)) isa LowerTriangular
+    @test iszero(zero(UpperTriangular(A)))
+    @test iszero(zero(LowerTriangular(A)))
+    @test zero(UnitUpperTriangular(A)) isa UpperTriangular
+    @test zero(UnitLowerTriangular(A)) isa LowerTriangular
+    @test iszero(zero(UnitUpperTriangular(A)))
+    @test iszero(zero(UnitLowerTriangular(A)))
+    @test iszero(diag(zero(UnitUpperTriangular(A))))
+    @test iszero(diag(zero(UnitLowerTriangular(A))))
+end
+
 end # module TestTriangular

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1124,6 +1124,21 @@ end
     @test iszero(zero(UnitLowerTriangular(A)))
     @test iszero(diag(zero(UnitUpperTriangular(A))))
     @test iszero(diag(zero(UnitLowerTriangular(A))))
+
+        # non-strided case: zero forwards to parent
+    struct ZeroTestWrapTri{T} <: AbstractArray{T,2}
+        parent::Matrix{T}
+    end
+    Base.size(A::ZeroTestWrapTri) = size(A.parent)
+    Base.getindex(A::ZeroTestWrapTri, i, j) = A.parent[i,j]
+    Base.zero(A::ZeroTestWrapTri) = ZeroTestWrapTri(zero(A.parent))
+
+    for T in (UpperTriangular, LowerTriangular)
+        Z = zero(T(ZeroTestWrapTri([1.0 2.0; 3.0 4.0])))
+        @test Z isa T
+        @test parent(Z) isa ZeroTestWrapTri
+        @test iszero(Z)
+    end
 end
 
 end # module TestTriangular

--- a/test/triangular.jl
+++ b/test/triangular.jl
@@ -1113,7 +1113,6 @@ end
     end
 end
 
-<<<<<<< fix/zero-unit-triangular
 @testset "zero for triangular matrices" begin
     A = rand(4, 4)
     @test zero(UpperTriangular(A)) isa UpperTriangular


### PR DESCRIPTION
Fixes #1613, part of #1050.

Calling `zero` on `UnitUpperTriangular` or `UnitLowerTriangular` was throwing:
ERROR: ArgumentError: cannot set index (1, 1) on the diagonal of a UnitUpperTriangular matrix to a non-unit value (0.0)
The diagonal is locked to 1 in these types, so creating a zero matrix while preserving the type is impossible. Instead I return `UpperTriangular`/`LowerTriangular` — same idea as `zero(1:2)` returning a `Vector` instead of a `Range`.
Also handled `UpperTriangular` and `LowerTriangular` to forward to `zero(parent(A))`.