### PR TITLE
Delete `Core.kwcall` methods in `prune_old_LA.jl`

### DIFF
--- a/test/prune_old_LA.jl
+++ b/test/prune_old_LA.jl
@@ -54,12 +54,27 @@ let
     LA = get(Base.loaded_modules, LinalgSysImg, nothing)
     if LA !== nothing && prune_old_LA
         @assert hasmethod(*, Tuple{Matrix{Float64}, Matrix{Float64}})
+        ftypes_to_delete = Set{Any}()
         for methss in methods_to_delete
             meths = getglobal(Base, methss)
+            push!(ftypes_to_delete, typeof(meths))
             for meth in methods(meths)
                 if meth.module === LA
                     Base.delete_method(meth)
                 end
+            end
+        end
+        # Calls that pass keyword arguments are dispatched through `Core.kwcall`, and
+        # the corresponding methods aren't listed in `methods(f)`, so they need to be
+        # deleted separately. Otherwise, e.g. `isapprox(x, y; norm)` would silently
+        # continue to be handled by the sysimage version of the method.
+        for meth in methods(Core.kwcall)
+            meth.module === LA || continue
+            sig = Base.unwrap_unionall(meth.sig)
+            # signature: Tuple{typeof(Core.kwcall), NamedTuple, typeof(f), args...}
+            length(sig.parameters) >= 3 || continue
+            if sig.parameters[3] in ftypes_to_delete
+                Base.delete_method(meth)
             end
         end
     end
@@ -72,6 +87,8 @@ let
     LA = get(Base.loaded_modules, LinalgSysImg, nothing)
     if LA !== nothing && prune_old_LA
         @assert !hasmethod(*, Tuple{Matrix{Float64}, Matrix{Float64}})
+        @assert isempty(methods(Core.kwcall,
+            Tuple{NamedTuple, typeof(isapprox), Vector{Float64}, Vector{Float64}}))
     end
     prune_old_LA && Base.unreference_module(LinalgSysImg)
 end

--- a/test/prune_old_LA.jl
+++ b/test/prune_old_LA.jl
@@ -64,10 +64,7 @@ let
                 end
             end
         end
-        # Calls that pass keyword arguments are dispatched through `Core.kwcall`, and
-        # the corresponding methods aren't listed in `methods(f)`, so they need to be
-        # deleted separately. Otherwise, e.g. `isapprox(x, y; norm)` would silently
-        # continue to be handled by the sysimage version of the method.
+
         for meth in methods(Core.kwcall)
             meth.module === LA || continue
             sig = Base.unwrap_unionall(meth.sig)


### PR DESCRIPTION
Methods that are called with keyword arguments are dispatched through `Core.kwcall`, and these aren't listed in `methods(f)`. Pruning therefore deleted e.g. `isapprox(x::AbstractArray, y::AbstractArray)`, but left the sysimage's

```
kwcall(::NamedTuple, ::typeof(isapprox), x::AbstractArray, y::AbstractArray) @ LinearAlgebra .../share/julia/stdlib/v1.14/LinearAlgebra/src/generic.jl:2003
```

in place. As a result, a call passing keywords silently continued to use the sysimage implementation, even though `which` reported that no method existed at all:

```julia
julia> which(isapprox, Tuple{Vector{Float64},Vector{Float64}})
ERROR: MethodError: no method matching invoke isapprox(::Vector{Float64}, ::Vector{Float64})

julia> isapprox(x, y; norm = v -> NaN, rtol = 4e-11, atol = 4e-11)
false # evaluated by the sysimage `LinearAlgebra`
```

This is easy to run into while testing a development version, as it makes the pruned session silently report results from the sysimage for any function that is called with keyword arguments (`isapprox` for `AbstractArray`, `UniformScaling` and `AbstractQ`, in the current list). It doesn't affect `runtests.jl`, since `using LinearAlgebra` there defines methods with identical signatures that overwrite the stale `Core.kwcall` ones.

With this PR, `methods(Core.kwcall)` is swept for methods that belong to the sysimage `LinearAlgebra` and that dispatch on one of the pruned functions, and these are deleted as well. Such a call now raises a `MethodError` until the development version is loaded, instead of quietly returning a stale result. An assertion is added to the verification block to catch a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
