### PR TITLE
Give a real infinite generalized eigenvalue a zero imaginary part

### DIFF
--- a/src/eigen.jl
+++ b/src/eigen.jl
@@ -461,6 +461,13 @@ function det(A::Eigen)
 end
 
 # Generalized eigenproblem
+# ALPHAI(j) == 0 means the eigenvalue is real, so do not divide it by a possibly zero BETA(j).
+function _generalized_eigvals(alphar::AbstractVector{T}, alphai::AbstractVector{T},
+                              beta::AbstractVector{T}) where {T<:BlasReal}
+    return Complex{T}[iszero(ai) && !iszero(ar) ? complex(ar / b, zero(T)) : complex(ar, ai) / b
+                      for (ar, ai, b) in zip(alphar, alphai, beta)]
+end
+
 function eigen!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Function,Nothing}=eigsortby) where T<:BlasReal
     issymmetric(A) && isposdef(B) && return eigen!(Symmetric(A), Symmetric(B), sortby=sortby)
     n = size(A, 1)
@@ -485,7 +492,7 @@ function eigen!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Function
         end
         j += 1
     end
-    return GeneralizedEigen(sorteig!(complex.(alphar, alphai)./beta, vecs, sortby)...)
+    return GeneralizedEigen(sorteig!(_generalized_eigvals(alphar, alphai, beta), vecs, sortby)...)
 end
 
 function eigen!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Function,Nothing}=eigsortby) where T<:BlasComplex
@@ -604,7 +611,7 @@ function eigvals!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Functi
     else
         alphar, alphai, beta, vl, vr = LAPACK.ggev3!('N', 'N', A, B)
     end
-    return sorteig!((iszero(alphai) ? alphar : complex.(alphar, alphai))./beta, sortby)
+    return sorteig!(iszero(alphai) ? alphar ./ beta : _generalized_eigvals(alphar, alphai, beta), sortby)
 end
 function eigvals!(A::StridedMatrix{T}, B::StridedMatrix{T}; sortby::Union{Function,Nothing}=eigsortby) where T<:BlasComplex
     ishermitian(A) && isposdef(B) && return sorteig!(eigvals!(Hermitian(A), Hermitian(B)), sortby)

--- a/test/eigen.jl
+++ b/test/eigen.jl
@@ -314,4 +314,52 @@ end
     @test_throws ArgumentError isposdef(F)
 end
 
+@testset "infinite eigenvalues of a regular pencil" begin
+    @testset "eltype $T" for T in (Float32, Float64)
+        B = T[1 0 0; 0 1 0; 0 0 0]                     # rank 2 -> one infinite eigenvalue
+        lambdas = eigvals(T[1 0 0; 0 2 0; 0 0 3], B)
+        @test count(isinf, lambdas) == 1
+        @test !any(isnan, lambdas)
+        @test sort(filter(isfinite, lambdas)) ≈ T[1, 2]
+        # A complex pair anywhere in the spectrum moves every eigenvalue onto the complex branch.
+        @testset "A[3,3] = $s" for s in (3, -3)
+            A = T[0 -1 0; 1 0 0; 0 0 s]
+            for lambdas in (eigvals(A, B), eigen(A, B).values)
+                @test eltype(lambdas) === Complex{T}
+                @test count(isinf, lambdas) == 1
+                @test !any(isnan, lambdas)
+                @test imag(lambdas[findfirst(isinf, lambdas)]) == 0
+            end
+            @test !any(isnan, eigvals(A, B; sortby=nothing))
+            vals, vecs = eigen(A, B)
+            v = vecs[:, findfirst(isinf, vals)]
+            @test norm(B * v) <= 10eps(T) * norm(v)
+            @test norm(A * v) > sqrt(eps(T))
+        end
+    end
+
+    @testset "multiplicity" begin
+        A = [0.0 -1 0 0; 1 0 0 0; 0 0 3 0; 0 0 0 5]
+        # rank(B) == 1 leaves det(A - lambda*B) constant, so the whole spectrum is infinite.
+        for (k, ninf) in ((1, 1), (2, 2), (3, 4))
+            B = diagm([fill(1.0, 4 - k); fill(0.0, k)])
+            lambdas = eigvals(A, B)
+            @test count(isinf, lambdas) == ninf
+            @test !any(isnan, lambdas)
+            # Reversing the pencil turns infinite eigenvalues into zeros.
+            @test count(x -> abs(x) < 1e-10, eigvals(B, A)) == ninf
+        end
+    end
+
+    @testset "promoted element types" begin
+        @test !any(isnan, eigvals([0.0 -1 0; 1 0 0; 0 0 3.0], [1 0 0; 0 1 0; 0 0 0]))
+    end
+
+    @testset "controls" begin
+        # A singular pencil has indeterminate eigenvalues and must keep reporting NaN.
+        @test any(isnan, eigvals([1.0 0 0; 0 0 0; 0 0 0.0], diagm([1.0, 0.0, 0.0])))
+        @test eigvals([0.0 -1 0; 1 0 0; 0 0 3.0], Matrix(1.0I, 3, 3)) ≈ [-im, im, 3]
+    end
+end
+
 end # module TestEigen


### PR DESCRIPTION
Addresses part of #1683.

## The judgment made here

**An infinite eigenvalue produced by a real pencil is a real quantity, so its imaginary part is
exactly zero.**

LAPACK's `dggev` documents the rule this rests on -- "If ALPHAI(j) is zero, then the j-th
eigenvalue is real" -- and separately warns that "the user should avoid naively computing the
ratio alpha/beta" because "BETA(j) may even be zero". The current code forms
`complex.(alphar, alphai) ./ beta`, which divides the zero imaginary part by a zero `beta` and
turns that `0/0` into a `NaN`. This PR forms the quotient elementwise instead.

This is not a new choice so much as the one already made a few lines above: the all-real branch
does `alphar ./ beta` and has always returned `Inf`. The complex branch now agrees with it.

## What that improves

`isnan` is the natural way to ask "did this decomposition go wrong", and today it cannot tell a
regular pencil from a singular one:

```julia
julia> B = diagm([1.0, 1.0, 0.0]);

julia> eigvals([0.0 -1 0; 1 0 0; 0 0 3], B)     # regular pencil, one infinite eigenvalue
3-element Vector{ComplexF64}:
   0.0 - 1.0im
   0.0 + 1.0im
 Inf + NaN*im

julia> eigvals([1.0 0 0; 0 0 0; 0 0 0], diagm([1.0, 0.0, 0.0]))   # genuinely singular pencil
3-element Vector{Float64}:
   1.0
 NaN
 NaN
```

Both answer `any(isnan, ...) == true`, because `isnan(::Complex)` is true when either part is
`NaN`. The two situations are completely different -- one has a well-defined spectrum with a
point at infinity, the other has no defined eigenvalues at all -- and a caller cannot separate
them. This is the ordinary situation when a matrix polynomial is linearized and its leading
coefficient drops rank at some parameter value: the pencil stays regular, the effective degree
drops, and eigenvalues move to infinity. Diagnosing that as "singular pencil" is a real
misattribution.

After this PR the first case is `Inf + 0.0im`, `any(isnan, ...) == false`, and `isinf` is the
predicate that fires. The second case is unchanged.

There is also a smaller oddity that goes away: which branch runs is decided by `iszero(alphai)`
over the *whole array*, so a complex pair somewhere else in the spectrum determined whether an
unrelated infinite eigenvalue carried a `NaN`.

## What was deliberately left alone

- **The complex-input path.** `eigvals(::Matrix{ComplexF64}, ::Matrix{ComplexF64})` returns
  `NaN + NaN*im` for the same pencil, because `(3+0im)/(0+0im)` is `NaN + NaN*im`. There is no
  existing real-valued branch to be consistent with there, so the answer depends on what the
  canonical representation should be -- which is the question below. Not touched.
- **Genuinely singular pencils.** When `alphar`, `alphai` and `beta` are all zero the eigenvalue
  really is indeterminate, and `NaN + NaN*im` is the honest answer. The `!iszero(ar)` guard in
  the helper keeps that case byte-identical to today. An earlier draft of this patch did change
  it, which was over-reach.
- **The real part.** It was already correct, including its sign; only the imaginary part moves.

## Alternatives, and the question I would like an opinion on

I picked `Inf + 0.0im` because the neighbouring branch already produces `Inf`. But several other
choices are defensible, and I do not think it is my call which is canonical:

1. **`Inf + 0.0im`** (this PR) -- consistent with the real branch; `isinf` works, `isnan` does not
   fire.
2. **Keep `Inf + NaN*im`** -- read as "the modulus is infinite and the argument is
   indeterminate". Defensible on the Riemann sphere, but then the real branch is the inconsistent
   one and should arguably produce `NaN` too.
3. **`NaN + NaN*im` everywhere** -- take LAPACK's "avoid naively computing the ratio" literally
   and refuse to represent the ratio at all when `beta == 0`. Honest, but strictly less
   informative than today's real branch, and it makes infinite eigenvalues indistinguishable from
   a singular pencil by construction.
4. **Expose `alpha` and `beta`** on `GeneralizedEigen` instead of only their quotient. This is
   what LAPACK's warning really points at, and it is the only option that lets a caller
   distinguish all the cases without heuristics. Much larger change; would not obsolete this one,
   since `values` still has to contain something.
5. **Drop the sign.** `-Inf + 0.0im` and `Inf + 0.0im` are the same point at infinity. This PR
   preserves the sign because the existing real branch does, but a single canonical `Inf` is
   arguable.

Concretely: **should `eigvals(A, B)` promise anything at all about infinite eigenvalues, and if
so which of the above?** The docstrings for `eigen(A, B)` and `eigvals(A, B)` currently do not
mention infinite eigenvalues, singular `B`, `Inf` or `NaN`, so there is nothing to appeal to. I
am happy to redo this patch against whichever answer you prefer, extend it to the complex-input
path, and add the documentation.

## Testing

`test/eigen.jl` gains a testset with 62 assertions covering `Float32` and `Float64`, both
`eigvals` and `eigen`, `sortby = nothing`, promoted element types, rank deficiencies of 1, 2 and
3 (the last making the entire spectrum infinite), and the eigenvector paired with an infinite
eigenvalue spanning `null(B)`.

Two of them are independent of the representation question, as oracles rather than pins:

- reversing the pencil turns infinite eigenvalues into zeros, so
  `count(isinf, eigvals(A, B)) == count(≈0, eigvals(B, A))`;
- a singular pencil must still report `NaN`, and a nonsingular `B` must be untouched.

Verified locally by applying this patch to the loaded `LinearAlgebra` at runtime and running the
new testset against it -- 62/62 pass with the patch, 23/62 fail without it, and the two control
assertions pass either way. I could not test by `Pkg.develop`ing this repo, since the sysimage
copy wins; the CI run here is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
