### PR TITLE
Restore support for `length(ev) == length(dv)` in `SymTridiagonal`

### DIFF
--- a/src/tridiag.jl
+++ b/src/tridiag.jl
@@ -68,7 +68,19 @@ julia> A[2,1]
 ```
 """
 SymTridiagonal(dv::V, ev::V) where {T,V<:AbstractVector{T}} = SymTridiagonal{T}(dv, ev)
-SymTridiagonal{T}(dv::V, ev::V) where {T,V<:AbstractVector{T}} = SymTridiagonal{T,V}(dv, ev)
+function SymTridiagonal{T}(dv::V, ev::V) where {T,V<:AbstractVector{T}}
+    # the second condition is false for infinite vectors, where length(dv) - 1 == length(dv)
+    if length(ev) == length(dv) != 0 && length(ev) != length(dv) - 1
+        Base.depwarn("constructing a `SymTridiagonal` with `length(ev) == length(dv)` is deprecated; " *
+            "`ev` should have one element less than `dv`. The last element of `ev` is ignored.", :SymTridiagonal)
+        ev = _droplast(ev)
+    end
+    return SymTridiagonal{T,V}(dv, ev)
+end
+# drop the last element, preserving the array type where possible so that
+# the result converts back to `V` in the inner constructor
+_droplast(v::AbstractVector) = v[begin:end-1]
+_droplast(v::SubArray) = view(v, firstindex(v):(lastindex(v) - 1))
 function SymTridiagonal{T}(dv::AbstractVector, ev::AbstractVector) where {T}
     d = convert(AbstractVector{T}, dv)::AbstractVector{T}
     e = convert(typeof(d), ev)::AbstractVector{T}

--- a/test/tridiag.jl
+++ b/test/tridiag.jl
@@ -62,7 +62,7 @@ end
             c += im*convert(Vector{elty}, randn(n - 1))
         end
     end
-    @test_throws DimensionMismatch SymTridiagonal(d, d)
+    @test_deprecated SymTridiagonal(d, d)
     @test_throws DimensionMismatch SymTridiagonal(dl, fill(elty(1), n+1))
     @test_throws ArgumentError SymTridiagonal(rand(n, n))
     @test_throws ArgumentError Tridiagonal(dl, dl, dl)
@@ -539,10 +539,17 @@ end
     @test SymTridiagonal(ones(1), Float64[]) isa SymTridiagonal
 
     # Must have length(dv) = length(ev) + 1
-    @test_throws DimensionMismatch SymTridiagonal(ones(1), ones(1))
-    @test_throws DimensionMismatch SymTridiagonal(ones(2), ones(2))
     @test_throws DimensionMismatch SymTridiagonal(ones(4), ones(2))
     @test_throws DimensionMismatch SymTridiagonal(ones(4), ones(5))
+
+    # length(ev) == length(dv) is deprecated; the last element of ev is ignored
+    @test (@test_deprecated SymTridiagonal(ones(1), ones(1))) == SymTridiagonal(ones(1), Float64[])
+    @test (@test_deprecated SymTridiagonal([1.0, 2.0], [3.0, 4.0])) == SymTridiagonal([1.0, 2.0], [3.0])
+    a, b = collect(1.0:4), collect(5.0:8)
+    S = @test_deprecated SymTridiagonal(view(a, 1:3), view(b, 1:3))
+    @test S == SymTridiagonal(a[1:3], b[1:2])
+    @test S.ev isa SubArray && parent(S.ev) === b
+    @test (@test_deprecated SymTridiagonal(1:3, 1:3)) == SymTridiagonal(1:3, 1:2)
 end
 
 @testset "convert for SymTridiagonal" begin


### PR DESCRIPTION
Since #1569, `SymTridiagonal(dv, ev)` throws a `DimensionMismatch` when `ev` has the same length as `dv`, which was previously accepted with the last element ignored (LAPACK convention). PkgEval on 1.14 shows this breaks released packages, via KrylovKit's `rayleighquotient` (fixed in KrylovKit v0.10.4), ExponentialUtilities' `expT!` (still present on master), and direct construction:

- [CustomGaussQuadrature](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/CustomGaussQuadrature.log)
- [Fermi](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/Fermi.log)
- [FirstPassageTools](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/FirstPassageTools.log)
- [KryburyCompress](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/KryburyCompress.log)
- [MRFingerprintingRecon](https://pkgeval.s3.us-east-2.amazonaws.com/runs/gh-5428371050/logs/primary/MRFingerprintingRecon.log)

This accepts the equal-length form again in the outer constructor, with a depwarn, dropping the last element of `ev` in a type-preserving way (`getindex` generally, `view` for `SubArray`s). The strict `length(ev) == length(dv) - 1` field invariant from #1569 and all its internal simplifications are kept, so only the constructor entry point changes. `Pkg.test` runs with `--depwarn=yes`, so downstream packages keep passing while maintainers see the warning.

The deprecated branch only triggers when the strict check would fail, keeping infinite matrices (where `length(dv) - 1 == length(dv)`) working.

Verified against the constructor patterns from the failing packages: plain `Vector`s, equal-length `SubArray`s (including the `StepRange`-into-`ReshapedArray` views from the ExponentialUtilities failure, where the stored `ev` keeps the input view type), ranges, and mixed eltypes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)