### PR TITLE
Remove methods for some unary operations

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -310,9 +310,9 @@ size(M::Bidiagonal) = (n = length(M.dv); (n, n))
 axes(M::Bidiagonal) = (ax = axes(M.dv, 1); (ax, ax))
 
 #Elementary operations
-for func in (:conj, :copy, :real, :imag)
-    @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.uplo)
-end
+# for func in (:conj, :copy, :real, :imag)
+#     @eval ($func)(M::Bidiagonal) = Bidiagonal(($func)(M.dv), ($func)(M.ev), M.uplo)
+# end
 isreal(M::Bidiagonal) = isreal(M.dv) && isreal(M.ev)
 
 adjoint(B::Bidiagonal) = Bidiagonal(_vecadjoint(B.dv), _vecadjoint(B.ev), B.uplo == 'U' ? :L : :U)
@@ -460,9 +460,9 @@ function -(A::Bidiagonal, B::Bidiagonal)
     end
 end
 
--(A::Bidiagonal)=Bidiagonal(-A.dv,-A.ev,A.uplo)
-*(A::Bidiagonal, B::Number) = Bidiagonal(A.dv*B, A.ev*B, A.uplo)
-*(B::Number, A::Bidiagonal) = Bidiagonal(B*A.dv, B*A.ev, A.uplo)
+# -(A::Bidiagonal)=Bidiagonal(-A.dv,-A.ev,A.uplo)
+# *(A::Bidiagonal, B::Number) = Bidiagonal(A.dv*B, A.ev*B, A.uplo)
+# *(B::Number, A::Bidiagonal) = Bidiagonal(B*A.dv, B*A.ev, A.uplo)
 function rmul!(B::Bidiagonal, x::Number)
     if size(B,1) > 1
         isupper = B.uplo == 'U'
@@ -489,8 +489,8 @@ function lmul!(x::Number, B::Bidiagonal)
     lmul!(x, B.ev)
     return B
 end
-/(A::Bidiagonal, B::Number) = Bidiagonal(A.dv/B, A.ev/B, A.uplo)
-\(B::Number, A::Bidiagonal) = Bidiagonal(B\A.dv, B\A.ev, A.uplo)
+# /(A::Bidiagonal, B::Number) = Bidiagonal(A.dv/B, A.ev/B, A.uplo)
+# \(B::Number, A::Bidiagonal) = Bidiagonal(B\A.dv, B\A.ev, A.uplo)
 
 function ==(A::Bidiagonal, B::Bidiagonal)
     if A.uplo == B.uplo

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -251,7 +251,7 @@ end
 
 parent(D::Diagonal) = D.diag
 
-copy(D::Diagonal) = Diagonal(copy(D.diag))
+# copy(D::Diagonal) = Diagonal(copy(D.diag))
 
 Base._reverse(A::Diagonal, dims) = reverse!(Matrix(A); dims)
 Base._reverse(A::Diagonal, ::Colon) = Diagonal(reverse(A.diag))

--- a/src/hessenberg.jl
+++ b/src/hessenberg.jl
@@ -72,9 +72,10 @@ AbstractMatrix{T}(H::UpperHessenberg{T}) where {T} = copy(H)
 Base.dataids(A::UpperHessenberg) = Base.dataids(parent(A))
 Base.unaliascopy(A::UpperHessenberg) = UpperHessenberg(Base.unaliascopy(parent(A)))
 
+# TODO: provide a specialized copyto!(::UpperHessenberg, ::UpperHessenberg) method and rely on fallback
 copy(H::UpperHessenberg) = UpperHessenberg(copy(H.data))
-real(H::UpperHessenberg{<:Complex}) = UpperHessenberg(triu!(real(H.data),-1))
-imag(H::UpperHessenberg) = UpperHessenberg(triu!(imag(H.data),-1))
+# real(H::UpperHessenberg{<:Complex}) = UpperHessenberg(triu!(real(H.data),-1))
+# imag(H::UpperHessenberg) = UpperHessenberg(triu!(imag(H.data),-1))
 
 Base.@constprop :aggressive function istriu(A::UpperHessenberg, k::Integer=0)
     k <= -1 && return true
@@ -121,7 +122,7 @@ end
 Base.copy(A::Adjoint{<:Any,<:UpperHessenberg}) = tril!(adjoint!(similar(A.parent.data), A.parent.data), 1)
 Base.copy(A::Transpose{<:Any,<:UpperHessenberg}) = tril!(transpose!(similar(A.parent.data), A.parent.data), 1)
 
--(A::UpperHessenberg) = UpperHessenberg(-A.data)
+# -(A::UpperHessenberg) = UpperHessenberg(-A.data)
 rmul!(H::UpperHessenberg, x::Number) = (rmul!(H.data, x); H)
 lmul!(x::Number, H::UpperHessenberg) = (lmul!(x, H.data); H)
 

--- a/src/triangular.jl
+++ b/src/triangular.jl
@@ -42,11 +42,11 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular, :UnitUpperTr
         # storage type of A (not wrapped in a triangular type). The following method covers these cases.
         similar(A::$t, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(A), T, dims)
 
-        copy(A::$t) = $t(copy(A.data))
+        # copy(A::$t) = $t(copy(A.data))
         Base.unaliascopy(A::$t) = $t(Base.unaliascopy(A.data))
 
-        real(A::$t{<:Complex}) = (B = real(A.data); $t(B))
-        real(A::$t{<:Complex, <:StridedMaybeAdjOrTransMat}) = $t(real.(A))
+        # real(A::$t{<:Complex}) = (B = real(A.data); $t(B))
+        # real(A::$t{<:Complex, <:StridedMaybeAdjOrTransMat}) = $t(real.(A))
     end
 end
 
@@ -158,29 +158,6 @@ function Matrix{T}(U::UpperOrLowerTriangular) where {T}
     M = Matrix{T}(undef, size(U))
     copy!(M, U)
     return M
-end
-
-imag(A::UpperTriangular) = UpperTriangular(imag(A.data))
-imag(A::LowerTriangular) = LowerTriangular(imag(A.data))
-imag(A::UpperTriangular{<:Any,<:StridedMaybeAdjOrTransMat}) = imag.(A)
-imag(A::LowerTriangular{<:Any,<:StridedMaybeAdjOrTransMat}) = imag.(A)
-function imag(A::UnitLowerTriangular)
-    L = LowerTriangular(A.data)
-    Lim = similar(L) # must be mutable to set diagonals to zero
-    Lim .= imag.(L)
-    for i in axes(Lim,1)
-        Lim[i,i] = zero(Lim[i,i])
-    end
-    return Lim
-end
-function imag(A::UnitUpperTriangular)
-    U = UpperTriangular(A.data)
-    Uim = similar(U) # must be mutable to set diagonals to zero
-    Uim .= imag.(U)
-    for i in axes(Uim,1)
-        Uim[i,i] = zero(Uim[i,i])
-    end
-    return Uim
 end
 
 parent(A::UpperOrLowerTriangular) = A.data
@@ -552,31 +529,31 @@ diag(A::UpperOrLowerTriangular) = diag(A.data)
 diag(A::Union{UnitLowerTriangular, UnitUpperTriangular}) = fill(oneunit(eltype(A)), size(A,1))
 
 # Unary operations
--(A::LowerTriangular) = LowerTriangular(-A.data)
--(A::UpperTriangular) = UpperTriangular(-A.data)
-function -(A::UnitLowerTriangular)
-    Adata = A.data
-    Anew = similar(Adata) # must be mutable, even if Adata is not
-    @. Anew = -Adata
-    for i in axes(A, 1)
-        Anew[i, i] = -A[i, i]
-    end
-    LowerTriangular(Anew)
-end
-function -(A::UnitUpperTriangular)
-    Adata = A.data
-    Anew = similar(Adata) # must be mutable, even if Adata is not
-    @. Anew = -Adata
-    for i in axes(A, 1)
-        Anew[i, i] = -A[i, i]
-    end
-    UpperTriangular(Anew)
-end
+# -(A::LowerTriangular) = LowerTriangular(-A.data)
+# -(A::UpperTriangular) = UpperTriangular(-A.data)
+# function -(A::UnitLowerTriangular)
+#     Adata = A.data
+#     Anew = similar(Adata) # must be mutable, even if Adata is not
+#     @. Anew = -Adata
+#     for i in axes(A, 1)
+#         Anew[i, i] = -A[i, i]
+#     end
+#     LowerTriangular(Anew)
+# end
+# function -(A::UnitUpperTriangular)
+#     Adata = A.data
+#     Anew = similar(Adata) # must be mutable, even if Adata is not
+#     @. Anew = -Adata
+#     for i in axes(A, 1)
+#         Anew[i, i] = -A[i, i]
+#     end
+#     UpperTriangular(Anew)
+# end
 
-# use broadcasting if the parents are strided, where we loop only over the triangular part
-for TM in (:LowerTriangular, :UpperTriangular)
-    @eval -(A::$TM{<:Any, <:StridedMaybeAdjOrTransMat}) = broadcast(-, A)
-end
+# # use broadcasting if the parents are strided, where we loop only over the triangular part
+# for TM in (:LowerTriangular, :UpperTriangular)
+#     @eval -(A::$TM{<:Any, <:StridedMaybeAdjOrTransMat}) = broadcast(-, A)
+# end
 
 tr(A::UpperOrLowerTriangular) = tr(A.data)
 tr(A::Union{UnitLowerTriangular, UnitUpperTriangular}) = size(A, 1) * oneunit(eltype(A))

--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -169,9 +169,9 @@ _copyto_banded!(dest::SymTridiagonal, src::SymTridiagonal) =
     (copyto!(dest.dv, src.dv); copyto!(dest.ev, src.ev); dest)
 
 #Elementary operations
-for func in (:conj, :copy, :real, :imag)
-    @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
-end
+# for func in (:conj, :copy, :real, :imag)
+#     @eval ($func)(M::SymTridiagonal) = SymTridiagonal(($func)(M.dv), ($func)(M.ev))
+# end
 isreal(S::SymTridiagonal) = isreal(S.dv) && isreal(S.ev)
 
 transpose(S::SymTridiagonal) = S
@@ -215,11 +215,11 @@ function diag(M::SymTridiagonal, n::Integer=0)
     return v
 end
 
-+(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv+B.dv, A.ev+B.ev)
--(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv-B.dv, A.ev-B.ev)
--(A::SymTridiagonal) = SymTridiagonal(-A.dv, -A.ev)
-*(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv*B, A.ev*B)
-*(B::Number, A::SymTridiagonal) = SymTridiagonal(B*A.dv, B*A.ev)
+# +(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv+B.dv, A.ev+B.ev)
+# -(A::SymTridiagonal, B::SymTridiagonal) = SymTridiagonal(A.dv-B.dv, A.ev-B.ev)
+# -(A::SymTridiagonal) = SymTridiagonal(-A.dv, -A.ev)
+# *(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv*B, A.ev*B)
+# *(B::Number, A::SymTridiagonal) = SymTridiagonal(B*A.dv, B*A.ev)
 function rmul!(A::SymTridiagonal, x::Number)
     if size(A,1) > 2
         # ensure that zeros are preserved on scaling
@@ -242,8 +242,8 @@ function lmul!(x::Number, B::SymTridiagonal)
     lmul!(x, B.ev)
     return B
 end
-/(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv/B, A.ev/B)
-\(B::Number, A::SymTridiagonal) = SymTridiagonal(B\A.dv, B\A.ev)
+# /(A::SymTridiagonal, B::Number) = SymTridiagonal(A.dv/B, A.ev/B)
+# \(B::Number, A::SymTridiagonal) = SymTridiagonal(B\A.dv, B\A.ev)
 ==(A::SymTridiagonal{<:Number}, B::SymTridiagonal{<:Number}) =
     (A.dv == B.dv) && (A.ev == B.ev)
 ==(A::SymTridiagonal, B::SymTridiagonal) =
@@ -725,11 +725,11 @@ function _copyto_banded!(dest::Tridiagonal, src::Tridiagonal)
 end
 
 #Elementary operations
-for func in (:conj, :copy, :real, :imag)
-    @eval function ($func)(M::Tridiagonal)
-        Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du))
-    end
-end
+# for func in (:conj, :copy, :real, :imag)
+#     @eval function ($func)(M::Tridiagonal)
+#         Tridiagonal(($func)(M.dl), ($func)(M.d), ($func)(M.du))
+#     end
+# end
 isreal(T::Tridiagonal) = isreal(T.dl) && isreal(T.d) && isreal(T.du)
 
 adjoint(S::Tridiagonal{<:Number}) = Tridiagonal(vec(adjoint(S.du)), vec(adjoint(S.d)), vec(adjoint(S.dl)))
@@ -939,11 +939,11 @@ tr(M::Tridiagonal) = sum(M.d)
 # Generic methods #
 ###################
 
-+(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl+B.dl, A.d+B.d, A.du+B.du)
--(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl-B.dl, A.d-B.d, A.du-B.du)
--(A::Tridiagonal) = Tridiagonal(-A.dl, -A.d, -A.du)
-*(A::Tridiagonal, B::Number) = Tridiagonal(A.dl*B, A.d*B, A.du*B)
-*(B::Number, A::Tridiagonal) = Tridiagonal(B*A.dl, B*A.d, B*A.du)
+# +(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl+B.dl, A.d+B.d, A.du+B.du)
+# -(A::Tridiagonal, B::Tridiagonal) = Tridiagonal(A.dl-B.dl, A.d-B.d, A.du-B.du)
+# -(A::Tridiagonal) = Tridiagonal(-A.dl, -A.d, -A.du)
+# *(A::Tridiagonal, B::Number) = Tridiagonal(A.dl*B, A.d*B, A.du*B)
+# *(B::Number, A::Tridiagonal) = Tridiagonal(B*A.dl, B*A.d, B*A.du)
 function rmul!(T::Tridiagonal, x::Number)
     if size(T,1) > 2
         # ensure that zeros are preserved on scaling
@@ -968,8 +968,8 @@ function lmul!(x::Number, T::Tridiagonal)
     lmul!(x, T.du)
     return T
 end
-/(A::Tridiagonal, B::Number) = Tridiagonal(A.dl/B, A.d/B, A.du/B)
-\(B::Number, A::Tridiagonal) = Tridiagonal(B\A.dl, B\A.d, B\A.du)
+# /(A::Tridiagonal, B::Number) = Tridiagonal(A.dl/B, A.d/B, A.du/B)
+# \(B::Number, A::Tridiagonal) = Tridiagonal(B\A.dl, B\A.d, B\A.du)
 
 ==(A::Tridiagonal, B::Tridiagonal) = (A.dl==B.dl) && (A.d==B.d) && (A.du==B.du)
 function ==(A::Tridiagonal, B::SymTridiagonal)


### PR DESCRIPTION
From what I understand, these should all work with the generic fallbacks and (except for `copy`) via broadcasting. Not surprisingly, this is in many cases even faster. For instance, broadcasting doesn't even touch the unseen triangle with `*Triangular` matrices.