### PR TITLE
fix left division with abstractly-typed rhs

### DIFF
--- a/src/generic.jl
+++ b/src/generic.jl
@@ -1227,6 +1227,7 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
     require_one_based_indexing(A, B)
     m, n = size(A)
     T = promote_op(\, eltype(A), eltype(B))
+    TA = isconcretetype(T) ? T : eltype(A)
     if m == n
         if istril(A)
             if istriu(A)
@@ -1238,9 +1239,9 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
         if istriu(A)
             return UpperTriangular(A) \ B
         end
-        return lu(convert(AbstractArray{T}, A)) \ B
+        return lu(convert(AbstractArray{TA}, A)) \ B
     end
-    return qr(convert(AbstractArray{T}, A), ColumnNorm()) \ B
+    return qr(convert(AbstractArray{TA}, A), ColumnNorm()) \ B
 end
 
 function (\)(a::AbstractVector, b::AbstractArray)

--- a/test/generic.jl
+++ b/test/generic.jl
@@ -1012,6 +1012,12 @@ end
     end
 end
 
+@testset "issue 1687" begin
+    A = rand(3, 3)
+    B = AbstractFloat[1.0, 2.0, 3.0]
+    @test A \ B isa Vector{Float64}
+end
+
 @testset "$fn requires square matrices" for fn in (det, logdet, logabsdet)
     # general rectangular matrix, G
     @test_throws DimensionMismatch fn(ones(3, 2))


### PR DESCRIPTION
Part of https://github.com/JuliaLang/julia/issues/62896

The rest is not due to #1475, but rather #1578. I'm not even sure it should be fixed, after all if you give an abstractly-typed vector as an input it is not a surprise that you get another as an output.