### PR TITLE
properly type broadcasting between Diagonal, SymTridiagonal, Symmetric, and Hermitian

### DIFF
--- a/src/special.jl
+++ b/src/special.jl
@@ -265,25 +265,6 @@ function (-)(A::UniformScaling, B::Diagonal)
     Diagonal(Ref(A) .- B.diag)
 end
 
-for f in (:+, :-)
-    @eval function $f(D::Diagonal{<:Number}, S::Symmetric)
-        uplo = _sym_uplo(S.uplo)
-        return Symmetric(parentof_applytri($f, Symmetric(D, uplo), S), uplo)
-    end
-    @eval function $f(S::Symmetric, D::Diagonal{<:Number})
-        uplo = _sym_uplo(S.uplo)
-        return Symmetric(parentof_applytri($f, S, Symmetric(D, uplo)), uplo)
-    end
-    @eval function $f(D::Diagonal{<:Real}, H::Hermitian)
-        uplo = _sym_uplo(H.uplo)
-        return Hermitian(parentof_applytri($f, Hermitian(D, uplo), H), uplo)
-    end
-    @eval function $f(H::Hermitian, D::Diagonal{<:Real})
-        uplo = _sym_uplo(H.uplo)
-        return Hermitian(parentof_applytri($f, H, Hermitian(D, uplo)), uplo)
-    end
-end
-
 ## Diagonal construction from UniformScaling
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
 Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)

--- a/src/structuredbroadcast.jl
+++ b/src/structuredbroadcast.jl
@@ -25,7 +25,9 @@ Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixSt
     StructuredMatrixStyle{Diagonal}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{Bidiagonal}) =
     StructuredMatrixStyle{Bidiagonal}()
-Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{<:Union{SymTridiagonal,Tridiagonal}}) =
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{SymTridiagonal}) =
+    StructuredMatrixStyle{SymTridiagonal}()
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{Tridiagonal}) =
     StructuredMatrixStyle{Tridiagonal}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{<:Union{LowerTriangular,UnitLowerTriangular}}) =
     StructuredMatrixStyle{LowerTriangular}()
@@ -35,6 +37,8 @@ Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixSt
     StructuredMatrixStyle{UpperHessenberg}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{Symmetric}) =
     StructuredMatrixStyle{Symmetric}()
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{Diagonal}, ::StructuredMatrixStyle{Hermitian}) =
+    StructuredMatrixStyle{Hermitian}()
 
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Bidiagonal}, ::StructuredMatrixStyle{Diagonal}) =
     StructuredMatrixStyle{Bidiagonal}()
@@ -43,12 +47,17 @@ Broadcast.BroadcastStyle(::StructuredMatrixStyle{Bidiagonal}, ::StructuredMatrix
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Bidiagonal}, ::StructuredMatrixStyle{UpperHessenberg}) =
     StructuredMatrixStyle{UpperHessenberg}()
 
-Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{<:Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal}}) =
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{Diagonal}) =
+    StructuredMatrixStyle{SymTridiagonal}()
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{<:Union{Bidiagonal,Tridiagonal}}) =
     StructuredMatrixStyle{Tridiagonal}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{UpperHessenberg}) =
     StructuredMatrixStyle{UpperHessenberg}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{Symmetric}) =
     StructuredMatrixStyle{Symmetric}()
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{SymTridiagonal}, ::StructuredMatrixStyle{Hermitian}) =
+    StructuredMatrixStyle{Hermitian}()
+
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Tridiagonal}, ::StructuredMatrixStyle{<:Union{Diagonal,Bidiagonal,SymTridiagonal,Tridiagonal}}) =
     StructuredMatrixStyle{Tridiagonal}()
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Tridiagonal}, ::StructuredMatrixStyle{UpperHessenberg}) =
@@ -79,6 +88,11 @@ Broadcast.BroadcastStyle(::StructuredMatrixStyle{<:Union{UpperTriangular,UnitUpp
 
 Broadcast.BroadcastStyle(::StructuredMatrixStyle{Symmetric}, ::StructuredMatrixStyle{<:Union{Diagonal,SymTridiagonal}}) =
     StructuredMatrixStyle{Symmetric}()
+    Broadcast.BroadcastStyle(::StructuredMatrixStyle{Symmetric}, ::StructuredMatrixStyle{Hermitian}) =
+    StructuredMatrixStyle{Hermitian}()
+
+Broadcast.BroadcastStyle(::StructuredMatrixStyle{Hermitian}, ::StructuredMatrixStyle{<:Union{Diagonal,SymTridiagonal,Symmetric}}) =
+    StructuredMatrixStyle{Hermitian}()
 
 # Make sure that `StructuredMatrixStyle{Matrix}` doesn't ever end up falling
 # through and give back `DefaultArrayStyle{2}`
@@ -198,7 +212,7 @@ end
 
 function ishermitianpreserving(bc::Broadcasted{StructuredMatrixStyle{Hermitian}})
     bc.f isa HermitianPreservingFunction || return false
-    return all(x -> x isa Union{Real,Hermitian}, bc.args)
+    return all(x -> x isa Union{Real,Diagonal{<:Real},SymTridiagonal{<:Real},Symmetric{<:Real},Hermitian}, bc.args)
 end
 
 const HermitianPreservingFunction = Union{

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -359,9 +359,6 @@ function applytri(f, A::HermOrSym, B::HermOrSym)
         f(uppertriangular(_conjugation(A)(A.data)), uppertriangular(B.data))
     end
 end
-_parent_tri(U::UpperOrLowerTriangular) = parent(U)
-_parent_tri(U) = U
-parentof_applytri(f, args...) = applytri(_parent_tri∘f, args...)
 
 isdiag(A::HermOrSym) = applytri(isdiag, A)
 
@@ -382,9 +379,6 @@ Hermitian{T,S}(A::Hermitian{T,S}) where {T,S<:AbstractMatrix{T}} = A
 Hermitian{T,S}(A::Hermitian) where {T,S<:AbstractMatrix{T}} = Hermitian{T,S}(convert(S,A.data),A.uplo)
 AbstractMatrix{T}(A::Hermitian) where {T} = Hermitian(convert(AbstractMatrix{T}, A.data), _sym_uplo(A.uplo))
 AbstractMatrix{T}(A::Hermitian{T}) where {T} = copy(A)
-
-copy(A::Symmetric) = (Symmetric(parentof_applytri(copy, A), _sym_uplo(A.uplo)))
-copy(A::Hermitian) = (Hermitian(parentof_applytri(copy, A), _sym_uplo(A.uplo)))
 
 function copyto!(dest::Symmetric, src::Symmetric)
     if axes(dest) != axes(src)
@@ -726,28 +720,6 @@ function _hermkron!(C, A, B, conj, real, Auplo, Buplo)
     end
 end
 
-(-)(A::Symmetric) = Symmetric(parentof_applytri(-, A), _sym_uplo(A.uplo))
-(-)(A::Hermitian) = Hermitian(parentof_applytri(-, A), _sym_uplo(A.uplo))
-
-## Addition/subtraction
-for f ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
-    @eval function $f(A::$Wrapper, B::$Wrapper)
-        uplo = A.uplo == B.uplo ? _sym_uplo(A.uplo) : (:U)
-        $Wrapper(parentof_applytri($f, A, B), uplo)
-    end
-end
-
-for f in (:+, :-)
-    @eval begin
-        $f(A::Hermitian, B::Symmetric{<:Real}) = $f(A, Hermitian(parent(B), _sym_uplo(B.uplo)))
-        $f(A::Symmetric{<:Real}, B::Hermitian) = $f(Hermitian(parent(A), _sym_uplo(A.uplo)), B)
-        $f(A::SymTridiagonal, B::Symmetric) = $f(Symmetric(A, _sym_uplo(B.uplo)), B)
-        $f(A::Symmetric, B::SymTridiagonal) = $f(A, Symmetric(B, _sym_uplo(A.uplo)))
-        $f(A::SymTridiagonal{<:Real}, B::Hermitian) = $f(Hermitian(A, _sym_uplo(B.uplo)), B)
-        $f(A::Hermitian, B::SymTridiagonal{<:Real}) = $f(A, Hermitian(B, _sym_uplo(A.uplo)))
-    end
-end
-
 mul(A::HermOrSym, B::HermOrSym) = A * copyto!(similar(parent(B)), B)
 # catch a few potential BLAS-cases
 function mul(A::HermOrSym{<:BlasFloat,<:StridedMatrix}, B::AdjOrTrans{<:BlasFloat,<:StridedMatrix})
@@ -793,14 +765,6 @@ function dot(x::AbstractVector, A::HermOrSym, y::AbstractVector)
     end
     return r
 end
-
-# Scaling with Number
-*(A::Symmetric, x::Number) = Symmetric(parentof_applytri(y -> y * x, A), _sym_uplo(A.uplo))
-*(x::Number, A::Symmetric) = Symmetric(parentof_applytri(y -> x * y, A), _sym_uplo(A.uplo))
-*(A::Hermitian, x::Real) = Hermitian(parentof_applytri(y -> y * x, A), _sym_uplo(A.uplo))
-*(x::Real, A::Hermitian) = Hermitian(parentof_applytri(y -> x * y, A), _sym_uplo(A.uplo))
-/(A::Symmetric, x::Number) = Symmetric(parentof_applytri(y -> y/x, A), _sym_uplo(A.uplo))
-/(A::Hermitian, x::Real) = Hermitian(parentof_applytri(y -> y/x, A), _sym_uplo(A.uplo))
 
 factorize(A::HermOrSym) = _factorize(A)
 function _factorize(A::HermOrSym{T}; check::Bool=true) where T

--- a/test/structuredbroadcast.jl
+++ b/test/structuredbroadcast.jl
@@ -512,6 +512,15 @@ end
     Sc = Symmetric(randn(ComplexF64, 3,3))
     Hr = Hermitian(randn(3,3))
     Hc = Hermitian(randn(ComplexF64, 3,3))
+    # Diagonal, SymTridiagonal
+    @test Dr .+ Tr isa SymTridiagonal{<:Real}
+    @test Dr .+ Tr == Matrix(Dr) + Matrix(Tr)
+    @test Dr .+ Tc isa SymTridiagonal
+    @test Dr .+ Tc == Matrix(Dr) + Matrix(Tc)
+    @test Dc .+ Tr isa SymTridiagonal
+    @test Dc .+ Tr == Matrix(Dc) + Matrix(Tr)
+    @test Dc .+ Tc isa SymTridiagonal
+    @test Dc .+ Tc == Matrix(Dc) + Matrix(Tc)
     # Diagonal, Symmetric
     @test Dr .+ Sr isa Symmetric{<:Real}
     @test Dr .+ Sr == Matrix(Dr) + Matrix(Sr)
@@ -522,10 +531,14 @@ end
     @test Dc .+ Sc isa Symmetric
     @test Dc .+ Sc == Matrix(Dc) + Matrix(Sc)
     # Diagonal, Hermitian
+    @test Dr .+ Hr isa Hermitian{<:Real}
     @test Dr .+ Hr == Matrix(Dr) + Matrix(Hr)
+    @test Dr .+ Hc isa Hermitian
     @test Dr .+ Hc == Matrix(Dr) + Matrix(Hc)
     @test Dc .+ Hr == Matrix(Dc) + Matrix(Hr)
+    @test_throws ArgumentError Hr .+= Dc
     @test Dc .+ Hc == Matrix(Dc) + Matrix(Hc)
+    @test_throws ArgumentError Hc .+= Dc
     # SymTridiagonal, Symmetric
     @test Tr .+ Sr isa Symmetric{<:Real}
     @test Tr .+ Sr == Matrix(Tr) + Matrix(Sr)
@@ -536,20 +549,28 @@ end
     @test Tc .+ Sc isa Symmetric
     @test Tc .+ Sc == Matrix(Tc) + Matrix(Sc)
     # SymTridiagonal, Hermitian
+    @test Tr .+ Hr isa Hermitian{<:Real}
     @test Tr .+ Hr == Matrix(Tr) + Matrix(Hr)
     @test Tr .+ Hc == Matrix(Tr) + Matrix(Hc)
+    @test Tr .+ Hc isa Hermitian
     @test Tc .+ Hr == Matrix(Tc) + Matrix(Hr)
+    @test_throws ArgumentError Hr .+= Tc
     @test Tc .+ Hc == Matrix(Tc) + Matrix(Hc)
+    @test_throws ArgumentError Hc .+= Tc
     for uplo1 in (:U, :L), uplo2 in (:U, :L)
         # Symmetric, Hermitian
         Sr = Symmetric(randn(3,3), uplo1)
         Sc = Symmetric(randn(ComplexF64, 3,3), uplo1)
         Hr = Hermitian(randn(3,3), uplo2)
         Hc = Hermitian(randn(ComplexF64, 3,3), uplo2)
+        @test Sr .+ Hr isa Hermitian{<:Real}
         @test Sr .+ Hr == Matrix(Sr) + Matrix(Hr)
+        @test Sr .+ Hc isa Hermitian
         @test Sr .+ Hc == Matrix(Sr) + Matrix(Hc)
         @test Sc .+ Hr == Matrix(Sc) + Matrix(Hr)
+        @test_throws ArgumentError Hr .+= Sc
         @test Sc .+ Hc == Matrix(Sc) + Matrix(Hc)
+        @test_throws ArgumentError Hc .+= Sc
         # Symmetric, Symmetric
         Sr1 = Symmetric(randn(3,3), uplo1)
         Sc1 = Symmetric(randn(ComplexF64, 3,3), uplo1)


### PR DESCRIPTION
Follow-up to #1607

Now `Diagonal` .+ `Hermitian`, `SymTridiagonal` .+ `Hermitian`, and `Symmetric` .+ `Hermitian` return properly typed matrices. With it we can remove the pseudo-broadcasting mechanism @jishnub had introduced for `Symmetric` and `Hermitian`.

I decided to sacrifice the combinations `Diagonal{<:Complex}` .+ `Hermitian{<:Real}`, `SymTridiagonal{<:Complex}` .+ `Hermitian{<:Real}`, and `Symmetric{<:Complex}` .+ `Hermitian{<:Real}`, as this drastically simplifies the code. They are of little use, as we have few methods that can handle `Symmetric{<:Complex}` (I found `bunchkaufman`, `kron`, and `dot`).