### PR TITLE
revert overly enthusiastic removal of methods

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -263,6 +263,9 @@ isposdef(D::Diagonal) = all(isposdef, D.diag)
 
 factorize(D::Diagonal) = D
 
+real(D::Diagonal) = Diagonal(real(D.diag))
+imag(D::Diagonal) = Diagonal(imag(D.diag))
+
 isreal(D::Diagonal) = isreal(D.diag)
 
 iszero(D::Diagonal) = all(iszero, D.diag)
@@ -294,7 +297,12 @@ function tril!(D::Diagonal{T}, k::Integer=0) where T
 end
 
 (==)(Da::Diagonal, Db::Diagonal) = Da.diag == Db.diag
+(-)(A::Diagonal) = Diagonal(-A.diag)
+(+)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag + Db.diag)
+(-)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag - Db.diag)
 
+(*)(x::Number, D::Diagonal) = Diagonal(x * D.diag)
+(*)(D::Diagonal, x::Number) = Diagonal(D.diag * x)
 function lmul!(x::Number, D::Diagonal)
     if size(D,1) > 1
         # ensure that zeros are preserved on scaling
@@ -315,6 +323,8 @@ function rmul!(D::Diagonal, x::Number)
     rmul!(D.diag, x)
     return D
 end
+(/)(D::Diagonal, x::Number) = Diagonal(D.diag / x)
+(\)(x::Number, D::Diagonal) = Diagonal(x \ D.diag)
 (^)(D::Diagonal, a::Number) = Diagonal(D.diag .^ a)
 (^)(D::Diagonal, a::Real) = Diagonal(D.diag .^ a) # for disambiguation
 (^)(D::Diagonal, a::Integer) = Diagonal(D.diag .^ a) # for disambiguation
@@ -936,6 +946,7 @@ end
     return C
 end
 
+conj(D::Diagonal) = Diagonal(conj(D.diag))
 transpose(D::Diagonal) = Diagonal(_vectranspose(D.diag))
 adjoint(D::Diagonal) = Diagonal(_vecadjoint(D.diag))
 permutedims(D::Diagonal) = D

--- a/src/special.jl
+++ b/src/special.jl
@@ -265,6 +265,25 @@ function (-)(A::UniformScaling, B::Diagonal)
     Diagonal(Ref(A) .- B.diag)
 end
 
+for f in (:+, :-)
+    @eval function $f(D::Diagonal{<:Number}, S::Symmetric)
+        uplo = _sym_uplo(S.uplo)
+        return Symmetric(parentof_applytri($f, Symmetric(D, uplo), S), uplo)
+    end
+    @eval function $f(S::Symmetric, D::Diagonal{<:Number})
+        uplo = _sym_uplo(S.uplo)
+        return Symmetric(parentof_applytri($f, S, Symmetric(D, uplo)), uplo)
+    end
+    @eval function $f(D::Diagonal{<:Real}, H::Hermitian)
+        uplo = _sym_uplo(H.uplo)
+        return Hermitian(parentof_applytri($f, Hermitian(D, uplo), H), uplo)
+    end
+    @eval function $f(H::Hermitian, D::Diagonal{<:Real})
+        uplo = _sym_uplo(H.uplo)
+        return Hermitian(parentof_applytri($f, H, Hermitian(D, uplo)), uplo)
+    end
+end
+
 ## Diagonal construction from UniformScaling
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
 Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -359,6 +359,9 @@ function applytri(f, A::HermOrSym, B::HermOrSym)
         f(uppertriangular(_conjugation(A)(A.data)), uppertriangular(B.data))
     end
 end
+_parent_tri(U::UpperOrLowerTriangular) = parent(U)
+_parent_tri(U) = U
+parentof_applytri(f, args...) = applytri(_parent_tri∘f, args...)
 
 isdiag(A::HermOrSym) = applytri(isdiag, A)
 
@@ -379,6 +382,9 @@ Hermitian{T,S}(A::Hermitian{T,S}) where {T,S<:AbstractMatrix{T}} = A
 Hermitian{T,S}(A::Hermitian) where {T,S<:AbstractMatrix{T}} = Hermitian{T,S}(convert(S,A.data),A.uplo)
 AbstractMatrix{T}(A::Hermitian) where {T} = Hermitian(convert(AbstractMatrix{T}, A.data), _sym_uplo(A.uplo))
 AbstractMatrix{T}(A::Hermitian{T}) where {T} = copy(A)
+
+copy(A::Symmetric) = (Symmetric(parentof_applytri(copy, A), _sym_uplo(A.uplo)))
+copy(A::Hermitian) = (Hermitian(parentof_applytri(copy, A), _sym_uplo(A.uplo)))
 
 function copyto!(dest::Symmetric, src::Symmetric)
     if axes(dest) != axes(src)
@@ -497,6 +503,9 @@ transpose(A::Hermitian{<:Real}) = A
 
 real(A::Symmetric{<:Real}) = A
 real(A::Hermitian{<:Real}) = A
+real(A::Symmetric) = Symmetric(parentof_applytri(real, A), _sym_uplo(A.uplo))
+real(A::Hermitian) = Hermitian(parentof_applytri(real, A), _sym_uplo(A.uplo))
+imag(A::Symmetric) = Symmetric(parentof_applytri(imag, A), _sym_uplo(A.uplo))
 
 Base.copy(A::Adjoint{<:Any,<:Symmetric}) =
     Symmetric(copy(adjoint(A.parent.data)), ifelse(A.parent.uplo == 'U', :L, :U))
@@ -505,6 +514,10 @@ Base.copy(A::Transpose{<:Any,<:Hermitian}) =
 
 tr(A::Symmetric{<:Number}) = tr(A.data) # to avoid AbstractMatrix fallback (incl. allocations)
 tr(A::Hermitian{<:Number}) = real(tr(A.data))
+
+Base.conj(A::Symmetric) = Symmetric(parentof_applytri(conj, A), _sym_uplo(A.uplo))
+Base.conj(A::Hermitian) = Hermitian(parentof_applytri(conj, A), _sym_uplo(A.uplo))
+Base.conj!(A::HermOrSym) = typeof(A)(parentof_applytri(conj!, A), A.uplo)
 
 # tril/triu
 function tril(A::Hermitian, k::Integer=0)
@@ -720,6 +733,28 @@ function _hermkron!(C, A, B, conj, real, Auplo, Buplo)
     end
 end
 
+(-)(A::Symmetric) = Symmetric(parentof_applytri(-, A), _sym_uplo(A.uplo))
+(-)(A::Hermitian) = Hermitian(parentof_applytri(-, A), _sym_uplo(A.uplo))
+
+## Addition/subtraction
+for f ∈ (:+, :-), Wrapper ∈ (:Hermitian, :Symmetric)
+    @eval function $f(A::$Wrapper, B::$Wrapper)
+        uplo = A.uplo == B.uplo ? _sym_uplo(A.uplo) : (:U)
+        $Wrapper(parentof_applytri($f, A, B), uplo)
+    end
+end
+
+for f in (:+, :-)
+    @eval begin
+        $f(A::Hermitian, B::Symmetric{<:Real}) = $f(A, Hermitian(parent(B), _sym_uplo(B.uplo)))
+        $f(A::Symmetric{<:Real}, B::Hermitian) = $f(Hermitian(parent(A), _sym_uplo(A.uplo)), B)
+        $f(A::SymTridiagonal, B::Symmetric) = $f(Symmetric(A, _sym_uplo(B.uplo)), B)
+        $f(A::Symmetric, B::SymTridiagonal) = $f(A, Symmetric(B, _sym_uplo(A.uplo)))
+        $f(A::SymTridiagonal{<:Real}, B::Hermitian) = $f(Hermitian(A, _sym_uplo(B.uplo)), B)
+        $f(A::Hermitian, B::SymTridiagonal{<:Real}) = $f(A, Hermitian(B, _sym_uplo(A.uplo)))
+    end
+end
+
 mul(A::HermOrSym, B::HermOrSym) = A * copyto!(similar(parent(B)), B)
 # catch a few potential BLAS-cases
 function mul(A::HermOrSym{<:BlasFloat,<:StridedMatrix}, B::AdjOrTrans{<:BlasFloat,<:StridedMatrix})
@@ -765,6 +800,14 @@ function dot(x::AbstractVector, A::HermOrSym, y::AbstractVector)
     end
     return r
 end
+
+# Scaling with Number
+*(A::Symmetric, x::Number) = Symmetric(parentof_applytri(y -> y * x, A), _sym_uplo(A.uplo))
+*(x::Number, A::Symmetric) = Symmetric(parentof_applytri(y -> x * y, A), _sym_uplo(A.uplo))
+*(A::Hermitian, x::Real) = Hermitian(parentof_applytri(y -> y * x, A), _sym_uplo(A.uplo))
+*(x::Real, A::Hermitian) = Hermitian(parentof_applytri(y -> x * y, A), _sym_uplo(A.uplo))
+/(A::Symmetric, x::Number) = Symmetric(parentof_applytri(y -> y/x, A), _sym_uplo(A.uplo))
+/(A::Hermitian, x::Real) = Hermitian(parentof_applytri(y -> y/x, A), _sym_uplo(A.uplo))
 
 factorize(A::HermOrSym) = _factorize(A)
 function _factorize(A::HermOrSym{T}; check::Bool=true) where T

--- a/test/diagonal.jl
+++ b/test/diagonal.jl
@@ -1213,7 +1213,7 @@ end
     @test D2 * oneunit(D2) == D2
     @test oneunit(D2) isa typeof(D2)
     D3 = Diagonal([D2, D2]);
-    @test_broken D3 + zero(D3) == D3
+    @test D3 + zero(D3) == D3
     @test D3 * one(D3) == D3
     @test D3 * oneunit(D3) == D3
     @test oneunit(D3) isa typeof(D3)


### PR DESCRIPTION
It turns out the methods removed in #1607, #1636, and #1639 are needed by `SparseArrays`, `StaticArrays`, and probably several other packages. We probably should replace them with structured broadcasting for `StridedMatrix`, but this is better left for another PR.