### PR TITLE
Array shape check in `isapprox`

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,8 +2004,16 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    _nested_axes(x) == _nested_axes(y) || return false
-    d = norm_x_minus_y(x, y)
+    local d
+    try
+        d = norm_x_minus_y(x, y)
+    catch e
+        if isa(e, DimensionMismatch)
+            return false
+        else
+            rethrow()
+        end
+    end
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
@@ -2013,11 +2021,6 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         # (mapreduce instead of all for greater generality [#44893])
         return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
-end
-_nested_axes(arr::AbstractArray{<:Number}) = axes(arr)
-function _nested_axes(arr::AbstractArray)
-    any(x -> x isa AbstractArray, arr) || return axes(arr)
-    return map(x -> x isa AbstractArray ? _nested_axes(x) : axes(x), arr)
 end
 
 norm_x_minus_y(x, y) = norm(x - y)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2014,6 +2014,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
 end
+_nested_axes(arr::AbstractArray{<:Number}) = axes(arr)
 function _nested_axes(arr::AbstractArray)
     any(x -> x isa AbstractArray, arr) || return axes(arr)
     return map(x -> x isa AbstractArray ? _nested_axes(x) : axes(x), arr)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,6 +2004,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
+    axes(A) == axes(B) || return false
     d = norm_x_minus_y(x, y)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,7 +2004,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    _nested_axes(A) == _nested_axes(B) || return false
+    _nested_axes(x) == _nested_axes(y) || return false
     d = norm_x_minus_y(x, y)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2004,7 +2004,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    axes(A) == axes(B) || return false
+    _nested_axes(A) == _nested_axes(B) || return false
     d = norm_x_minus_y(x, y)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
@@ -2013,6 +2013,10 @@ function isapprox(x::AbstractArray, y::AbstractArray;
         # (mapreduce instead of all for greater generality [#44893])
         return mapreduce((a, b) -> isapprox(a, b; rtol=rtol, atol=atol, nans=nans), &, x, y)
     end
+end
+function _nested_axes(arr::AbstractArray)
+    any(x -> x isa AbstractArray, arr) || return axes(arr)
+    return map(x -> x isa AbstractArray ? _nested_axes(x) : axes(x), arr)
 end
 
 norm_x_minus_y(x, y) = norm(x - y)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -956,6 +956,13 @@ end
     n = @allocated isapprox(A, A)
     @test n == 0
     @test Int[] ≈ Int[]
+    # arrays with different size
+    @test !isapprox(rand(2, 3), rand(2, 2))
+    # nested arrays
+    a = [[1, 2, [3, 4]], 5.0, [6im, [7.0, 8.0]]]
+    b = [[1, 2, [3, 4, 5]], 5.0, [6im, [7.0, 8.0]]]
+    @test a ≈ a
+    @test !isapprox(a, b)
 end
 
 @testset "issue 930" begin


### PR DESCRIPTION
This PR adds an array shape check in `isapprox`, so that it directly returns `false` when the two arrays to be compared have different shapes.

Closes #1624.