### PR TITLE
fix: zero(::Symmetric/Hermitian) use fill! for strided case

### DIFF
--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -222,7 +222,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     end
 end
 # zero should forward to the parent array type
-zero(A::Union{Symmetric{T,<:StridedMatrix},Hermitian{T,<:StridedMatrix}}) where {T<:Number} = fill!(similar(A, T), zero(T))
+zero(A::Union{Symmetric{T,<:StridedMatrix},Hermitian{T,<:StridedMatrix}}) where {T<:Number} = fill!(similar(A, typeof(zero(T))), zero(T))
 zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -222,6 +222,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     end
 end
 # zero should forward to the parent array type
+zero(A::Union{Symmetric{T,<:StridedMatrix},Hermitian{T,<:StridedMatrix}}) where {T} = fill!(similar(A, T), zero(T))
 zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -222,7 +222,7 @@ for (S, H) in ((:Symmetric, :Hermitian), (:Hermitian, :Symmetric))
     end
 end
 # zero should forward to the parent array type
-zero(A::Union{Symmetric{T,<:StridedMatrix},Hermitian{T,<:StridedMatrix}}) where {T} = fill!(similar(A, T), zero(T))
+zero(A::Union{Symmetric{T,<:StridedMatrix},Hermitian{T,<:StridedMatrix}}) where {T<:Number} = fill!(similar(A, T), zero(T))
 zero(A::Union{Symmetric,Hermitian}) = wrappertype(A)(zero(parent(A)), _sym_uplo(A.uplo))
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Symmetric} = m isa T ? m : T(m)::T
 convert(::Type{T}, m::Union{Symmetric,Hermitian}) where {T<:Hermitian} = m isa T ? m : T(m)::T

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1396,6 +1396,11 @@ Base.zero(A::ZeroTestWrap) = ZeroTestWrap(zero(A.parent))
         @test parent(Z) isa ZeroTestWrap
         @test iszero(Z)
     end
+    # strided case uses fill!
+    @test iszero(zero(Symmetric(rand(4, 4))))
+    @test zero(Symmetric(rand(4, 4))) isa Symmetric
+    @test iszero(zero(Hermitian(rand(ComplexF64, 4, 4))))
+    @test zero(Hermitian(rand(ComplexF64, 4, 4))) isa Hermitian
 end
 
 end # module TestSymmetric


### PR DESCRIPTION
Part of #1592
For strided parents, the previous implementation wrote to the whole parent array. This uses fill! on similar(A, T) instead, so only the relevant half gets filled with zeros.

The non-strided fallback still forwards to zero(parent(A)).