### PR TITLE
Respect the `norm` keyword in `isapprox` for arrays

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1155,7 +1155,7 @@ function generic_normp(D::Diagonal, p)
     end
     return v
 end
-norm_x_minus_y(D1::Diagonal, D2::Diagonal, nrm::typeof(norm)) = norm_x_minus_y(D1.diag, D2.diag, nrm)
+norm_x_minus_y(D1::Diagonal, D2::Diagonal, norm) = norm_x_minus_y(D1.diag, D2.diag, norm)
 
 _opnorm1(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnormInf(A::Diagonal) = maximum(norm(x) for x in A.diag)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1155,7 +1155,7 @@ function generic_normp(D::Diagonal, p)
     end
     return v
 end
-norm_x_minus_y(D1::Diagonal, D2::Diagonal) = norm_x_minus_y(D1.diag, D2.diag)
+norm_x_minus_y(D1::Diagonal, D2::Diagonal, nrm::typeof(norm)) = norm_x_minus_y(D1.diag, D2.diag, nrm)
 
 _opnorm1(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnormInf(A::Diagonal) = maximum(norm(x) for x in A.diag)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1155,7 +1155,7 @@ function generic_normp(D::Diagonal, p)
     end
     return v
 end
-norm_x_minus_y(D1::Diagonal, D2::Diagonal, nrm::typeof(norm)) = norm_x_minus_y(D1.diag, D2.diag, nrm)
+norm_x_minus_y(D1::Diagonal, D2::Diagonal, ::typeof(norm)) = norm_x_minus_y(D1.diag, D2.diag, norm)
 
 _opnorm1(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnormInf(A::Diagonal) = maximum(norm(x) for x in A.diag)

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -1155,7 +1155,7 @@ function generic_normp(D::Diagonal, p)
     end
     return v
 end
-norm_x_minus_y(D1::Diagonal, D2::Diagonal, norm) = norm_x_minus_y(D1.diag, D2.diag, norm)
+norm_x_minus_y(D1::Diagonal, D2::Diagonal, nrm::typeof(norm)) = norm_x_minus_y(D1.diag, D2.diag, nrm)
 
 _opnorm1(A::Diagonal) = maximum(norm(x) for x in A.diag)
 _opnormInf(A::Diagonal) = maximum(norm(x) for x in A.diag)

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2008,7 +2008,7 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     atol::Real=0,
     rtol::Real=Base.rtoldefault(promote_leaf_eltypes(x),promote_leaf_eltypes(y),atol),
     nans::Bool=false, norm::Function=norm)
-    d = norm_x_minus_y(x, y)
+    d = norm_x_minus_y(x, y, norm)
     if isfinite(d)
         return iszero(rtol) ? d <= atol : d <= max(atol, rtol*max(norm(x), norm(y)))
     else
@@ -2018,10 +2018,10 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     end
 end
 
-norm_x_minus_y(x, y) = norm(x - y)
+norm_x_minus_y(x, y, nrm::F) where {F} = nrm(x - y)
 FastContiguousArrayView{T,N,P<:Array,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
 const ArrayOrFastContiguousArrayView = Union{Array, FastContiguousArrayView}
-function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView)
+function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView, ::typeof(norm))
     Base.promote_shape(size(x), size(y)) # ensure compatible size
     if isempty(x) && isempty(y)
         norm(zero(eltype(x)) - zero(eltype(y)))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2018,10 +2018,10 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     end
 end
 
-norm_x_minus_y(x, y, nrm::F) where {F} = nrm(x - y)
+norm_x_minus_y(x, y, norm::F) where {F} = norm(x - y)
 FastContiguousArrayView{T,N,P<:Array,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
 const ArrayOrFastContiguousArrayView = Union{Array, FastContiguousArrayView}
-function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView, ::typeof(norm))
+function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView, norm::F) where {F}
     Base.promote_shape(size(x), size(y)) # ensure compatible size
     if isempty(x) && isempty(y)
         norm(zero(eltype(x)) - zero(eltype(y)))

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -2018,10 +2018,10 @@ function isapprox(x::AbstractArray, y::AbstractArray;
     end
 end
 
-norm_x_minus_y(x, y, norm::F) where {F} = norm(x - y)
+norm_x_minus_y(x, y, nrm::F) where {F} = nrm(x - y)
 FastContiguousArrayView{T,N,P<:Array,I<:Tuple{AbstractUnitRange, Vararg{Any}}} = Base.SubArray{T,N,P,I,true}
 const ArrayOrFastContiguousArrayView = Union{Array, FastContiguousArrayView}
-function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView, norm::F) where {F}
+function norm_x_minus_y(x::ArrayOrFastContiguousArrayView, y::ArrayOrFastContiguousArrayView, ::typeof(norm))
     Base.promote_shape(size(x), size(y)) # ensure compatible size
     if isempty(x) && isempty(y)
         norm(zero(eltype(x)) - zero(eltype(y)))

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -963,6 +963,24 @@ end
     n = @allocated isapprox(A, A)
     @test n == 0
     @test Int[] ≈ Int[]
+
+    @testset "norm keyword (issue #1675)" begin
+        x = [0.057618841449997994, -0.055947092101983294, 0.7492941853741162]
+        y = [0.057618841449997994, -0.055947092101983335, 0.7492941853741162]
+        # if the specified norm isn't finite, fall back to an elementwise comparison
+        for nonfinitenorm in (v -> NaN, v -> Inf)
+            @test isapprox(x, y; norm=nonfinitenorm, rtol=4e-11, atol=4e-11)
+            @test !isapprox(x, y .+ 1; norm=nonfinitenorm, rtol=4e-11, atol=4e-11)
+            @test isapprox(Diagonal(x), Diagonal(y); norm=nonfinitenorm, rtol=4e-11, atol=4e-11)
+            @test isapprox(view(x, :), view(y, :); norm=nonfinitenorm, rtol=4e-11, atol=4e-11)
+        end
+        # the specified norm is used to evaluate the distance
+        @test isapprox(x, y; norm=v -> 0.0, atol=0, rtol=0)
+        @test !isapprox(x, x; norm=v -> 1.0, atol=0, rtol=0)
+        @test !isapprox(Diagonal(x), Diagonal(x); norm=v -> 1.0, atol=0, rtol=0)
+        @test !isapprox(view(x, :), view(x, :); norm=v -> 1.0, atol=0, rtol=0)
+        @test isapprox(x, y; norm=v -> 1.0, atol=2)
+    end
 end
 
 @testset "issue 930" begin

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -324,6 +324,14 @@ end
     @test @inferred(opnorm(fill(1,2,2))) ≈ 2
 end
 
+@testset "norm > opnorm" begin
+    X = [1 0; 0 1]; Y = X + [1 0; 0 2]*1e-3
+    @test !isapprox(X, Y, atol=0.0021) # norm(X - Y) > opnorm(X - Y)
+    for (X, Y) in ((X, Y), (Diagonal(X), Diagonal(Y)))
+        @test isapprox(X, Y, atol=0.0021, norm=opnorm) && !isapprox(X, Y, atol=0.00199, norm=opnorm)
+    end
+end
+
 @testset "generic norm for arrays of arrays" begin
     x = Vector{Int}[[1,2], [3,4]]
     @test @inferred(norm(x)) ≈ sqrt(30)


### PR DESCRIPTION
Fixes #1675, and addresses https://github.com/JuliaLang/LinearAlgebra.jl/pull/1378#discussion_r2410297577.

Since #1378, `isapprox(x::AbstractArray, y::AbstractArray; norm)` evaluated the distance using `norm_x_minus_y(x, y)`, which was hard-coded to use the 2-norm, while the `norm` keyword was still used for the relative tolerance. A custom `norm` was therefore ignored where it mattered most, and in particular the documented fallback to a component-wise comparison for a non-finite `norm(x-y)` was never triggered:

```julia
julia> using LinearAlgebra

julia> x = [0.057618841449997994, -0.055947092101983294, 0.7492941853741162];

julia> y = [0.057618841449997994, -0.055947092101983335, 0.7492941853741162];

julia> isapprox(x, y; norm = v -> NaN, rtol = 4e-11, atol = 4e-11)
false # master
true  # this PR
```

Following @stevengj's suggestion, the keyword is passed on to `norm_x_minus_y`, and the allocation-free iterator path added in #1378 is dispatched on `::typeof(norm)`, so that it only applies for the default norm. The fast path is unchanged for the default case, and `isapprox` remains allocation-free for `Array`s, contiguous views of `Array`s and `Diagonal`s.

Tests are added for a non-finite `norm` (which must fall back to the component-wise comparison) and for a finite custom `norm` (which must determine the result), for each of the types that have a specialized `norm_x_minus_y` method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
