### PR TITLE
Fix typo in documentation for `axpby!`

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1681,7 +1681,7 @@ end
     axpby!(α, x::AbstractArray, β, y::AbstractArray)
 
 Overwrite `y` with `x * α + y * β` and return `y`.
-If `x` and `y` have the same axes, it's equivalent with `y .= x .* a .+ y .* β`.
+If `x` and `y` have the same axes, it's equivalent with `y .= x .* α .+ y .* β`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Change a variable name in the docstring body to match the one used in the docstring function signature of `axpby!`.