### PR TITLE
use dedicated uppercase function instead of adding methods to `Base.uppercase`

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -590,6 +590,25 @@ const ⋅ = dot
 const × = cross
 export ⋅, ×
 
+function _uppercase(c::Char)
+    if c ∈ ('N', 'T', 'C', 'H', 'S')
+        return c
+    elseif c ∈ ('n', 't', 'c', 'h', 's')
+        return c - 32
+    else
+        throw(ArgumentError("Unsupported character."))
+    end
+end
+_isuppercase(c::Char) = c ∈ ('N', 'T', 'C', 'H', 'S')
+function _lowercase(c::Char)
+    if c ∈ ('n', 't', 'c', 'h', 's')
+        return c
+    elseif c ∈ ('N', 'T', 'C', 'H', 'S')
+        return c + 32
+    else
+        throw(ArgumentError("Unsupported character."))
+    end
+end
 # Separate the char corresponding to the wrapper from that corresponding to the uplo
 # In most cases, the former may be constant-propagated, while the latter usually can't be.
 # This improves type-inference in wrap for Symmetric/Hermitian matrices
@@ -603,18 +622,17 @@ function Base.Char(w::WrapperChar)
     if T ∈ ('N', 'T', 'C') # known cases where isuppertri is true
         T
     else
-        _isuppertri(w) ? uppercase(T) : lowercase(T)
+        _isuppertri(w) ? _uppercase(T) : _lowercase(T)
     end
 end
-Base.codepoint(w::WrapperChar) = codepoint(Char(w))
-WrapperChar(n::UInt32) = WrapperChar(Char(n))
-WrapperChar(c::Char) = WrapperChar(c, isuppercase(c))
+WrapperChar(c::Char) = WrapperChar(c, _isuppercase(c))
 # We extract the wrapperchar so that the result may be constant-propagated
 # This doesn't return a value of the same type on purpose
-Base.uppercase(w::WrapperChar) = uppercase(w.wrapperchar)
-Base.lowercase(w::WrapperChar) = lowercase(w.wrapperchar)
+_uppercase(w::WrapperChar) = _uppercase(w.wrapperchar)
+_lowercase(w::WrapperChar) = _lowercase(w.wrapperchar)
+_isuppercase(w::WrapperChar) = w.isuppertri
 _isuppertri(w::WrapperChar) = w.isuppertri
-_isuppertri(x::AbstractChar) = isuppercase(x) # compatibility with earlier Char-based implementation
+_isuppertri(x::AbstractChar) = _isuppercase(x) # compatibility with earlier Char-based implementation
 _uplosym(x) = _isuppertri(x) ? (:U) : (:L)
 
 wrapper_char(::AbstractArray) = 'N'
@@ -625,7 +643,7 @@ wrapper_char(A::Hermitian) =  WrapperChar('H', A.uplo == 'U')
 wrapper_char(A::Hermitian{<:Real}) = WrapperChar('S', A.uplo == 'U')
 wrapper_char(A::Symmetric) = WrapperChar('S', A.uplo == 'U')
 
-wrapper_char_NTC(A::AbstractArray) = uppercase(wrapper_char(A)) == 'N'
+wrapper_char_NTC(A::AbstractArray) = _uppercase(wrapper_char(A)) == 'N'
 wrapper_char_NTC(A::Union{StridedArray, Adjoint, Transpose}) = true
 wrapper_char_NTC(A::Union{Symmetric, Hermitian}) = false
 
@@ -633,7 +651,7 @@ Base.@constprop :aggressive function wrap(A::AbstractVecOrMat, tA::AbstractChar)
     # merge the result of this before return, so that we can type-assert the return such
     # that even if the tmerge is inaccurate, inference can still identify that the
     # `_generic_matmatmul` signature still matches and doesn't require missing backedges
-    tA_uc = uppercase(tA)
+    tA_uc = _uppercase(tA)
     B = if tA_uc == 'N'
         A
     elseif tA_uc == 'T'

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -320,8 +320,8 @@ end
 @inline function _mul!(C::AbstractMatrix, A::AbstractVecOrMat, B::AbstractVecOrMat, α::Number, β::Number)
     tA = wrapper_char(A)
     tB = wrapper_char(B)
-    tA_uc = uppercase(tA)
-    tB_uc = uppercase(tB)
+    tA_uc = _uppercase(tA)
+    tB_uc = _uppercase(tB)
     isntc = wrapper_char_NTC(A) & wrapper_char_NTC(B)
     blasfn = if isntc
         if (tA_uc == 'T' && tB_uc == 'N') || (tA_uc == 'N' && tB_uc == 'T')
@@ -530,7 +530,7 @@ end
 
 Base.@constprop :aggressive function _syrk_herk_gemm_wrapper!(C, tA, tB, A, B, α, β, ::Val{BlasFlag.SYRK})
     if A === B
-        tA_uc = uppercase(tA) # potentially strip a WrapperChar
+        tA_uc = _uppercase(tA) # potentially strip a WrapperChar
         return syrk_wrapper!(C, tA_uc, A, α, β)
     else
         return gemm_wrapper!(C, tA, tB, A, B, α, β)
@@ -538,7 +538,7 @@ Base.@constprop :aggressive function _syrk_herk_gemm_wrapper!(C, tA, tB, A, B, �
 end
 Base.@constprop :aggressive function _syrk_herk_gemm_wrapper!(C, tA, tB, A, B, α, β, ::Val{BlasFlag.HERK})
     if A === B
-        tA_uc = uppercase(tA) # potentially strip a WrapperChar
+        tA_uc = _uppercase(tA) # potentially strip a WrapperChar
         return herk_wrapper!(C, tA_uc, A, α, β)
     else
         return gemm_wrapper!(C, tA, tB, A, B, α, β)
@@ -570,12 +570,12 @@ Base.@constprop :aggressive function generic_matmatmul_wrapper!(C::StridedMatrix
     return C
 end
 Base.@constprop :aggressive function _lrchar_ulchar(tA, tB)
-    if uppercase(tA) == 'N'
+    if _uppercase(tA) == 'N'
         lrchar = 'R'
-        ulchar = isuppercase(tB) ? 'U' : 'L'
+        ulchar = _isuppercase(tB) ? 'U' : 'L'
     else
         lrchar = 'L'
-        ulchar = isuppercase(tA) ? 'U' : 'L'
+        ulchar = _isuppercase(tA) ? 'U' : 'L'
     end
     return lrchar, ulchar
 end
@@ -713,7 +713,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{T}, tA::AbstractChar
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
         stride(A, 1) == 1 && _fullstride2(A, abs) &&
         !iszero(stride(x, 1)) && # We only check input's stride here.
@@ -741,7 +741,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
             stride(A, 1) == 1 && _fullstride2(A, abs) &&
             stride(y, 1) == 1 && tA_uc == 'N' && # reinterpret-based optimization is valid only for contiguous `y`
@@ -762,7 +762,7 @@ Base.@constprop :aggressive function gemv!(y::StridedVector{Complex{T}}, tA::Abs
     mA == 0 && return y
     nA == 0 && return _rmul_or_fill!(y, β)
     alpha, beta = promote(α, β, zero(T))
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     @views if alpha isa Union{Bool,T} && beta isa Union{Bool,T} &&
             stride(A, 1) == 1 && _fullstride2(A, abs) &&
             !iszero(stride(x, 1)) && tA_uc in ('N', 'T', 'C')
@@ -785,7 +785,7 @@ end
 Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
         α::Number, β::Number) where {T<:BlasFloat}
     nC = checksquare(C)
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     if tA_uc == 'T'
         (nA, mA) = size(A,1), size(A,2)
         tAt = 'N'
@@ -816,7 +816,7 @@ Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::Abst
 end
 Base.@constprop :aggressive function syrk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
         α::Number, β::Number) where {T<:Number}
-    tA_uc = uppercase(tA) # potentially strip a WrapperChar
+    tA_uc = _uppercase(tA) # potentially strip a WrapperChar
     aat = (tA_uc == 'N')
     if T <: Union{Real,Complex} && (iszero(β) || issymmetric(C))
         return copytri!(generic_syrk!(C, A, false, aat, α, β), 'U')
@@ -838,7 +838,7 @@ Base.@constprop :aggressive function herk_wrapper!(C::StridedMatrix{TC}, tA::Abs
         α::Number, β::Number) where {TC<:BlasComplex}
     T = real(TC)
     nC = checksquare(C)
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     if tA_uc == 'C'
         (nA, mA) = size(A,1), size(A,2)
         tAt = 'N'
@@ -867,7 +867,7 @@ Base.@constprop :aggressive function herk_wrapper!(C::StridedMatrix{TC}, tA::Abs
 end
 Base.@constprop :aggressive function herk_wrapper!(C::StridedMatrix{T}, tA::AbstractChar, A::StridedVecOrMat{T},
         α::Number, β::Number) where {T<:Number}
-    tA_uc = uppercase(tA) # potentially strip a WrapperChar
+    tA_uc = _uppercase(tA) # potentially strip a WrapperChar
     aat = (tA_uc == 'N')
     if isreal(α) && isreal(β) && (iszero(β) || ishermitian(C))
         return copytri!(generic_syrk!(C, A, true, aat, α, β), 'U', true)
@@ -894,7 +894,7 @@ Base.@constprop :aggressive function gemm_wrapper(tA::AbstractChar, tB::Abstract
     C = similar(B, T, mA, nB)
     # We convert the chars to uppercase to potentially unwrap a WrapperChar,
     # and extract the char corresponding to the wrapper type
-    tA_uc, tB_uc = uppercase(tA), uppercase(tB)
+    tA_uc, tB_uc = _uppercase(tA), _uppercase(tB)
     # the map in all ensures constprop by acting on tA and tB individually, instead of looping over them.
     if all(map(in(('N', 'T', 'C')), (tA_uc, tB_uc)))
         gemm_wrapper!(C, tA, tB, A, B, true, false)
@@ -955,7 +955,7 @@ Base.@constprop :aggressive function gemm_wrapper!(C::StridedVecOrMat{Complex{T}
 
     alpha, beta = promote(α, β, zero(T))
 
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
 
     # Make-sure reinterpret-based optimization is BLAS-compatible.
     if (alpha isa Union{Bool,T} &&
@@ -998,7 +998,7 @@ parameters must satisfy `length(ir_dest) == length(ir_src)` and
 See also [`copy_transpose!`](@ref) and [`copy_adjoint!`](@ref).
 """
 function copyto!(B::AbstractVecOrMat, ir_dest::AbstractUnitRange{Int}, jr_dest::AbstractUnitRange{Int}, tM::AbstractChar, M::AbstractVecOrMat, ir_src::AbstractUnitRange{Int}, jr_src::AbstractUnitRange{Int})
-    tM_uc = uppercase(tM) # potentially convert a WrapperChar to a Char
+    tM_uc = _uppercase(tM) # potentially convert a WrapperChar to a Char
     if tM_uc == 'N'
         copyto!(B, ir_dest, jr_dest, M, ir_src, jr_src)
     elseif tM_uc == 'T'
@@ -1030,7 +1030,7 @@ range parameters must satisfy `length(ir_dest) == length(jr_src)` and
 See also [`copyto!`](@ref) and [`copy_adjoint!`](@ref).
 """
 function copy_transpose!(B::AbstractMatrix, ir_dest::AbstractUnitRange{Int}, jr_dest::AbstractUnitRange{Int}, tM::AbstractChar, M::AbstractVecOrMat, ir_src::AbstractUnitRange{Int}, jr_src::AbstractUnitRange{Int})
-    tM_uc = uppercase(tM) # potentially convert a WrapperChar to a Char
+    tM_uc = _uppercase(tM) # potentially convert a WrapperChar to a Char
     if tM_uc == 'N'
         copy_transpose!(B, ir_dest, jr_dest, M, ir_src, jr_src)
     else
@@ -1064,7 +1064,7 @@ instead of `mul!`.
 """
 @inline function generic_matvecmul!(C::AbstractVector, tA, A::AbstractVecOrMat, B::AbstractVector,
                                     alpha::Number, beta::Number)
-    tA_uc = uppercase(tA) # potentially convert a WrapperChar to a Char
+    tA_uc = _uppercase(tA) # potentially convert a WrapperChar to a Char
     Anew, ta = tA_uc in ('S', 'H') ? (wrap(A, tA), oftype(tA, 'N')) : (A, tA)
     return _generic_matvecmul!(C, ta, Anew, B, alpha, beta)
 end
@@ -1276,7 +1276,7 @@ function _matmul2x2_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::Ab
 end
 function __matmul2x2_elements(tA, A::AbstractMatrix)
     @inbounds begin
-    tA_uc = uppercase(tA) # possibly unwrap a WrapperChar
+    tA_uc = _uppercase(tA) # possibly unwrap a WrapperChar
     if tA_uc == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A21 = A[2,1]; A22 = A[2,2]
     elseif tA_uc == 'T'
@@ -1288,7 +1288,7 @@ function __matmul2x2_elements(tA, A::AbstractMatrix)
         A11 = copy(A[1,1]'); A12 = copy(A[2,1]')
         A21 = copy(A[1,2]'); A22 = copy(A[2,2]')
     elseif tA_uc == 'S'
-        if isuppercase(tA) # tA == 'S'
+        if _isuppercase(tA) # tA == 'S'
             A11 = symmetric(A[1,1], :U); A12 = A[1,2]
             A21 = copy(transpose(A[1,2])); A22 = symmetric(A[2,2], :U)
         else
@@ -1296,7 +1296,7 @@ function __matmul2x2_elements(tA, A::AbstractMatrix)
             A21 = A[2,1]; A22 = symmetric(A[2,2], :L)
         end
     elseif tA_uc == 'H'
-        if isuppercase(tA) # tA == 'H'
+        if _isuppercase(tA) # tA == 'H'
             A11 = hermitian(A[1,1], :U); A12 = A[1,2]
             A21 = copy(adjoint(A[1,2])); A22 = hermitian(A[2,2], :U)
         else # if tA == 'h'
@@ -1335,7 +1335,7 @@ function _matmul3x3_elements(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::Ab
 end
 function __matmul3x3_elements(tA, A::AbstractMatrix)
     @inbounds begin
-    tA_uc = uppercase(tA) # possibly unwrap a WrapperChar
+    tA_uc = _uppercase(tA) # possibly unwrap a WrapperChar
     if tA_uc == 'N'
         A11 = A[1,1]; A12 = A[1,2]; A13 = A[1,3]
         A21 = A[2,1]; A22 = A[2,2]; A23 = A[2,3]
@@ -1351,7 +1351,7 @@ function __matmul3x3_elements(tA, A::AbstractMatrix)
         A21 = copy(A[1,2]'); A22 = copy(A[2,2]'); A23 = copy(A[3,2]')
         A31 = copy(A[1,3]'); A32 = copy(A[2,3]'); A33 = copy(A[3,3]')
     elseif tA_uc == 'S'
-        if isuppercase(tA) # tA == 'S'
+        if _isuppercase(tA) # tA == 'S'
             A11 = symmetric(A[1,1], :U); A12 = A[1,2]; A13 = A[1,3]
             A21 = copy(transpose(A[1,2])); A22 = symmetric(A[2,2], :U); A23 = A[2,3]
             A31 = copy(transpose(A[1,3])); A32 = copy(transpose(A[2,3])); A33 = symmetric(A[3,3], :U)
@@ -1361,7 +1361,7 @@ function __matmul3x3_elements(tA, A::AbstractMatrix)
             A31 = A[3,1]; A32 = A[3,2]; A33 = symmetric(A[3,3], :L)
         end
     elseif tA_uc == 'H'
-        if isuppercase(tA) # tA == 'H'
+        if _isuppercase(tA) # tA == 'H'
             A11 = hermitian(A[1,1], :U); A12 = A[1,2]; A13 = A[1,3]
             A21 = copy(adjoint(A[1,2])); A22 = hermitian(A[2,2], :U); A23 = A[2,3]
             A31 = copy(adjoint(A[1,3])); A32 = copy(adjoint(A[2,3])); A33 = hermitian(A[3,3], :U)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -52,13 +52,13 @@ mul_wrappers = [
         @test LinearAlgebra.WrapperChar('c') == 'c'
         @test LinearAlgebra.WrapperChar('C') == 'C'
         @testset "constant propagation in uppercase/lowercase" begin
-            v = @inferred (() -> Val(uppercase(LinearAlgebra.WrapperChar('C'))))()
+            v = @inferred (() -> Val(LinearAlgebra._uppercase(LinearAlgebra.WrapperChar('C'))))()
             @test v isa Val{'C'}
-            v = @inferred (() -> Val(uppercase(LinearAlgebra.WrapperChar('s'))))()
+            v = @inferred (() -> Val(LinearAlgebra._uppercase(LinearAlgebra.WrapperChar('s'))))()
             @test v isa Val{'S'}
-            v = @inferred (() -> Val(lowercase(LinearAlgebra.WrapperChar('C'))))()
+            v = @inferred (() -> Val(LinearAlgebra._lowercase(LinearAlgebra.WrapperChar('C'))))()
             @test v isa Val{'c'}
-            v = @inferred (() -> Val(lowercase(LinearAlgebra.WrapperChar('s'))))()
+            v = @inferred (() -> Val(LinearAlgebra._lowercase(LinearAlgebra.WrapperChar('s'))))()
             @test v isa Val{'s'}
         end
     end


### PR DESCRIPTION
Closes #1384
```julia
julia> Base.infer_effects(*, Tuple{Matrix{Int}, Matrix{Int}})
(!c,?e,!n,!t,+s,?m,!u,+o,+r)
```
Unfortunately that doesn't solve the more important problem of
```julia
julia> Base.infer_effects(*, Tuple{Matrix{Float64}, Matrix{Float64}})
(!c,!e,!n,!t,!s,!m,!u,+o,!r)
```
But I'm afraid that's impossible, because
```julia
julia> Base.infer_effects(BLAS.gemm!, Tuple{Char,Char,Bool,Matrix{Float64},Matrix{Float64},Bool,Matrix{Float64}})
(!c,!e,!n,!t,!s,!m,!u,+o,!r)
```