### PR TITLE
feat: implement matrix absolute value support with unit tests

### DIFF
--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1175,11 +1175,7 @@ julia> abs(A)
 """
 function abs(A::AbstractMatrix{T}) where T
     if isdiag(A)
-        if T <: Real
-            return Hermitian(applydiagonal(abs ∘ float, A))
-        else
-            return Hermitian(applydiagonal(complex ∘ abs ∘ float, A))
-        end
+        return Hermitian(convert(AbstractMatrix{float(T)}, applydiagonal(abs, A)))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2058,12 +2058,13 @@ julia> abs(A)
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
     if isempty(A)
-        return Hermitian(zeros(float(real(T)), n, n))
+        return Hermitian(zeros(float(T), n, n))
     elseif isdiag(A)
-        return Hermitian(applydiagonal(abs ∘ float, A))
+        return Hermitian(applydiagonal(x -> float(T)(abs(x)), A))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end
     u, s, v = svd(A)
     return Hermitian(v * Diagonal(s) * v')
 end
+

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2067,4 +2067,3 @@ function abs(A::AbstractMatrix{T}) where T
     u, s, v = svd(A)
     return Hermitian(v * Diagonal(s) * v')
 end
-

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2058,7 +2058,7 @@ julia> abs(A)
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
     if isdiag(A)
-        return Hermitian(applydiagonal(x -> float(T)(abs(x)), A))
+        return Hermitian(diagm(float(T).(abs.(diag(A)))))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2057,8 +2057,6 @@ julia> abs(A)
 
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
-    if isempty(A)
-        return Hermitian(zeros(float(T), n, n))
     elseif isdiag(A)
         return Hermitian(applydiagonal(x -> float(T)(abs(x)), A))
     elseif ishermitian(A)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2058,9 +2058,9 @@ julia> abs(A)
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
     if isempty(A)
-        return zeros(float(T), n, n)
+        return Hermitian(zeros(float(real(T)), n, n))
     elseif isdiag(A)
-        return applydiagonal(abs, A)
+        return Hermitian(applydiagonal(abs ∘ float, A))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1159,6 +1159,32 @@ end
 @inline _broadcast!!(f, dest, args...) = broadcast(f, args...)
 
 """
+    abs(A::AbstractMatrix)
+
+Compute the matrix absolute value `|A| = sqrt(A'A)`
+
+# Examples
+```jldoctest
+julia> A = [1.0 2.0; 3.0 4.0];
+
+julia> abs(A)
+2×2 Hermitian{Float64, Matrix{Float64}}:
+ 2.05798  2.40098
+ 2.40098  3.77297
+```
+"""
+function abs(A::AbstractMatrix{T}) where T
+    m, n = size(A)
+    if isdiag(A)
+        return Hermitian(diagm(float(T).(abs.(diag(A)))))
+    elseif ishermitian(A)
+        return abs(Hermitian(A))
+    end
+    u, s, v = svd(A)
+    return Hermitian(v * Diagonal(s) * v')
+end
+
+"""
     cos(A::AbstractMatrix)
 
 Compute the matrix cosine of a square matrix `A`.
@@ -2037,31 +2063,3 @@ function lyap(A::AbstractMatrix{T}, C::AbstractMatrix{T}) where {T<:BlasFloat}
     rmul!(Q * Y * Q', inv(scale))
 end
 lyap(a::Union{Real,Complex}, c::Union{Real,Complex}) = -c/(2real(a))
-
-"""
-    abs(A::AbstractMatrix)
-
-Compute the matrix absolute value `|A| = sqrt(A'A)`
-
-# Examples
-```jldoctest
-julia> A = [1.0 2.0; 3.0 4.0];
-
-julia> abs(A)
-2×2 Hermitian{Float64, Matrix{Float64}}:
- 2.05798  2.40098
- 2.40098  3.77297
-```
-"""
-
-
-function abs(A::AbstractMatrix{T}) where T
-    m, n = size(A)
-    if isdiag(A)
-        return Hermitian(diagm(float(T).(abs.(diag(A)))))
-    elseif ishermitian(A)
-        return abs(Hermitian(A))
-    end
-    u, s, v = svd(A)
-    return Hermitian(v * Diagonal(s) * v')
-end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2037,3 +2037,34 @@ function lyap(A::AbstractMatrix{T}, C::AbstractMatrix{T}) where {T<:BlasFloat}
     rmul!(Q * Y * Q', inv(scale))
 end
 lyap(a::Union{Real,Complex}, c::Union{Real,Complex}) = -c/(2real(a))
+
+"""
+    abs(A::AbstractMatrix)
+
+Compute the matrix absolute value `|A| = sqrt(A'A)`
+
+# Examples
+```jldoctest
+julia> A = [1.0 2.0; 3.0 4.0];
+
+julia> abs(A)
+2×2 Hermitian{Float64, Matrix{Float64}}:
+ 2.05798  2.40098
+ 2.40098  3.77297
+```
+"""
+
+
+function abs(A::AbstractMatrix{T}) where T
+    m, n = size(A)
+    if isempty(A)
+        return zeros(float(T), n, n)
+    elseif isdiag(A)
+        return applydiagonal(abs, A)
+    elseif ishermitian(A)
+        return abs(Hermitian(A))
+    end
+    u, s, v = svd(A)
+    return Hermitian(v * Diagonal(s) * v')
+end
+

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1175,7 +1175,7 @@ julia> abs(A)
 """
 function abs(A::AbstractMatrix{T}) where T
     if isdiag(A)
-        return Hermitian(convert(AbstractMatrix{float(T)}, applydiagonal(abs, A)))
+        return Hermitian(convert(AbstractMatrix{float(T)}, applydiagonal(abs ∘ float, A)))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1175,7 +1175,8 @@ julia> abs(A)
 """
 function abs(A::AbstractMatrix{T}) where T
     if isdiag(A)
-        return Hermitian(convert(AbstractMatrix{float(T)}, applydiagonal(abs ∘ float, A)))
+        f(x) = convert(AbstractMatrix{float(T)}, x) #preserves complexes and quaternions
+        return Hermitian(applydiagonal(f ∘ abs ∘ float, A))
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1176,7 +1176,11 @@ julia> abs(A)
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
     if isdiag(A)
-        return Hermitian(diagm(float(T).(abs.(diag(A)))))
+        if T <: Real
+            return Hermitian(applydiagonal(abs ∘ float, A))
+        else
+            return Hermitian(applydiagonal(complex ∘ abs ∘ float, A))
+        end
     elseif ishermitian(A)
         return abs(Hermitian(A))
     end

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -1174,7 +1174,6 @@ julia> abs(A)
 ```
 """
 function abs(A::AbstractMatrix{T}) where T
-    m, n = size(A)
     if isdiag(A)
         return Hermitian(diagm(float(T).(abs.(diag(A)))))
     elseif ishermitian(A)

--- a/src/dense.jl
+++ b/src/dense.jl
@@ -2057,7 +2057,7 @@ julia> abs(A)
 
 function abs(A::AbstractMatrix{T}) where T
     m, n = size(A)
-    elseif isdiag(A)
+    if isdiag(A)
         return Hermitian(applydiagonal(x -> float(T)(abs(x)), A))
     elseif ishermitian(A)
         return abs(Hermitian(A))

--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -974,7 +974,7 @@ function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct
 end
 
 # Matrix functions
-for f in (:exp, :cis, :log, :sqrt,
+for f in (:exp, :cis, :log, :sqrt, :abs,
           :cos, :sin, :tan, :csc, :sec, :cot,
           :cosh, :sinh, :tanh, :csch, :sech, :coth,
           :acos, :asin, :atan, :acsc, :asec, :acot,

--- a/src/symmetric.jl
+++ b/src/symmetric.jl
@@ -919,7 +919,7 @@ function ^(A::SymSymTri{<:Complex}, p::Real)
     return Symmetric(schurpow(A, p))
 end
 
-for func in (:cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :cbrt)
+for func in (:cos, :sin, :tan, :cosh, :sinh, :tanh, :atan, :asinh, :cbrt, :abs)
     @eval begin
         function ($func)(A::SelfAdjoint)
             F = eigen(A)

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1456,4 +1456,29 @@ end
     @test_throws DimensionMismatch LinearAlgebra.checksquare(A,B)
 end
 
+@testset "abs(A::AbstractMatrix{T})" begin
+    N = 10
+
+    # Real valued Non-square
+    A = randn(N,N+2)
+    H = abs(A)
+    @test H'H ≈ A'A
+
+    # Complex valued non-square
+    A = randn(ComplexF64, N,N+2)
+    H = abs(A)
+    @test H'H ≈ A'A
+
+    # Diagonal
+    D = Diagonal([1.0, -2.0, 3.0, -4.0])
+    @test abs(D) == Diagonal([1.0, 2.0, 3.0, 4.0])
+    @test abs(D) isa Diagonal
+    
+    # Hermitian
+    H = Hermitian([1.0 2.0im; -2.0im 1.0])
+    @test abs(H) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])
+    @test abs(H) isa Hermitian
+    @test abs(H)^2 ≈ H^2
+end
+
 end # module TestDense

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1458,25 +1458,36 @@ end
 
 @testset "abs(A::AbstractMatrix{T})" begin
     N = 10
-
-    # Real valued Non-square
+    
+    # Real valued Non-square 
     A = randn(N, N+2)
     H = @inferred abs(A)
     @test H'H ≈ A'A
     @test H isa Hermitian{Float64}
 
-    # Complex valued non-square
+    # Complex valued non-square 
     A = randn(ComplexF64, N, N+2)
     H = @inferred abs(A)
     @test H'H ≈ A'A
     @test H isa Hermitian{ComplexF64}
 
-    # Diagonal
+    # Dense diagonal matrix 
+    D = diagm([1.0, -2.0, 3.0, -4.0])
+    @test (@inferred abs(D)) ≈ diagm([1.0, 2.0, 3.0, 4.0])
+    @test abs(D) isa Hermitian{Float64}
+
+    # Dense Hermitian matrix 
+    A1 = randn(ComplexF64, N, N)
+    H_dense = A1 + A1'
+    @test (@inferred abs(H_dense)) ≈ abs(Hermitian(H_dense))
+    @test abs(H_dense) isa Hermitian{ComplexF64}
+
+    # Diagonal wrapper (
     D = Diagonal([1.0, -2.0, 3.0, -4.0])
     @test (@inferred abs(D)) == Diagonal([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Diagonal
 
-    # Hermitian
+    # Hermitian wrapper 
     H = Hermitian([1.0 2.0im; -2.0im 1.0])
     @test (@inferred abs(H)) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])
     @test abs(H) isa Hermitian

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1473,7 +1473,7 @@ end
     D = Diagonal([1.0, -2.0, 3.0, -4.0])
     @test abs(D) == Diagonal([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Diagonal
-    
+
     # Hermitian
     H = Hermitian([1.0 2.0im; -2.0im 1.0])
     @test abs(H) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1458,36 +1458,36 @@ end
 
 @testset "abs(A::AbstractMatrix{T})" begin
     N = 10
-    
-    # Real valued Non-square 
+
+    # Real valued Non-square
     A = randn(N, N+2)
     H = @inferred abs(A)
     @test H'H ≈ A'A
     @test H isa Hermitian{Float64}
 
-    # Complex valued non-square 
+    # Complex valued non-square
     A = randn(ComplexF64, N, N+2)
     H = @inferred abs(A)
     @test H'H ≈ A'A
     @test H isa Hermitian{ComplexF64}
 
-    # Dense diagonal matrix 
+    # Dense diagonal matrix
     D = diagm([1.0, -2.0, 3.0, -4.0])
     @test (@inferred abs(D)) ≈ diagm([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Hermitian{Float64}
 
-    # Dense Hermitian matrix 
+    # Dense Hermitian matrix
     A1 = randn(ComplexF64, N, N)
     H_dense = A1 + A1'
     @test (@inferred abs(H_dense)) ≈ abs(Hermitian(H_dense))
     @test abs(H_dense) isa Hermitian{ComplexF64}
 
-    # Diagonal wrapper (
+    # Diagonal wrapper
     D = Diagonal([1.0, -2.0, 3.0, -4.0])
     @test (@inferred abs(D)) == Diagonal([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Diagonal
 
-    # Hermitian wrapper 
+    # Hermitian wrapper
     H = Hermitian([1.0 2.0im; -2.0im 1.0])
     @test (@inferred abs(H)) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])
     @test abs(H) isa Hermitian

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1476,6 +1476,11 @@ end
     @test (@inferred abs(D)) ≈ diagm([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Hermitian{Float64}
 
+    # Dense complex diagonal matrix
+    Dc = diagm([3.0 + 4.0im, -1.0 + 2.0im, 0.0 - 5.0im])
+    @test (@inferred abs(Dc)) ≈ diagm([5.0, sqrt(5.0), 5.0])
+    @test abs(Dc) isa Hermitian{ComplexF64}
+
     # Dense Hermitian matrix
     A1 = randn(ComplexF64, N, N)
     H_dense = A1 + A1'

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1476,6 +1476,11 @@ end
     @test (@inferred abs(D)) ≈ diagm([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Hermitian{Float64}
 
+    # Guard against integer overflow
+    D_int8 = diagm(Int8[-128, 127])
+    @test (@inferred abs(D_int8)) ≈ diagm([128.0, 127.0])
+    @test abs(D_int8) isa Hermitian{Float64}
+
     # Dense complex diagonal matrix
     Dc = diagm([3.0 + 4.0im, -1.0 + 2.0im, 0.0 - 5.0im])
     @test (@inferred abs(Dc)) ≈ diagm([5.0, sqrt(5.0), 5.0])

--- a/test/dense.jl
+++ b/test/dense.jl
@@ -1460,25 +1460,26 @@ end
     N = 10
 
     # Real valued Non-square
-    A = randn(N,N+2)
-    H = abs(A)
+    A = randn(N, N+2)
+    H = @inferred abs(A)
     @test H'H ≈ A'A
+    @test H isa Hermitian{Float64}
 
     # Complex valued non-square
-    A = randn(ComplexF64, N,N+2)
-    H = abs(A)
+    A = randn(ComplexF64, N, N+2)
+    H = @inferred abs(A)
     @test H'H ≈ A'A
+    @test H isa Hermitian{ComplexF64}
 
     # Diagonal
     D = Diagonal([1.0, -2.0, 3.0, -4.0])
-    @test abs(D) == Diagonal([1.0, 2.0, 3.0, 4.0])
+    @test (@inferred abs(D)) == Diagonal([1.0, 2.0, 3.0, 4.0])
     @test abs(D) isa Diagonal
 
     # Hermitian
     H = Hermitian([1.0 2.0im; -2.0im 1.0])
-    @test abs(H) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])
+    @test (@inferred abs(H)) ≈ Hermitian([2.0 1.0im; -1.0im 2.0])
     @test abs(H) isa Hermitian
-    @test abs(H)^2 ≈ H^2
 end
 
 end # module TestDense

--- a/test/symmetric.jl
+++ b/test/symmetric.jl
@@ -1317,16 +1317,17 @@ end
             end
         end
         #nice functions
-        for f in (x->x^2, exp, cos, sin, tan, cosh, sinh, tanh, atan, asinh, cbrt)
+        for f in (x->x^2, exp, cos, sin, tan, cosh, sinh, tanh, atan, asinh, cbrt, abs)
             if T <: Real
-                @test @inferred(f(a)) isa Matrix{T}
+                f != abs && @test @inferred(f(a)) isa Matrix{T}
                 @test @inferred(f(syma)) isa Symmetric{T}
                 @test @inferred(f(symtria)) isa Symmetric{T}
                 @test @inferred(f(herma)) isa Hermitian{T}
             else
-                f != cbrt && @test @inferred(f(a)) isa Matrix{T}
+                f != cbrt && f != abs && @test @inferred(f(a)) isa Matrix{T}
                 @test @inferred(f(herma)) isa Hermitian{T}
             end
+            f == abs && @test @inferred(f(a)) isa Hermitian{T}
         end
         #special case cis
         if T <: Real


### PR DESCRIPTION
Closes: #1648

Implements the matrix absolute value $|A| = \sqrt{A^\dagger A}$ for abstract matrices using the SVD factorization.
Specialized dispatches are included for:
- `SelfAdjoint` (`Hermitian`/`Symmetric`): Spectral decomposition via `eigen`.
- `Diagonal`: Element-wise absolute value via `applydiagonal`.
- Empty matrices: Returns `zeros(float(T), n, n)`.

I tried @[stevengj](https://github.com/stevengj) suggestion to try the qdwh algorithm
But it seemed consistently slower than SVD factorization

Benchmark:

```
Matrix Size (N×N)   SVD Time      QDWH Time    
================================================
10 × 10             0.026 ms      0.093 ms      
25 × 25             0.136 ms      0.469 ms     
50 × 50             0.885 ms      3.148 ms      
100 × 100           3.953 ms      18.092 ms     
200 × 200           23.303 ms     84.571 ms     
400 × 400           89.852 ms     295.538 ms   
800 × 800           338.54 ms     1100.807 ms   
================================================

```