### PR TITLE
`lu`: respect input array type for the pivot vector

### DIFF
--- a/src/lu.jl
+++ b/src/lu.jl
@@ -208,7 +208,7 @@ Stacktrace:
 """
 lu!(A::AbstractMatrix, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(eltype(A));
     check::Bool = true, allowsingular::Bool = false) = generic_lufact!(A, pivot; check, allowsingular)
-function generic_lufact!(A::AbstractMatrix{T}, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(T), ipiv::AbstractVector{BlasInt} = Vector{BlasInt}(undef,min(size(A)...));
+function generic_lufact!(A::AbstractMatrix{T}, pivot::Union{RowMaximum,NoPivot,RowNonZero} = lupivottype(T), ipiv::AbstractVector{BlasInt} = similar(A, BlasInt, min(size(A)...));
                          check::Bool = true, allowsingular::Bool = false) where {T}
     check && LAPACK.chkfinite(A)
     # Extract values
@@ -633,7 +633,7 @@ function lu!(A::Tridiagonal{T,V}, pivot::Union{RowMaximum,NoPivot} = RowMaximum(
     else
         du2 = similar(A.d, max(0, n-2))::V
     end
-    _lu_tridiag!(A.dl, A.d, A.du, du2, Vector{BlasInt}(undef, n), pivot, check, allowsingular)
+    _lu_tridiag!(A.dl, A.d, A.du, du2, similar(A.d, BlasInt, n), pivot, check, allowsingular)
 end
 function lu!(F::LU{<:Any,<:Tridiagonal}, A::Tridiagonal, pivot::Union{RowMaximum,NoPivot} = RowMaximum();
         check::Bool = true, allowsingular::Bool = false)

--- a/test/lu.jl
+++ b/test/lu.jl
@@ -332,6 +332,30 @@ end
     @test allnames == ["L", "P", "U", "factors", "info", "ipiv", "p"]
 end
 
+struct TaggedArray{T,N} <: AbstractArray{T,N}
+    a::Array{T,N}
+end
+Base.size(A::TaggedArray) = size(A.a)
+Base.IndexStyle(::Type{<:TaggedArray}) = IndexLinear()
+Base.getindex(A::TaggedArray, i::Int) = A.a[i]
+Base.setindex!(A::TaggedArray, v, i::Int) = (A.a[i] = v; A)
+Base.similar(::TaggedArray, ::Type{T}, dims::Dims{N}) where {T,N} =
+    TaggedArray(Array{T,N}(undef, dims))
+
+@testset "Issue #1604. lu preserves the input array type" begin
+    A = TaggedArray(Rational{Int}[2 1 0; 1 2 1; 0 1 2])
+    F = lu(A)
+    @test F.factors isa TaggedArray{Rational{Int},2}
+    @test F.ipiv isa TaggedArray{LinearAlgebra.BlasInt,1}
+
+    T = Tridiagonal(TaggedArray([1.0, 1.0]),
+                    TaggedArray([4.0, 4.0, 4.0]),
+                    TaggedArray([1.0, 1.0]))
+    G = lu(T)
+    @test G.factors isa Tridiagonal{Float64,TaggedArray{Float64,1}}
+    @test G.ipiv isa TaggedArray{LinearAlgebra.BlasInt,1}
+end
+
 include("trickyarithmetic.jl")
 
 @testset "lu with type whose sum is another type" begin


### PR DESCRIPTION
The generic dense (`generic_lufact!`) and `Tridiagonal` LU code paths hardcoded the pivot to `Vector{BlasInt}`, while `factors` already follows the input array type (and the dense BLAS path uses `similar(A, BlasInt, min(m, n))`). This left the resulting `LU` in an asymmetric state for non-`Vector`-backed array types.

Use `similar` so the pivot lands in the same container family as the input, matching the BLAS path.

Fixes #1604.