### PR TITLE
[NFC] Register LBT callbacks as C-style function pointers

### DIFF
--- a/src/LinearAlgebra.jl
+++ b/src/LinearAlgebra.jl
@@ -844,9 +844,12 @@ function lbt_openblas_onload_callback()
 end
 
 function __init__()
-    # If users want to lazily load a different BLAS, they'd need to either change this call, or
-    # clear the datastructures modified by this call and call it again with their own.
-    libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, lbt_openblas_onload_callback)
+    @static if isdefined(Libdl, :LazyLibrary) && hasfield(Libdl.LazyLibrary, :_on_load_c_callback)
+        callback = @cfunction(lbt_openblas_onload_callback, Cvoid, ())
+    else
+        callback = lbt_openblas_onload_callback
+    end
+    libblastrampoline_jll.add_dependency!(OpenBLAS_jll, libopenblas, callback)
 end
 
 end # module LinearAlgebra

--- a/src/blas.jl
+++ b/src/blas.jl
@@ -165,13 +165,30 @@ function check()
     # ensure that we have a complete set here (warning on an incomplete BLAS implementation)
     # We don't use `get_config()` here because we are invoked in the onload callback and
     # we don't want to take any locks.
-    config = LBTConfig(unsafe_load(ccall((:lbt_get_config, libblastrampoline), Ptr{lbt_config_t}, ())))
 
-    # Ensure that one of our loaded libraries satisfies our interface requirement
-    interface = USE_BLAS64 ? :ilp64 : :lp64
-    if !any(lib.interface == interface for lib in config.loaded_libs)
-        interfacestr = uppercase(string(interface))
-        println(Core.stderr, "No loaded BLAS libraries were built with $interfacestr support.")
+    # Use the raw lbt_config_t to keep this lightweight (`LBTConfig(...)` adds ~200 KB),
+    # since `--trim` does not know how to prune it
+    config = unsafe_load(ccall((:lbt_get_config, libblastrampoline), Ptr{lbt_config_t}, ()))
+
+    # Ensure that one of our loaded libraries satisfies our interface requirement.
+    wanted = USE_BLAS64 ? LBT_INTERFACE_ILP64 : LBT_INTERFACE_LP64
+    found = false
+    idx = 1
+    lib_ptr = unsafe_load(config.loaded_libs, idx)
+    while lib_ptr != C_NULL
+        if unsafe_load(lib_ptr).interface == wanted
+            found = true
+            break
+        end
+        idx += 1
+        lib_ptr = unsafe_load(config.loaded_libs, idx)
+    end
+    if !found
+        if USE_BLAS64
+            println(Core.stderr, "No loaded BLAS libraries were built with ILP64 support.")
+        else
+            println(Core.stderr, "No loaded BLAS libraries were built with LP64 support.")
+        end
         exit(1)
     end
 end


### PR DESCRIPTION
This tweak, in combination with an upcoming Base PR, allows LazyLibrary to be used for our BLAS libraries with `--trim`.

The changes to `check()` are just a tweak to re-implement the same functionality with lower-level C-style APIs, since `--trim` will not be able to prune the LinearAlgebra on-load / dependency callback. This saves ~200 KB for a basic `--trim` executable.

Should be NFC (no functional change), and backwards compatible since it will only register the C-style pointers once an upcoming Base PR adds support for this via `_on_load_c_callback` in LazyLibrary upstream.