### PR TITLE
RFC: Add docstrings to `generic_mat[mat/vec]mul!`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -616,6 +616,8 @@ below (e.g. `mul!`) according to the usual Julia convention.
 
 ```@docs
 LinearAlgebra.mul!
+LinearAlgebra.generic_matvecmul!
+LinearAlgebra.generic_matmatmul!
 LinearAlgebra.lmul!
 LinearAlgebra.rmul!
 LinearAlgebra.ldiv!

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1049,6 +1049,19 @@ end
 # legacy method, retained for backward compatibility
 generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector, _add::MulAddMul = MulAddMul()) =
     generic_matvecmul!(C, tA, A, B, _add.alpha, _add.beta)
+
+"""
+    generic_matvecmul!(c::AbstractVector, tA, A::AbstractVecOrMat, b::AbstractVector, α::Number, β::Number)
+
+Combined inplace matrix-vector multiply-add ``A b α + c β`` (`tA == 'N'`),
+``A^⊤ b α + c β`` (`tA == 'T'`), or ``A' b α + c β`` (`tA == 'C'`).
+The result is stored in `c` by overwriting it.  Note that `c` must not be
+aliased with either `A` or `b`.
+
+This is an abstraction layer below [`mul!`](@ref) used to dispatch on storage types.
+Packages that provide their own storage type are advised to overload `generic_matvecmul!`
+instead of `mul!`.
+"""
 @inline function generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector,
                                     alpha::Number, beta::Number)
     tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
@@ -1134,6 +1147,18 @@ end
 # legacy method
 Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, _add::MulAddMul = MulAddMul()) =
     _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), _add.alpha, _add.beta)
+
+"""
+    generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number)
+
+Combined inplace matrix-matrix multiply-add ``A B α + C β`` (`tA == 'N'`),
+``A^⊤ B α + C β`` (`tA == 'T'`), or ``A' B α + C β`` (`tA == 'C'`), and potential matrix
+transpositions corresponding to `tB`. The result is stored in `C` by overwriting it.  Note that `C`
+must not be aliased with either `A` or `B`.
+
+This is an abstraction layer below [`mul!`](@ref). Packages that provide their own storage type are
+advised to overload `generic_matmatmul!` instead of `mul!`.
+"""
 Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, alpha::Number, beta::Number) =
     _generic_matmatmul!(C, wrap(A, tA), wrap(B, tB), alpha, beta)
 

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -1053,7 +1053,7 @@ generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector
 """
     generic_matvecmul!(c::AbstractVector, tA, A::AbstractVecOrMat, b::AbstractVector, α::Number, β::Number)
 
-Combined inplace matrix-vector multiply-add ``A b α + c β`` (`tA == 'N'`),
+Calculates the combined matrix-vector multiply-add ``A b α + c β`` (`tA == 'N'`),
 ``A^⊤ b α + c β`` (`tA == 'T'`), or ``A' b α + c β`` (`tA == 'C'`).
 The result is stored in `c` by overwriting it.  Note that `c` must not be
 aliased with either `A` or `b`.
@@ -1151,10 +1151,10 @@ Base.@constprop :aggressive generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::A
 """
     generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number)
 
-Combined inplace matrix-matrix multiply-add ``A B α + C β`` (`tA == 'N'`),
-``A^⊤ B α + C β`` (`tA == 'T'`), or ``A' B α + C β`` (`tA == 'C'`), and potential matrix
-transpositions corresponding to `tB`. The result is stored in `C` by overwriting it.  Note that `C`
-must not be aliased with either `A` or `B`.
+Calculates the combined matrix-matrix multiply-add ``A B α + C β`` (`tA == 'N'`),
+``A^⊤ B α + C β`` (`tA == 'T'`), or ``A' B α + C β`` (`tA == 'C'`), with potential matrix
+transpositions of `B` corresponding to `tB`. The result is stored in `C` by overwriting it.  Note
+that `C` must not be aliased with either `A` or `B`.
 
 This is an abstraction layer below [`mul!`](@ref). Packages that provide their own storage type are
 advised to overload `generic_matmatmul!` instead of `mul!`.


### PR DESCRIPTION
This is just to get started. Please help with improving wording and clarity.

Fixes #1664.