### PR TITLE
[CI] Fix slow aarch64 macos times

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,10 +17,6 @@ end
 # file without it and falls back to the serial path.
 if Base.find_package("ParallelTestRunner") !== nothing
     using ParallelTestRunner
-    # Auto CPU thread count detection in ParallelTestRunner is bad
-    if Sys.isapple() && Sys.ARCH === :aarch64
-        push!(ARGS, "--jobs=2")
-    end
     push!(ARGS, "--verbose")
     testsuite = Dict{String,Expr}(splitext(f)[1] => :(include($(joinpath(@__DIR__, f))))
                                   for f in testfiles)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,9 @@ end
 if Base.find_package("ParallelTestRunner") !== nothing
     using ParallelTestRunner
     # Auto CPU thread count detection in ParallelTestRunner is bad
+    if Sys.isapple() && Sys.ARCH === :aarch64
+        push!(ARGS, "--jobs=2")
+    end
     push!(ARGS, "--verbose")
     testsuite = Dict{String,Expr}(splitext(f)[1] => :(include($(joinpath(@__DIR__, f))))
                                   for f in testfiles)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ end
 if Base.find_package("ParallelTestRunner") !== nothing
     using ParallelTestRunner
     # Auto CPU thread count detection in ParallelTestRunner is bad
-    push!(ARGS, "--jobs=$(Sys.CPU_THREADS)")
+    push!(ARGS, "--verbose")
     testsuite = Dict{String,Expr}(splitext(f)[1] => :(include($(joinpath(@__DIR__, f))))
                                   for f in testfiles)
     runtests(LinearAlgebra, ARGS; testsuite,


### PR DESCRIPTION
Forcing too many jobs on the macOS runners with 7GB memory leads to https://github.com/JuliaTesting/ParallelTestRunner.jl/issues/124, which ends up with the testsuite taking 90 minutes with 3 parallel workers as opposed to 60 minutes when letting PTR pick 1 job.

All other runners are unaffected because they all have at least 2GB of available memory per available core.