### PR TITLE
mini-optimization of eigmax/eigmin

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -404,8 +404,8 @@ Stacktrace:
 ```
 """
 function eigmax(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true)
-    v = eigvals(A; permute, scale)
-    if eltype(v)<:Complex
+    v = eigvals(A; permute, scale, sortby=nothing)
+    if eltype(v) <: Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))
     end
     return maximum(v)
@@ -440,8 +440,8 @@ Stacktrace:
 ```
 """
 function eigmin(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true)
-    v = eigvals(A; permute, scale)
-    if eltype(v)<:Complex
+    v = eigvals(A; permute, scale, sortby=nothing)
+    if eltype(v) <: Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))
     end
     return minimum(v)


### PR DESCRIPTION
Now that `sortby` is accepted everywhere, we don't need to sort the vector before maximizing/minimizing.