### PR TITLE
simplify sortby interface

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -327,12 +327,12 @@ julia> A
 ```
 """
 function eigvals!(A::StridedMatrix{<:BlasReal}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby)
-    issymmetric(A) && return sorteig!(eigvals!(Symmetric(A)), sortby)
+    issymmetric(A) && return eigvals!(Symmetric(A); sortby)
     _, valsre, valsim, _ = LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'N', 'N', A)
     return sorteig!(iszero(valsim) ? valsre : complex.(valsre, valsim), sortby)
 end
 function eigvals!(A::StridedMatrix{<:BlasComplex}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby)
-    ishermitian(A) && return sorteig!(eigvals(Hermitian(A)), sortby)
+    ishermitian(A) && return eigvals!(Hermitian(A); sortby)
     return sorteig!(LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'N', 'N', A)[2], sortby)
 end
 

--- a/src/symmetriceigen.jl
+++ b/src/symmetriceigen.jl
@@ -20,7 +20,7 @@ default_eigen_alg(@nospecialize(A)) = RobustRepresentations()
 
 # Eigensolvers for symmetric and Hermitian matrices
 function eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=eigsortby)
-    sortby2 = sortby == eigsortby ? nothing : sortby
+    sortby2 = sortby == eigsortby ? nothing : sortby # eigsortby is done by LAPACK.syev*
     if alg === DivideAndConquer()
         Eigen(sorteig!(LAPACK.syevd!('V', A.uplo, A.data)..., sortby2)...)
     elseif alg === QRIteration()

--- a/src/symmetriceigen.jl
+++ b/src/symmetriceigen.jl
@@ -19,13 +19,14 @@ Defaults to `LinearAlegbra.RobustRepresentations()`, which corresponds to the LA
 default_eigen_alg(@nospecialize(A)) = RobustRepresentations()
 
 # Eigensolvers for symmetric and Hermitian matrices
-function eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=nothing)
+function eigen!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=eigsortby)
+    sortby2 = sortby == eigsortby ? nothing : sortby
     if alg === DivideAndConquer()
-        Eigen(sorteig!(LAPACK.syevd!('V', A.uplo, A.data)..., sortby)...)
+        Eigen(sorteig!(LAPACK.syevd!('V', A.uplo, A.data)..., sortby2)...)
     elseif alg === QRIteration()
-        Eigen(sorteig!(LAPACK.syev!('V', A.uplo, A.data)..., sortby)...)
+        Eigen(sorteig!(LAPACK.syev!('V', A.uplo, A.data)..., sortby2)...)
     elseif alg === RobustRepresentations()
-        Eigen(sorteig!(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby)...)
+        Eigen(sorteig!(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)..., sortby2)...)
     else
         throw(ArgumentError("Unsupported value for `alg` keyword."))
     end
@@ -55,7 +56,7 @@ The default `alg` used may change in the future.
 
 The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`](@ref), and [`isposdef`](@ref).
 """
-function eigen(A::RealHermSymComplexHerm; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=nothing)
+function eigen(A::RealHermSymComplexHerm; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=eigsortby)
     _eigen(A; alg, sortby)
 end
 
@@ -65,7 +66,7 @@ function _eigen(A::RealHermSymComplexHerm; alg::Algorithm, sortby)
     eigen!(eigencopy_oftype(A, S); alg, sortby)
 end
 
-function _eigen(A::RealHermSymComplexHerm{Float16}; alg::Algorithm, sortby::Union{Function,Nothing}=nothing)
+function _eigen(A::RealHermSymComplexHerm{Float16}; alg::Algorithm, sortby::Union{Function,Nothing}=eigsortby)
     S = eigtype(eltype(A))
     E = eigen!(eigencopy_oftype(A, S); alg, sortby)
     values = convert(AbstractVector{Float16}, E.values)
@@ -124,7 +125,7 @@ function eigen(A::RealHermSymComplexHerm, vl::Real, vh::Real)
 end
 
 
-function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=nothing)
+function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=eigsortby)
     vals::Vector{real(eltype(A))} = if alg === DivideAndConquer()
         LAPACK.syevd!('N', A.uplo, A.data)
     elseif alg === QRIteration()
@@ -134,7 +135,7 @@ function eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}; alg::Al
     else
         throw(ArgumentError("Unsupported value for `alg` keyword."))
     end
-    !isnothing(sortby) && sort!(vals, by=sortby)
+    sorteig!(vals, sortby == eigsortby ? nothing : sortby)
     return vals
 end
 
@@ -157,7 +158,7 @@ The default `alg` used may change in the future.
     The `alg` keyword argument requires Julia 1.12 or later.
 
 """
-function eigvals(A::RealHermSymComplexHerm; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=nothing)
+function eigvals(A::RealHermSymComplexHerm; alg::Algorithm = default_eigen_alg(A), sortby::Union{Function,Nothing}=eigsortby)
     S = eigtype(eltype(A))
     eigvals!(eigencopy_oftype(A, S); alg, sortby)
 end


### PR DESCRIPTION
I think it's confusing to pass `sortby = nothing` when we want the eigenvalues to be sorted: the fact that LAPACK already sorts the eigenvalues for Hermitian matrices is an implementation detail. I've passed then `sortby = eigsortby`, and optimized this to a non-sort only in the same function where LAPACK is called.

This has the nice consequence of avoiding a useless sort when the user passes `sortby = eigsortby`.