### PR TITLE
fix normalize and normalize!

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2033,21 +2033,12 @@ Normalize the array `a` in-place so that its `p`-norm equals unity,
 i.e. `norm(a, p) == 1`.
 See also [`normalize`](@ref) and [`norm`](@ref).
 """
-function normalize!(a::AbstractArray, p::Real=2)
+function normalize!(a::AbstractArray, p::Real=2) #logic equal to normalize, should be kept in sync
     nrm = norm(a, p)
-    __normalize!(a, nrm)
-end
-
-@inline function __normalize!(a::AbstractArray, nrm)
-    # The largest positive floating point number whose inverse is less than infinity
-    δ = inv(prevfloat(typemax(nrm)))
-    if nrm ≥ δ # Safe to multiply with inverse
-        invnrm = inv(nrm)
-        rmul!(a, invnrm)
-    else # scale elements to avoid overflow
-        εδ = eps(one(nrm))/δ
-        rmul!(a, εδ)
-        rmul!(a, inv(nrm*εδ))
+    if !issubnormal(nrm) # nrm is accurate and inverting won't overflow
+        rmul!(a, inv(nrm))
+    else # scale elements to be non-subnormal and re-normalize
+        normalize!(rmul!(a, inv(floatmin(nrm))), p)
     end
     return a
 end
@@ -2105,14 +2096,12 @@ julia> normalize(0, 1)
 NaN
 ```
 """
-function normalize(a::AbstractArray, p::Real = 2)
+function normalize(a::AbstractArray, p::Real = 2) #logic equal to normalize!, should be kept in sync
     nrm = norm(a, p)
-    if !isempty(a)
-        aa = copymutable_oftype(a, typeof(first(a)/nrm))
-        return __normalize!(aa, nrm)
+    if !issubnormal(nrm)
+        return a * inv(nrm)
     else
-        T = typeof(zero(eltype(a))/nrm)
-        return T[]
+        return normalize(a * inv(floatmin(nrm)), p)
     end
 end
 

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -443,6 +443,11 @@ end
             @test isempty(normalize!(T[]))
         end
     end
+    a = [[1,2], [3,4]]
+    na = @inferred normalize(a)
+    @test norm(na) ≈ 1
+    @test na isa Vector{Vector{Float64}}
+    @test normalize!(convert(Vector{Vector{Float64}}, a)) ≈ na
 end
 
 @testset "normalize for multidimensional arrays" begin
@@ -478,21 +483,22 @@ end
 end
 
 @testset "potential overflow in normalize!" begin
-    δ = inv(prevfloat(typemax(Float64)))
+    δ = nextfloat(0.0)
     v = [δ, -δ]
 
-    @test norm(v) === 7.866824069956793e-309
+    @test norm(v) === 5.0e-324
     w = normalize(v)
     @test w ≈ [1/√2, -1/√2]
-    @test norm(w) === 1.0
     @test norm(normalize!(v) - w, Inf) < eps()
 end
 
 @testset "normalize with Infs. Issue 29681." begin
-    @test all(isequal.(normalize([1, -1, Inf]),
-                       [0.0, -0.0, NaN]))
-    @test all(isequal.(normalize([complex(1), complex(0, -1), complex(Inf, -Inf)]),
-                       [0.0 + 0.0im, 0.0 - 0.0im, NaN + NaN*im]))
+    for f in (normalize, normalize!)
+        @test all(isequal.(f([1, -1, Inf]),
+                           [0.0, -0.0, NaN]))
+        @test all(isequal.(f([complex(1), complex(0, -1), complex(Inf, -Inf)]),
+                           [0.0 + 0.0im, 0.0 - 0.0im, NaN + NaN*im]))
+    end
 end
 
 @testset "Issue 14657" begin

--- a/test/testhelpers/DualNumbers.jl
+++ b/test/testhelpers/DualNumbers.jl
@@ -31,8 +31,8 @@ Base.convert(::Type{Dual{T}}, x::Real) where {T} = Dual(convert(T, x), zero(T))
 
 Base.float(x::Dual) = Dual(float(x.val), float(x.eps))
 # the following two methods are needed for normalize (to check for potential overflow)
-Base.typemax(x::Dual) = Dual(typemax(x.val), zero(x.eps))
-Base.prevfloat(x::Dual{<:AbstractFloat}) = prevfloat(x.val)
+Base.floatmin(x::Dual{<:AbstractFloat}) = floatmin(x.val)
+Base.issubnormal(x::Dual{<:AbstractFloat}) = issubnormal(x.val)
 
 Base.abs2(x::Dual) = x*x
 Base.abs(x::Dual) = sqrt(abs2(x))


### PR DESCRIPTION
Closes #1630, closes #1182

I loathe duplicating code, but if we can't use `first` nor `promote_op` I guess there's no choice.

I wanted to get a `Dual` vector with subnormal norm to test both paths, but I couldn't figure out how to generate it.