### PR TITLE
mini-optimization of transposition

### DIFF
--- a/src/transpose.jl
+++ b/src/transpose.jl
@@ -104,8 +104,8 @@ function transpose_f!(f, B::AbstractMatrix, A::AbstractMatrix)
     m, n = length(inds[1]), length(inds[2])
     if m*n<=4*transposebaselength
         @inbounds begin
-            for j = inds[2]
-                for i = inds[1]
+            for i = inds[1]
+                for j = inds[2]
                     B[j,i] = f(A[i,j])
                 end
             end
@@ -118,8 +118,8 @@ end
 function transposeblock!(f, B::AbstractMatrix, A::AbstractMatrix, m::Int, n::Int, offseti::Int, offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
-            for j = offsetj .+ (1:n)
-                for i = offseti .+ (1:m)
+            for i = offseti .+ (1:m)
+                for j = offsetj .+ (1:n)
                     B[j,i] = f(A[i,j])
                 end
             end


### PR DESCRIPTION
[This essay](https://gudok.xyz/transpose/) claims that out-of-order writes are more expensive than out-of-order reads, so I swapped them, and voilà, benchmarks agree. On master:
```julia
julia> @btime transpose!(B, A) setup = (n = 16; A = randn(n, n); B = similar(A));
  59.745 ns (0 allocations: 0 bytes)

julia> @btime transpose!(B, A) setup = (n = 1024; A = randn(n, n); B = similar(A));
  2.103 ms (0 allocations: 0 bytes)
```
This PR:
```julia
julia> @btime transpose!(B, A) setup = (n = 16; A = randn(n, n); B = similar(A));
  54.327 ns (0 allocations: 0 bytes)

julia> @btime transpose!(B, A) setup = (n = 1024; A = randn(n, n); B = similar(A));
  1.928 ms (0 allocations: 0 bytes)
```
The magical number 16 is the largest size for which transposition doesn't use the blocked algorithm, so I'm benchmarking both cases.