### PR TITLE
make eig*(::Bidiagonal) accept sortby

### DIFF
--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1452,10 +1452,7 @@ function eigvecs(M::Bidiagonal{T}; sortby=eigsortby) where T
             for j = blks[idx_block] + 1:i - 1 #Starting from j=i, eigenvector elements will be 0
                 v[j+1] = (M.dv[i] - M.dv[j])/M.ev[j] * v[j]
             end
-            c = norm(v)
-            for j = 1:n
-                Q[j, i] = v[j] / c
-            end
+            Q[:, i] = normalize!(v)
         end
     else
         for idx_block = 1:length(blks) - 1, i = blks[idx_block + 1]:-1:blks[idx_block] + 1 #index of eigenvector
@@ -1464,10 +1461,7 @@ function eigvecs(M::Bidiagonal{T}; sortby=eigsortby) where T
             for j = (blks[idx_block+1] - 1):-1:max(1, (i - 1)) #Starting from j=i, eigenvector elements will be 0
                 v[j] = (M.dv[i] - M.dv[j+1])/M.ev[j] * v[j+1]
             end
-            c = norm(v)
-            for j = 1:n
-                Q[j, i] = v[j] / c
-            end
+            Q[:, i] = normalize!(v)
         end
     end
     return isnothing(sortby) ? Q : sorteig!(copy(M.dv), Q, sortby)[2]

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1470,7 +1470,7 @@ function eigvecs(M::Bidiagonal{T}; sortby=eigsortby) where T
             end
         end
     end
-    return sorteig!(copy(M.dv), Q, sortby)[2]
+    return isnothing(sortby) ? Q : sorteig!(copy(M.dv), Q, sortby)[2]
 end
 eigen(M::Bidiagonal; sortby=eigsortby) = Eigen(sorteig!(eigvals(M; sortby=nothing), eigvecs(M; sortby=nothing), sortby)...)
 

--- a/src/bidiag.jl
+++ b/src/bidiag.jl
@@ -1439,8 +1439,8 @@ for (T, uplo) in ((:UpperTriangular, :(:U)), (:LowerTriangular, :(:L)))
 end
 
 # Eigensystems
-eigvals(M::Bidiagonal) = copy(M.dv)
-function eigvecs(M::Bidiagonal{T}) where T
+eigvals(M::Bidiagonal; sortby=eigsortby) = sorteig!(copy(M.dv), sortby)
+function eigvecs(M::Bidiagonal{T}; sortby=eigsortby) where T
     n = length(M.dv)
     Q = Matrix{T}(undef, n,n)
     blks = [0; findall(iszero, M.ev); n]
@@ -1470,9 +1470,9 @@ function eigvecs(M::Bidiagonal{T}) where T
             end
         end
     end
-    Q #Actually Triangular
+    return sorteig!(copy(M.dv), Q, sortby)[2]
 end
-eigen(M::Bidiagonal) = Eigen(eigvals(M), eigvecs(M))
+eigen(M::Bidiagonal; sortby=eigsortby) = Eigen(sorteig!(eigvals(M; sortby=nothing), eigvecs(M; sortby=nothing), sortby)...)
 
 Base._sum(A::Bidiagonal, ::Colon) = sum(A.dv) + sum(A.ev)
 function Base._sum(A::Bidiagonal, dims::Integer)

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -403,8 +403,8 @@ Random.seed!(1)
 
         @testset "Eigensystems" begin
             if relty <: AbstractFloat
-                d1, v1 = eigen(T)
-                d2, v2 = eigen(map(elty<:Complex ? ComplexF64 : Float64,Tfull), sortby=nothing)
+                d1, v1 = eigen(T; sortby=nothing)
+                d2, v2 = eigen(map(elty<:Complex ? ComplexF64 : Float64,Tfull); sortby=nothing)
                 @test (uplo === :U ? d1 : reverse(d1)) ≈ d2
                 if elty <: Real
                     test_approx_eq_modphase(v1, uplo === :U ? v2 : v2[:,n:-1:1])
@@ -1293,6 +1293,18 @@ end
         @test B == B2
         LinearAlgebra.fillband!(B, 0, 10, 10)
         @test B == B2
+    end
+end
+
+@testset "eigenvalue sorting" begin
+    for T in (Float64, ComplexF64, Float16, ComplexF16)
+        B = Bidiagonal(randn(T, 4), randn(T, 3), :U)
+        @test eigvals(B; sortby=nothing) == diag(B)
+        F = eigen(B)
+        @test issorted(F.values, by=LinearAlgebra.eigsortby) #sort by default
+        @test B * F.vectors ≈ F.vectors * Diagonal(F.values)
+        @test F.values ≈ eigvals(B; sortby = LinearAlgebra.eigsortby)
+        @test F.vectors ≈ eigvecs(B; sortby = LinearAlgebra.eigsortby)
     end
 end
 

--- a/test/bidiag.jl
+++ b/test/bidiag.jl
@@ -1303,7 +1303,7 @@ end
         F = eigen(B)
         @test issorted(F.values, by=LinearAlgebra.eigsortby) #sort by default
         @test B * F.vectors ≈ F.vectors * Diagonal(F.values)
-        @test F.values ≈ eigvals(B; sortby = LinearAlgebra.eigsortby)
+        @test F.values == sort!(diag(B), by=LinearAlgebra.eigsortby) == eigvals(B; sortby = LinearAlgebra.eigsortby)
         @test F.vectors ≈ eigvecs(B; sortby = LinearAlgebra.eigsortby)
     end
 end


### PR DESCRIPTION
Closes #1644

In my defence I had tested it; I just didn't realise that `eigvals(B; sortby)` was falling back to the general case instead of using the dedicated `Bidiagonal` methods.