### PR TITLE
restore codepoint and conversion from UInt32 for WrapperChar

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -624,6 +624,11 @@ function Base.Char(w::WrapperChar)
     end
 end
 WrapperChar(c::Char) = WrapperChar(c, _isuppercase(c))
+# The `AbstractChar` interface requires `codepoint` and construction from `UInt32`;
+# generic char operations are built on top of these — e.g. `Base.uppercase`, which
+# SparseArrays applies to the wrapper chars we pass to `generic_matvecmul!`.
+Base.codepoint(w::WrapperChar) = codepoint(Char(w))
+WrapperChar(n::UInt32) = WrapperChar(Char(n))
 # We extract the wrapperchar so that the result may be constant-propagated
 # This doesn't return a value of the same type on purpose
 _uppercase(w::WrapperChar) = _uppercase(w.wrapperchar)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -61,6 +61,25 @@ mul_wrappers = [
             v = @inferred (() -> Val(LinearAlgebra._lowercase(LinearAlgebra.WrapperChar('s'))))()
             @test v isa Val{'s'}
         end
+        @testset "AbstractChar interface" begin
+            # `codepoint` and construction from a codepoint are required by the
+            # `AbstractChar` interface, and generic char operations are built on
+            # them — e.g. `Base.uppercase`, which SparseArrays applies to the
+            # wrapper chars we pass to its `generic_matvecmul!`
+            WC = LinearAlgebra.WrapperChar
+            @test codepoint(WC('S', true)) == codepoint('S')
+            @test codepoint(WC('S', false)) == codepoint('s')
+            @test WC(UInt32('C')) == 'C'
+            for c in ('S', 'H'), isuppertri in (true, false)
+                w = WC(c, isuppertri)
+                @test isascii(w)
+                @test uppercase(w) == c
+                @test lowercase(w) == lowercase(c)
+                @test isuppercase(w) == isuppertri
+            end
+            @test uppercase(LinearAlgebra.wrapper_char(Symmetric(rand(2, 2), :L))) == 'S'
+            @test uppercase(LinearAlgebra.wrapper_char(Hermitian(rand(ComplexF64, 2, 2), :L))) == 'H'
+        end
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -63,9 +63,7 @@ mul_wrappers = [
         end
         @testset "AbstractChar interface" begin
             # `codepoint` and construction from a codepoint are required by the
-            # `AbstractChar` interface, and generic char operations are built on
-            # them — e.g. `Base.uppercase`, which SparseArrays applies to the
-            # wrapper chars we pass to its `generic_matvecmul!`
+            # `AbstractChar` interface, functions like `uppercase` fail otherwise
             WC = LinearAlgebra.WrapperChar
             @test codepoint(WC('S', true)) == codepoint('S')
             @test codepoint(WC('S', false)) == codepoint('s')


### PR DESCRIPTION
These were removed in #1668, but SparseArrays still relies on these methods in `generic_matmatmul!` since it calls `uppercase`. Found tracking down regressions in AMDGPU.jl on nightly

ref https://github.com/JuliaGPU/AMDGPU.jl/pull/1027